### PR TITLE
Fix syncing issue and enable txn_doublespend.py

### DIFF
--- a/divi/qa/rpc-tests/run-tests.sh
+++ b/divi/qa/rpc-tests/run-tests.sh
@@ -12,4 +12,6 @@ echo "$path"
 cd $path
 ./listtransactions.py
 ./mempool_resurrect_test.py
+./txn_doublespend.py
+./txn_doublespend.py --mineblock
 ./wallet.py

--- a/divi/src/main.cpp
+++ b/divi/src/main.cpp
@@ -402,6 +402,20 @@ void UpdateBlockAvailability(NodeId nodeid, const uint256& hash)
     }
 }
 
+/** Updates information about what blocks a node is assumed to have based on
+ *  a block locator it has sent.  */
+void UpdateBlockAvailability(NodeId nodeid, const CBlockLocator& locator)
+{
+    AssertLockHeld(cs_main);
+    for (const auto& hash : locator.vHave) {
+        auto it = mapBlockIndex.find(hash);
+        if (it != mapBlockIndex.end() && it->second->nChainWork > 0) {
+            UpdateBlockAvailability(nodeid, hash);
+            return;
+        }
+    }
+}
+
 /** Find the last common ancestor two blocks have.
  *  Both pa and pb must be non-NULL. */
 CBlockIndex* LastCommonAncestor(CBlockIndex* pa, CBlockIndex* pb)
@@ -2854,6 +2868,54 @@ static bool ActivateBestChainStep(CValidationState& state, CBlockIndex* pindexMo
     return true;
 }
 
+namespace {
+
+/**
+ * Sends inv messages to update the given node about a new chain tip we have.
+ * Normally this just sends an inv for the new block; but if the node is behind
+ * (or e.g. we just had a reorg), make sure to send all inv's in order from
+ * what we know to be the node's best known block.
+ */
+void RelayNewTipToNode(CNode& node, const CBlockIndex& index)
+{
+    const auto* state = State(node.GetId());
+
+    /* In the most common case, the node is behind just one block.  Just relay
+       the current one then; also do this if we don't know where the node is.
+       We use a direct inv message rather than PushInventory, because we always
+       want to announce the inv to peers even if they know it already (e.g. because
+       we got if from them).  This ensures that nodes keep track of an accurate
+       pindexBestKnownBlock for each other.  */
+    if (state == nullptr || state->pindexBestKnownBlock == nullptr || index.pprev->GetBlockHash() == state->pindexBestKnownBlock->GetBlockHash()) {
+        std::vector<CInv> vInv;
+        vInv.emplace_back(MSG_BLOCK, index.GetBlockHash());
+        node.PushMessage("inv", vInv);
+        return;
+    }
+
+    /* If the node is behind more than that, look for the fork point and relay
+       all inv's since then in order.  */
+    LOCK(cs_main);
+    const auto* pindexFork = chainActive.FindFork(state->pindexBestKnownBlock);
+    if (pindexFork == nullptr) {
+        /* This means that not even the genesis block is shared between us
+           and the node, in which case there's not much point anyway in
+           relaying and blocks.  */
+        return;
+    }
+    pindexFork = chainActive.Next(pindexFork);
+    assert(pindexFork != nullptr);
+    LogPrint("net", "sending multiple inv (from %d) for new chain tip %s to peer=%d\n",
+             pindexFork->nHeight, index.GetBlockHash().ToString(), node.id);
+    for (; pindexFork != nullptr; pindexFork = chainActive.Next(pindexFork)) {
+        node.PushInventory(CInv(MSG_BLOCK, pindexFork->GetBlockHash()));
+        if (pindexFork->GetBlockHash() == index.GetBlockHash())
+            break;
+    }
+}
+
+} // anonymous namespace
+
 /**
  * Make the best chain active, in multiple steps. The result is either failure
  * or an activated best chain. pblock is either NULL or a pointer to a block
@@ -2891,17 +2953,17 @@ bool ActivateBestChain(CValidationState& state, CBlock* pblock, bool fAlreadyChe
 
         // Notifications/callbacks that can run without cs_main
         if (!fInitialDownload) {
-            uint256 hashNewTip = pindexNewTip->GetBlockHash();
             // Relay inventory, but don't relay old inventory during initial block download.
             int nBlockEstimate = checkpointsVerifier.GetTotalBlocksEstimate();
             {
                 LOCK(cs_vNodes);
-                BOOST_FOREACH (CNode* pnode, vNodes)
-                        if (chainActive.Height() > (pnode->nStartingHeight != -1 ? pnode->nStartingHeight - 2000 : nBlockEstimate))
-                        pnode->PushInventory(CInv(MSG_BLOCK, hashNewTip));
+                for (auto* pnode : vNodes) {
+                    if (chainActive.Height() > (pnode->nStartingHeight != -1 ? pnode->nStartingHeight - 2000 : nBlockEstimate))
+                        RelayNewTipToNode(*pnode, *pindexNewTip);
+                }
             }
             // Notify external listeners about the new tip.
-            uiInterface.NotifyBlockTip(hashNewTip);
+            uiInterface.NotifyBlockTip(pindexNewTip->GetBlockHash());
         }
     } while (pindexMostWork != chainActive.Tip());
     CheckBlockIndex();
@@ -4916,6 +4978,9 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
 
         LOCK(cs_main);
 
+        // Use the locator to (maybe) set our information of what blocks the node has.
+        UpdateBlockAvailability(pfrom->id, locator);
+
         // Find the last block the caller has in the main chain
         CBlockIndex* pindex = FindForkInGlobalIndex(chainActive, locator);
 
@@ -4950,6 +5015,9 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
 
         if (IsInitialBlockDownload())
             return true;
+
+        // Use the locator to (maybe) set our information of what blocks the node has.
+        UpdateBlockAvailability(pfrom->id, locator);
 
         CBlockIndex* pindex = NULL;
         if (locator.IsNull()) {


### PR DESCRIPTION
This enables the `txn_doublespend.py` regtest (which needed only small adjustments as previously).  It also fixes a syncing issue uncovered more or less accidentally by `txn_doublespend.py --mineblock`.  From 252368f01d17c3db2bb496f9a102acb70b64df70:

When node A does a reorg from an orphan block X to a longer chain Y-Z (where X and Y have the same height), it previously sent only an inv for the new best tip Z.  Another node B connected to A and on X will then receive the inv and block data for Z, but disregard it since the previous block is not known.  B will still request getblocks from A that ultimately cover the whole fork, but since A already sent the inv for Z to B, it will not send it again and B will never be able to switch to Z as it should.

This is a fix for this issue.  When we send inv's to peers about a new best tip, we attempt to send them in the order required for each peer based on where we think they are (so that in the case of a reorg / fork, they get all inv's from the fork point as would be the case with a getblocks request).