### PR TITLE
Remove unused fields in CBlockTemplate

### DIFF
--- a/divi/src/BlockFactory.cpp
+++ b/divi/src/BlockFactory.cpp
@@ -44,8 +44,6 @@ void BlockFactory::SetCoinbaseTransactionAndDefaultFees(
     const CMutableTransaction& coinbaseTransaction)
 {
     pblocktemplate->block.vtx.push_back(coinbaseTransaction);
-    pblocktemplate->vTxFees.push_back(-1);   // updated at end
-    pblocktemplate->vTxSigOps.push_back(-1); // updated at end
 }
 
 void BlockFactory::CreateCoinbaseTransaction(const CScript& scriptPubKeyIn, CMutableTransaction& txNew)

--- a/divi/src/BlockMemoryPoolTransactionCollector.h
+++ b/divi/src/BlockMemoryPoolTransactionCollector.h
@@ -143,9 +143,7 @@ private:
 
     void AddTransactionToBlock (
         const CTransaction& tx, 
-        std::unique_ptr<CBlockTemplate>& pblocktemplate,
-        const CAmount& nTxFees,
-        const unsigned int& nTxSigOps) const;
+        std::unique_ptr<CBlockTemplate>& pblocktemplate) const;
 
     std::vector<TxPriority> PrioritizeMempoolTransactions (
         const int& nHeight,
@@ -168,8 +166,7 @@ private:
     void AddTransactionsToBlockIfPossible (
         const int& nHeight,
         CCoinsViewCache& view,
-        std::unique_ptr<CBlockTemplate>& pblocktemplate,
-        CAmount& nFees) const;
+        std::unique_ptr<CBlockTemplate>& pblocktemplate) const;
 public:
     BlockMemoryPoolTransactionCollector(
         CTxMemPool& mempool, 

--- a/divi/src/BlockTemplate.h
+++ b/divi/src/BlockTemplate.h
@@ -13,7 +13,5 @@ struct CBlockTemplate {
     std::shared_ptr<CMutableTransaction> coinbaseTransaction;
     const CBlockIndex* previousBlockIndex;
     CBlock block;
-    std::vector<CAmount> vTxFees;
-    std::vector<int64_t> vTxSigOps;
 };
 #endif // BLOCK_TEMPLATE_H

--- a/divi/src/CoinMinter.cpp
+++ b/divi/src/CoinMinter.cpp
@@ -198,7 +198,6 @@ void CoinMinter::SetBlockHeaders(std::unique_ptr<CBlockTemplate>& pblocktemplate
     block.nBits = GetNextWorkRequired(pblocktemplate->previousBlockIndex, &block, chainParameters_);
     block.nNonce = 0;
     block.nAccumulatorCheckpoint = static_cast<uint256>(0);
-    pblocktemplate->vTxSigOps[0] = GetLegacySigOpCount(block.vtx[0]);
 }
 
 bool CoinMinter::createProofOfStakeBlock(


### PR DESCRIPTION
Remove the `vTxFees` and `vTxSigOps` fields in `CBlockTemplate`, which were only filled in but never actually used/read.