### PR TITLE
sanity_tests.cpp: memory access violation

### DIFF
--- a/divi/src/test/sanity_tests.cpp
+++ b/divi/src/test/sanity_tests.cpp
@@ -7,13 +7,18 @@
 
 #include <boost/test/unit_test.hpp>
 #include "test_only.h"
+
 BOOST_AUTO_TEST_SUITE(sanity_tests)
 
-BOOST_AUTO_TEST_CASE(basic_sanity,SKIP_TEST)
+BOOST_AUTO_TEST_CASE(basic_sanity)
 {
   BOOST_CHECK_MESSAGE(glibc_sanity_test() == true, "libc sanity test");
   BOOST_CHECK_MESSAGE(glibcxx_sanity_test() == true, "stdlib sanity test");
+
+  ECCVerifyHandle verificationModule;
+  ECC_Start();
   BOOST_CHECK_MESSAGE(ECC_InitSanityCheck() == true, "openssl ECC test");
+  ECC_Stop();
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
### Feature

The unit tests for `src/test/sanity_tests.cpp` would throw the following error

```bash
memory access violation at address: 0x00000008: no mapping at fault address
```

### Description

Using the globals (which German hates, and I now hate too) `ECC_Start()` and `ECC_Stop()` resolved the memory access violation error.