### PR TITLE
Fix and enable some regtests

### DIFF
--- a/divi/qa/rpc-tests/listtransactions.py
+++ b/divi/qa/rpc-tests/listtransactions.py
@@ -34,6 +34,12 @@ def check_array_result(object_array, to_match, expected):
 class ListTransactionsTest(BitcoinTestFramework):
 
     def run_test(self):
+        # Get some coins into both nodes.
+        self.nodes[0].setgenerate(True, 5)
+        self.sync_all()
+        self.nodes[1].setgenerate(True, 5)
+        self.sync_all()
+
         # Simple send, 0 to 1:
         txid = self.nodes[0].sendtoaddress(self.nodes[1].getnewaddress(), 0.1)
         self.sync_all()
@@ -56,10 +62,7 @@ class ListTransactionsTest(BitcoinTestFramework):
         # send-to-self:
         txid = self.nodes[0].sendtoaddress(self.nodes[0].getnewaddress(), 0.2)
         check_array_result(self.nodes[0].listtransactions(),
-                           {"txid":txid, "category":"send"},
-                           {"amount":Decimal("-0.2")})
-        check_array_result(self.nodes[0].listtransactions(),
-                           {"txid":txid, "category":"receive"},
+                           {"txid":txid, "category":"move"},
                            {"amount":Decimal("0.2")})
 
         # sendmany from node1: twice to self, twice to node2:

--- a/divi/qa/rpc-tests/mempool_resurrect_test.py
+++ b/divi/qa/rpc-tests/mempool_resurrect_test.py
@@ -33,7 +33,9 @@ class MempoolCoinbaseTest(BitcoinTestFramework):
         return signresult["hex"]
 
     def run_test(self):
-        node0_address = self.nodes[0].getnewaddress()
+        node = self.nodes[0]
+        node.setgenerate(True, 10)
+        node0_address = node.getnewaddress()
 
         # Spend block 1/2/3's coinbase transactions
         # Mine a block.
@@ -45,42 +47,39 @@ class MempoolCoinbaseTest(BitcoinTestFramework):
         # Mine a new block
         # ... make sure all the transactions are confirmed again.
 
-        b = [ self.nodes[0].getblockhash(n) for n in range(1, 4) ]
-        coinbase_txids = [ self.nodes[0].getblock(h)['tx'][0] for h in b ]
-        spends1_raw = [ self.create_tx(txid, node0_address, 50) for txid in coinbase_txids ]
-        spends1_id = [ self.nodes[0].sendrawtransaction(tx) for tx in spends1_raw ]
+        b = [ node.getblockhash(n) for n in range(1, 4) ]
+        coinbase_txids = [ node.getblock(h)['tx'][0] for h in b ]
+        spends1_raw = [ self.create_tx(txid, node0_address, 1250) for txid in coinbase_txids ]
+        spends1_id = [ node.sendrawtransaction(tx) for tx in spends1_raw ]
 
         blocks = []
-        blocks.extend(self.nodes[0].setgenerate(True, 1))
+        blocks.extend(node.setgenerate(True, 1))
 
-        spends2_raw = [ self.create_tx(txid, node0_address, 49.99) for txid in spends1_id ]
-        spends2_id = [ self.nodes[0].sendrawtransaction(tx) for tx in spends2_raw ]
+        spends2_raw = [ self.create_tx(txid, node0_address, 1249.99) for txid in spends1_id ]
+        spends2_id = [ node.sendrawtransaction(tx) for tx in spends2_raw ]
 
-        blocks.extend(self.nodes[0].setgenerate(True, 1))
+        blocks.extend(node.setgenerate(True, 1))
 
         # mempool should be empty, all txns confirmed
-        assert_equal(set(self.nodes[0].getrawmempool()), set())
+        assert_equal(set(node.getrawmempool()), set())
         for txid in spends1_id+spends2_id:
-            tx = self.nodes[0].gettransaction(txid)
+            tx = node.gettransaction(txid)
             assert(tx["confirmations"] > 0)
 
         # Use invalidateblock to re-org back; all transactions should
         # end up unconfirmed and back in the mempool
-        for node in self.nodes:
-            node.invalidateblock(blocks[0])
-
-        # mempool should be empty, all txns confirmed
-        assert_equal(set(self.nodes[0].getrawmempool()), set(spends1_id+spends2_id))
+        node.invalidateblock(blocks[0])
+        assert_equal(set(node.getrawmempool()), set(spends1_id+spends2_id))
         for txid in spends1_id+spends2_id:
-            tx = self.nodes[0].gettransaction(txid)
+            tx = node.gettransaction(txid)
             assert(tx["confirmations"] == 0)
 
         # Generate another block, they should all get mined
-        self.nodes[0].setgenerate(True, 1)
+        node.setgenerate(True, 1)
         # mempool should be empty, all txns confirmed
-        assert_equal(set(self.nodes[0].getrawmempool()), set())
+        assert_equal(set(node.getrawmempool()), set())
         for txid in spends1_id+spends2_id:
-            tx = self.nodes[0].gettransaction(txid)
+            tx = node.gettransaction(txid)
             assert(tx["confirmations"] > 0)
 
 

--- a/divi/qa/rpc-tests/run-tests.sh
+++ b/divi/qa/rpc-tests/run-tests.sh
@@ -7,4 +7,5 @@
 
 set -ex
 
+./listtransactions.py
 ./wallet.py

--- a/divi/qa/rpc-tests/run-tests.sh
+++ b/divi/qa/rpc-tests/run-tests.sh
@@ -8,4 +8,5 @@
 set -ex
 
 ./listtransactions.py
+./mempool_resurrect_test.py
 ./wallet.py

--- a/divi/qa/rpc-tests/run-tests.sh
+++ b/divi/qa/rpc-tests/run-tests.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+# This is a convenience script that runs all regtests that
+# are supposed to work for Divi.  It is essentially a "variant" of
+# qa/pull-tester/rpc-tests.sh that is not meant to be run automatically
+# but just manually during development.
+
+set -ex
+
+./wallet.py

--- a/divi/qa/rpc-tests/wallet.py
+++ b/divi/qa/rpc-tests/wallet.py
@@ -7,15 +7,15 @@
 # Exercise the wallet.  Ported from wallet.sh.
 # Does the following:
 #   a) creates 3 nodes, with an empty chain (no blocks).
-#   b) node0 mines a block
-#   c) node1 mines 32 blocks, so now node 0 has 60001div, node 1 has 4250div, node2 has none.
-#   d) node0 sends 601 div to node2, in two transactions (301 div, then 300 div).
-#   e) node0 mines a block, collects the fee on the second transaction
-#   f) node1 mines 16 blocks, to mature node0's just-mined block
-#   g) check that node0 has 100-21, node2 has 21
-#   h) node0 should now have 2 unspent outputs;  send these to node2 via raw tx broadcast by node1
-#   i) have node1 mine a block
-#   j) check balances - node0 should have 0, node2 should have 100
+#   b) node0 mines two blocks
+#   c) node1 mines 32 blocks, so now node 0 and 1 have some block rewards,
+#      node2 has still no coins
+#   d) node0 sends 701 div to node2, in two transactions (351 div, then 350 div)
+#   e) check the expected balances
+#   f) node0 should now have 2 unspent outputs;  send these to node2 via raw
+#      tx broadcast by node1
+#   g) have node1 mine a block
+#   h) check balances - node0 should have 0, node2 should have the coins
 #
 
 from test_framework import BitcoinTestFramework
@@ -29,7 +29,8 @@ class WalletTest (BitcoinTestFramework):
         initialize_chain_clean(self.options.tmpdir, 3)
 
     def setup_network(self, split=False):
-        self.nodes = start_nodes(3, self.options.tmpdir)
+        args = [["-spendzeroconfchange"]] * 3
+        self.nodes = start_nodes(3, self.options.tmpdir, extra_args=args)
         connect_nodes_bi(self.nodes,0,1)
         connect_nodes_bi(self.nodes,1,2)
         connect_nodes_bi(self.nodes,0,2)
@@ -39,32 +40,26 @@ class WalletTest (BitcoinTestFramework):
     def run_test (self):
         print "Mining blocks..."
 
-        self.nodes[0].setgenerate(True, 1)
+        self.nodes[0].setgenerate(True, 2)
 
         self.sync_all()
         self.nodes[1].setgenerate(True, 32)
         self.sync_all()
 
-        assert_equal(self.nodes[0].getbalance(), 60001)
-        assert_equal(self.nodes[1].getbalance(), 4250)
+        assert_equal(self.nodes[0].getbalance(), 2500)
+        assert_equal(self.nodes[1].getbalance(), 38750)
         assert_equal(self.nodes[2].getbalance(), 0)
 
-        # Send 601 BTC from 0 to 2 using sendtoaddress call.
+        # Send 701 BTC from 0 to 2 using sendtoaddress call.
         # Second transaction will be child of first, and will require a fee
         self.nodes[0].sendtoaddress(self.nodes[2].getnewaddress(), 351)
         self.nodes[0].sendtoaddress(self.nodes[2].getnewaddress(), 350)
-
-        # Have node0 mine a block, thus he will collect his own fee.
-        self.nodes[0].setgenerate(True, 1)
-        self.sync_all()
-
-        # Have node1 generate 100 blocks (so node0 can recover the fee)
         self.nodes[1].setgenerate(True, 16)
         self.sync_all()
 
-        # node0 should end up with 100 btc in block rewards plus fees, but
-        # minus the 21 plus fees sent to node2
-        assert_greater_than(self.nodes[0].getbalance(), 59549)
+        # Compare the expected balances.  Give 1 coin leeway
+        # for fees paid by node0 (which are burnt in Divi).
+        assert_greater_than(self.nodes[0].getbalance(), 1798)
         assert_equal(self.nodes[2].getbalance(), 701)
 
         # Node0 should have two unspent outputs.
@@ -92,8 +87,8 @@ class WalletTest (BitcoinTestFramework):
         self.sync_all()
 
         assert_equal(self.nodes[0].getbalance(), 0)
-        assert_greater_than(self.nodes[2].getbalance(), 60250)
-        assert_greater_than(self.nodes[2].getbalance("from1"), 59549)
+        assert_greater_than(self.nodes[2].getbalance(), 2499)
+        assert_greater_than(self.nodes[2].getbalance("from1"), 1798)
 
 
 if __name__ == '__main__':

--- a/divi/src/BlockMemoryPoolTransactionCollector.cpp
+++ b/divi/src/BlockMemoryPoolTransactionCollector.cpp
@@ -161,10 +161,10 @@ void BlockMemoryPoolTransactionCollector::AddTransactionToBlock (
 
 std::vector<TxPriority> BlockMemoryPoolTransactionCollector::PrioritizeMempoolTransactions (
     const int& nHeight,
+    std::list<COrphan>& vOrphan,
     std::map<uint256, std::vector<COrphan*> >& dependentTransactions,
     CCoinsViewCache& view) const
 {
-    std::list<COrphan> vOrphan;
     std::vector<TxPriority> vecPriority;
     vecPriority.reserve(mempool_.mapTx.size());
     for (std::map<uint256, CTxMemPoolEntry>::iterator mi = mempool_.mapTx.begin(); mi != mempool_.mapTx.end(); ++mi) {
@@ -338,10 +338,11 @@ void BlockMemoryPoolTransactionCollector::AddTransactionsToBlockIfPossible (
     CCoinsViewCache& view,
     std::unique_ptr<CBlockTemplate>& pblocktemplate) const
 {
+    std::list<COrphan> vOrphan;
     std::map<uint256, std::vector<COrphan*> > dependentTransactions;
 
     std::vector<TxPriority> vecPriority = 
-        PrioritizeMempoolTransactions(nHeight, dependentTransactions, view);
+        PrioritizeMempoolTransactions(nHeight, vOrphan, dependentTransactions, view);
         
     std::vector<PrioritizedTransactionData> prioritizedTransactions = 
         PrioritizeTransactions(

--- a/divi/src/BlockMemoryPoolTransactionCollector.cpp
+++ b/divi/src/BlockMemoryPoolTransactionCollector.cpp
@@ -313,6 +313,9 @@ std::vector<PrioritizedTransactionData> BlockMemoryPoolTransactionCollector::Pri
         nBlockSize += nTxSize;
         nBlockSigOps += nTxSigOps;
 
+        CTxUndo txundo;
+        UpdateCoins(tx, view, txundo, nHeight);
+
         if (fPrintPriority) {
             LogPrintf("priority %.1f fee %s txid %s\n",
                     dPriority, feeRate.ToString(), tx.GetHash().ToString());
@@ -346,10 +349,6 @@ void BlockMemoryPoolTransactionCollector::AddTransactionsToBlockIfPossible (
     for(const PrioritizedTransactionData& txData: prioritizedTransactions)
     {
         const CTransaction& tx = *txData.tx;
-        CTxUndo txundo;
-        UpdateCoins(tx, view, txundo, nHeight);
-
-        // Added
         AddTransactionToBlock(tx, blocktemplate);
     }
 }

--- a/divi/src/BlockMemoryPoolTransactionCollector.h
+++ b/divi/src/BlockMemoryPoolTransactionCollector.h
@@ -147,6 +147,7 @@ private:
 
     std::vector<TxPriority> PrioritizeMempoolTransactions (
         const int& nHeight,
+        std::list<COrphan>& vOrphan,
         std::map<uint256, std::vector<COrphan*> >& mapDependers,
         CCoinsViewCache& view) const;
 

--- a/divi/src/BlockMemoryPoolTransactionCollector.h
+++ b/divi/src/BlockMemoryPoolTransactionCollector.h
@@ -101,15 +101,13 @@ private:
     AnnotatedMixin<boost::recursive_mutex>& mainCS_;
 private: 
     void UpdateTime(CBlockHeader* block, const CBlockIndex* pindexPrev) const;
-    void SetBlockHeaders(CBlock& block, const bool& proofOfStake, const CBlockIndex& indexPrev, std::unique_ptr<CBlockTemplate>& pblocktemplate) const;
     bool VerifyUTXOIsKnownToMemPool (const CTxIn& txin, bool& fMissingInputs) const;
     bool CheckUTXOValidity (const CTxIn& txin, bool& fMissingInputs, const CTransaction &tx) const;
     void RecordOrphanTransaction (
-        COrphan* porphan, 
-        std::list<COrphan>& vOrphan, 
+        std::shared_ptr<COrphan>& porphan,
         const CTransaction& tx, 
         const CTxIn& txin,
-        std::map<uint256, std::vector<COrphan*> >& mapDependers) const;
+        std::map<uint256, std::vector<std::shared_ptr<COrphan>>>& mapDependers) const;
 
     void ComputeTransactionPriority (
         double& dPriority, 
@@ -119,19 +117,11 @@ private:
         std::vector<TxPriority>& vecPriority,
         const CTransaction* mempoolTx) const;
     void AddDependingTransactionsToPriorityQueue (
-        std::map<uint256, std::vector<COrphan*> >& mapDependers,
+        std::map<uint256, std::vector<std::shared_ptr<COrphan>>>& mapDependers,
         const uint256& hash,
         std::vector<TxPriority>& vecPriority,
         TxPriorityCompare& comparer) const;
 
-    void SetCoinBaseTransaction (
-        CBlock& block, 
-        std::unique_ptr<CBlockTemplate>& pblocktemplate,
-        const bool& fProofOfStake, 
-        const int& nHeight,
-        CMutableTransaction& txNew,
-        const CAmount& nFees) const;
-    
     bool IsFreeTransaction (
         const uint256& hash,
         const bool& fSortedByFee,
@@ -143,12 +133,11 @@ private:
 
     void AddTransactionToBlock (
         const CTransaction& tx, 
-        std::unique_ptr<CBlockTemplate>& pblocktemplate) const;
+        CBlockTemplate& blocktemplate) const;
 
     std::vector<TxPriority> PrioritizeMempoolTransactions (
         const int& nHeight,
-        std::list<COrphan>& vOrphan,
-        std::map<uint256, std::vector<COrphan*> >& mapDependers,
+        std::map<uint256, std::vector<std::shared_ptr<COrphan>>>& mapDependers,
         CCoinsViewCache& view) const;
 
     void PrioritizeFeePastPrioritySize (
@@ -163,11 +152,11 @@ private:
         std::vector<TxPriority>& vecPriority,
         const int& nHeight,
         CCoinsViewCache& view,
-        std::map<uint256, std::vector<COrphan*> >& mapDependers) const;
+        std::map<uint256, std::vector<std::shared_ptr<COrphan>>>& mapDependers) const;
     void AddTransactionsToBlockIfPossible (
         const int& nHeight,
         CCoinsViewCache& view,
-        std::unique_ptr<CBlockTemplate>& pblocktemplate) const;
+        CBlockTemplate& blocktemplate) const;
 public:
     BlockMemoryPoolTransactionCollector(
         CTxMemPool& mempool, 

--- a/divi/src/CoinMinter.cpp
+++ b/divi/src/CoinMinter.cpp
@@ -205,7 +205,7 @@ bool CoinMinter::createProofOfStakeBlock(
     CReserveKey& reserveKey) const
 {
     constexpr const bool fProofOfStake = true;
-    bool blockSuccesfullyCreated = false;
+    bool blockSuccessfullyCreated = false;
     CBlockIndex* pindexPrev = chain_.Tip();
     if (!pindexPrev)
         return false;
@@ -230,10 +230,10 @@ bool CoinMinter::createProofOfStakeBlock(
 
     LogPrintf("CPUMiner : proof-of-stake block was signed %s \n", block->GetHash().ToString().c_str());
     SetThreadPriority(THREAD_PRIORITY_NORMAL);
-    blockSuccesfullyCreated = ProcessBlockFound(block, reserveKey);
+    blockSuccessfullyCreated = ProcessBlockFound(block, reserveKey);
     SetThreadPriority(THREAD_PRIORITY_LOWEST);
 
-    return blockSuccesfullyCreated;
+    return blockSuccessfullyCreated;
 }
 
 bool CoinMinter::createProofOfWorkBlock(
@@ -241,7 +241,7 @@ bool CoinMinter::createProofOfWorkBlock(
     CReserveKey& reserveKey) const
 {
     constexpr const bool fProofOfStake = false;
-    bool blockSuccesfullyCreated = false;
+    bool blockSuccessfullyCreated = false;
     unsigned int nTransactionsUpdatedLast = mempool_.GetTransactionsUpdated();
     CBlockIndex* pindexPrev = chain_.Tip();
     if (!pindexPrev)
@@ -265,7 +265,7 @@ bool CoinMinter::createProofOfWorkBlock(
     while (true) 
     {
         unsigned int nHashesDone = 0;
-        blockSuccesfullyCreated = false;
+        blockSuccessfullyCreated = false;
         uint256 hash;
         while (true) {
             hash = block->GetHash();
@@ -275,13 +275,13 @@ bool CoinMinter::createProofOfWorkBlock(
                 SetThreadPriority(THREAD_PRIORITY_NORMAL);
                 LogPrintf("BitcoinMiner:\n");
                 LogPrintf("proof-of-work found  \n  hash: %s  \ntarget: %s\n", hash.GetHex(), hashTarget.GetHex());
-                blockSuccesfullyCreated = ProcessBlockFound(block, reserveKey);
+                blockSuccessfullyCreated = ProcessBlockFound(block, reserveKey);
                 SetThreadPriority(THREAD_PRIORITY_LOWEST);
 
                 // In regression test mode, stop mining after a block is found. This
                 // allows developers to controllably generate a block on demand.
                 if (chainParameters_.MineBlocksOnDemand())
-                    throw boost::thread_interrupted();
+                    return blockSuccessfullyCreated;
 
                 break;
             }
@@ -311,7 +311,7 @@ bool CoinMinter::createProofOfWorkBlock(
             hashTarget.SetCompact(block->nBits);
         }
     }
-    return blockSuccesfullyCreated;
+    return blockSuccessfullyCreated;
 }
 
 

--- a/divi/src/chainparams.cpp
+++ b/divi/src/chainparams.cpp
@@ -453,6 +453,13 @@ public:
         pchMessageStart[1] = 0xcf;
         pchMessageStart[2] = 0x7e;
         pchMessageStart[3] = 0xac;
+
+        /* The premine on mainnet needs no tests, as it is "tested" by
+           syncing on mainnet anyway.  On regtest, it is easiest to not
+           have a special premine, as it makes the generated coins more
+           predictable.  */
+        premineAmt = 1'250 * COIN;
+
         nSubsidyHalvingInterval = 100;
         nEnforceBlockUpgradeMajority = 750;
         nRejectBlockOutdatedMajority = 950;


### PR DESCRIPTION
This includes some fixes necessary to make `divid` work in regtest mode, especially with respect to how regtest blocks are mined.  With this, we adjust some of the existing tests (`mempool_resurrect_test.py`, `listtransactions.py` and `wallet.py` for now) so they actually pass for Divi, which mostly means updating them for minor things like the changed block reward in Divi.

Also includes some bug fixes and general cleanups to the mempool tx collection logic, which were exposed by `mempool_resurrect_test.py`.