### PR TITLE
Remove TLS support for RPC methods

### DIFF
--- a/divi/src/Settings.cpp
+++ b/divi/src/Settings.cpp
@@ -6,28 +6,36 @@
 #include <boost/program_options/detail/config_file.hpp>
 #include <set>
 
-std::string Settings::GetArg(const std::string& strArg, const std::string& strDefault)
+std::string Settings::GetArg(const std::string& strArg, const std::string& strDefault) const
 {
     if (mapArgs_.count(strArg))
         return mapArgs_[strArg];
     return strDefault;
 }
 
-int64_t Settings::GetArg(const std::string& strArg, int64_t nDefault)
+int64_t Settings::GetArg(const std::string& strArg, int64_t nDefault) const
 {
     if (mapArgs_.count(strArg))
         return atoi64(mapArgs_[strArg]);
     return nDefault;
 }
 
-bool InterpretBool(const std::string& strValue)
+static bool InterpretBool(const std::string& strValue)
 {
     if (strValue.empty())
         return true;
     return (atoi(strValue) != 0);
 }
 
-bool Settings::GetBoolArg(const std::string& strArg, bool fDefault)
+static void InterpretNegativeSetting(std::string& strKey, std::string& strValue)
+{
+    if (strKey.length()>3 && strKey[0]=='-' && strKey[1]=='n' && strKey[2]=='o') {
+        strKey = "-" + strKey.substr(3);
+        strValue = InterpretBool(strValue) ? "0" : "1";
+    }
+}
+
+bool Settings::GetBoolArg(const std::string& strArg, bool fDefault) const
 {
     if (mapArgs_.count(strArg))
         return InterpretBool(mapArgs_[strArg]);
@@ -55,12 +63,12 @@ void Settings::ForceRemoveArg(const std::string &strArg)
     mapArgs_.erase(strArg);
 }
 
-bool Settings::ParameterIsSet (const std::string& key)
+bool Settings::ParameterIsSet (const std::string& key) const
 {
-    return mapArgs_.count(key);
+    return mapArgs_.count(key) > 0;
 }
 
-std::string Settings::GetParameter(const std::string& key)
+std::string Settings::GetParameter(const std::string& key) const
 {
     if(ParameterIsSet(key))
     {
@@ -82,24 +90,9 @@ void Settings::ClearParameter ()
     mapArgs_.clear();
 }
 
-bool Settings::ParameterIsSetForMultiArgs (const std::string& key)
+bool Settings::ParameterIsSetForMultiArgs (const std::string& key) const
 {
-    return mapMultiArgs_.count(key);
-}
-
-bool Settings::InterpretBool(const std::string& strValue)
-{
-    if (strValue.empty())
-        return true;
-    return (atoi(strValue) != 0);
-}
-
-void Settings::InterpretNegativeSetting(std::string& strKey, std::string& strValue)
-{
-    if (strKey.length()>3 && strKey[0]=='-' && strKey[1]=='n' && strKey[2]=='o') {
-        strKey = "-" + strKey.substr(3);
-        strValue = InterpretBool(strValue) ? "0" : "1";
-    }
+    return mapMultiArgs_.count(key) > 0;
 }
 
 void Settings::ParseParameters(int argc, const char* const argv[])

--- a/divi/src/Settings.h
+++ b/divi/src/Settings.h
@@ -12,10 +12,6 @@ private:
     std::map<std::string, std::string>& mapArgs_;
     std::map<std::string, std::vector<std::string> >& mapMultiArgs_;
 
-    bool InterpretBool(const std::string& strValue);
-    
-    void InterpretNegativeSetting(std::string& strKey, std::string& strValue);
-
     Settings(
         std::map<std::string, std::string>& mapArgs,
         std::map<std::string, std::vector<std::string> >& mapMultiArgs
@@ -34,11 +30,11 @@ public:
         return settings;
     }
     
-    std::string GetArg(const std::string& strArg, const std::string& strDefault);
+    std::string GetArg(const std::string& strArg, const std::string& strDefault) const;
 
-    int64_t GetArg(const std::string& strArg, int64_t nDefault);
+    int64_t GetArg(const std::string& strArg, int64_t nDefault) const;
 
-    bool GetBoolArg(const std::string& strArg, bool fDefault);
+    bool GetBoolArg(const std::string& strArg, bool fDefault) const;
 
     bool SoftSetArg(const std::string& strArg, const std::string& strValue);
 
@@ -46,15 +42,15 @@ public:
     
     void ForceRemoveArg(const std::string &strArg);
 
-    bool ParameterIsSet (const std::string& key);
+    bool ParameterIsSet (const std::string& key) const;
 
-    std::string GetParameter(const std::string& key);
+    std::string GetParameter(const std::string& key) const;
 
     void SetParameter (const std::string& key, const std::string& value);
 
     void ClearParameter (); 
 
-    bool ParameterIsSetForMultiArgs (const std::string& key);
+    bool ParameterIsSetForMultiArgs (const std::string& key) const;
 
     void ParseParameters(int argc, const char* const argv[]);
 

--- a/divi/src/init.cpp
+++ b/divi/src/init.cpp
@@ -567,12 +567,6 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += HelpMessageOpt("-rpcthreads=<n>", strprintf(translate("Set the number of threads to service RPC calls (default: %d)"), 4));
     strUsage += HelpMessageOpt("-rpckeepalive", strprintf(translate("RPC support for HTTP persistent connections (default: %d)"), 1));
 
-    strUsage += HelpMessageGroup(translate("RPC SSL options: (see the DIVI Wiki for SSL setup instructions)"));
-    strUsage += HelpMessageOpt("-rpcssl", translate("Use OpenSSL (https) for JSON-RPC connections"));
-    strUsage += HelpMessageOpt("-rpcsslcertificatechainfile=<file.cert>", strprintf(translate("Server certificate file (default: %s)"), "server.cert"));
-    strUsage += HelpMessageOpt("-rpcsslprivatekeyfile=<file.pem>", strprintf(translate("Server private key (default: %s)"), "server.pem"));
-    strUsage += HelpMessageOpt("-rpcsslciphers=<ciphers>", strprintf(translate("Acceptable ciphers (default: %s)"), "TLSv1.2+HIGH:TLSv1+HIGH:!SSLv2:!aNULL:!eNULL:!3DES:@STRENGTH"));
-
     return strUsage;
 }
 

--- a/divi/src/rpcprotocol.cpp
+++ b/divi/src/rpcprotocol.cpp
@@ -19,7 +19,6 @@
 #include "json/json_spirit_writer_template.h"
 #include <boost/algorithm/string.hpp>
 #include <boost/asio.hpp>
-#include <boost/asio/ssl.hpp>
 #include <boost/bind.hpp>
 #include <boost/filesystem.hpp>
 #include <boost/foreach.hpp>

--- a/divi/src/rpcprotocol.h
+++ b/divi/src/rpcprotocol.h
@@ -7,7 +7,6 @@
 #define BITCOIN_RPCPROTOCOL_H
 
 #include <boost/asio.hpp>
-#include <boost/asio/ssl.hpp>
 #include <boost/iostreams/concepts.hpp>
 #include <boost/iostreams/stream.hpp>
 #include <list>
@@ -75,74 +74,6 @@ enum RPCErrorCode {
     RPC_WALLET_ENCRYPTION_FAILED = -16,    //! Failed to encrypt the wallet
     RPC_WALLET_ALREADY_UNLOCKED = -17,     //! Wallet is already unlocked
     RPC_WALLET_NEEDS_RELOCK = -18,         //! Wallet needs to be re-locked
-};
-
-/**
- * IOStream device that speaks SSL but can also speak non-SSL
- */
-template <typename Protocol>
-class SSLIOStreamDevice : public boost::iostreams::device<boost::iostreams::bidirectional>
-{
-public:
-    SSLIOStreamDevice(boost::asio::ssl::stream<typename Protocol::socket>& streamIn, bool fUseSSLIn) : stream(streamIn)
-    {
-        fUseSSL = fUseSSLIn;
-        fNeedHandshake = fUseSSLIn;
-    }
-
-    void handshake(boost::asio::ssl::stream_base::handshake_type role)
-    {
-        if (!fNeedHandshake) return;
-        fNeedHandshake = false;
-        stream.handshake(role);
-    }
-    std::streamsize read(char* s, std::streamsize n)
-    {
-        handshake(boost::asio::ssl::stream_base::server); // HTTPS servers read first
-        if (fUseSSL) return stream.read_some(boost::asio::buffer(s, n));
-        return stream.next_layer().read_some(boost::asio::buffer(s, n));
-    }
-    std::streamsize write(const char* s, std::streamsize n)
-    {
-        handshake(boost::asio::ssl::stream_base::client); // HTTPS clients write first
-        if (fUseSSL) return boost::asio::write(stream, boost::asio::buffer(s, n));
-        return boost::asio::write(stream.next_layer(), boost::asio::buffer(s, n));
-    }
-    bool connect(const std::string& server, const std::string& port)
-    {
-        using namespace boost::asio::ip;
-        tcp::resolver resolver(stream.get_io_service());
-        tcp::resolver::iterator endpoint_iterator;
-#if BOOST_VERSION >= 104300
-        try {
-#endif
-            // The default query (flags address_configured) tries IPv6 if
-            // non-localhost IPv6 configured, and IPv4 if non-localhost IPv4
-            // configured.
-            tcp::resolver::query query(server.c_str(), port.c_str());
-            endpoint_iterator = resolver.resolve(query);
-#if BOOST_VERSION >= 104300
-        } catch (boost::system::system_error& e) {
-            // If we at first don't succeed, try blanket lookup (IPv4+IPv6 independent of configured interfaces)
-            tcp::resolver::query query(server.c_str(), port.c_str(), resolver_query_base::flags());
-            endpoint_iterator = resolver.resolve(query);
-        }
-#endif
-        boost::system::error_code error = boost::asio::error::host_not_found;
-        tcp::resolver::iterator end;
-        while (error && endpoint_iterator != end) {
-            stream.lowest_layer().close();
-            stream.lowest_layer().connect(*endpoint_iterator++, error);
-        }
-        if (error)
-            return false;
-        return true;
-    }
-
-private:
-    bool fNeedHandshake;
-    bool fUseSSL;
-    boost::asio::ssl::stream<typename Protocol::socket>& stream;
 };
 
 std::string HTTPPost(const std::string& strMsg, const std::map<std::string, std::string>& mapRequestHeaders);


### PR DESCRIPTION
Remove the TLS support for the RPC server and client.  This fixes the need for a specific old boost version.
    
Upstream Bitcoin has removed TLS support for the RPC interface a long time ago; instead of relying on a custom TLS layer inside the Divi daemon, most users will just expose RPC locally anyway.  And those who might need to make calls over an untrusted network should instead add an external security layer, like a VPN, SSH tunnel or a dedicated HTTP reverse proxy with TLS.

This also includes a fix for the `Settings` class, marking methods that should be as `const` so the ZMQ code actually compiles.