### PR TITLE
rpc_tests.cpp: fix memory violation error

### DIFF
--- a/divi/src/test/rpc_tests.cpp
+++ b/divi/src/test/rpc_tests.cpp
@@ -92,6 +92,9 @@ BOOST_AUTO_TEST_CASE(rpc_rawparams)
 
 BOOST_AUTO_TEST_CASE(rpc_rawsign)
 {
+    ECCVerifyHandle verificationModule;
+    ECC_Start();
+
     Value r;
     // input is a 1-of-2 multisig (so is output):
     string prevout =
@@ -103,14 +106,13 @@ BOOST_AUTO_TEST_CASE(rpc_rawsign)
     string notsigned = r.get_str();
     string privkey1 = "\"YVobcS47fr6kceZy9LzLJR8WQ6YRpUwYKoJhrnEXepebMxaSpbnn\"";
     string privkey2 = "\"YRyMjG8hbm8jHeDMAfrzSeHq5GgAj7kuHFvJtMudCUH3sCkq1WtA\"";
-    
+
     r = CallRPC(string("signrawtransaction ")+notsigned+" "+prevout+" "+"[]");
     BOOST_CHECK(find_value(r.get_obj(), "complete").get_bool() == false);
 
-    ECCVerifyHandle verificationModule;
-    ECC_Start();
     r = CallRPC(string("signrawtransaction ")+notsigned+" "+prevout+" "+"["+privkey1+","+privkey2+"]");
     BOOST_CHECK(find_value(r.get_obj(), "complete").get_bool() == true);
+
     ECC_Stop();
 }
 


### PR DESCRIPTION
### Feature

- The unit tests for `src/test/rpc_tests.cpp` would throw the following error

```bash
memory access violation at address: 0x00000008: no mapping at fault address
```