### PR TITLE
No difficulty retargeting on regtest

### DIFF
--- a/divi/src/chainparams.cpp
+++ b/divi/src/chainparams.cpp
@@ -225,9 +225,9 @@ public:
         fAllowMinDifficultyBlocks = false;
         fDefaultConsistencyChecks = false;
         fRequireStandard = true;
+        fDifficultyRetargeting = true;
         fMineBlocksOnDemand = false;
         fHeadersFirstSyncingActive = false;
-        fSkipProofOfWorkCheck = false;
         
         nFulfilledRequestExpireTime = 30 * 60; // fulfilled requests expire in 30 minutes
         strSporkKey = "02c1ed5eadcf6793fa22840febfbd667fabbabc48ddd75c2d228662d65e292eb00";
@@ -340,7 +340,6 @@ public:
         fDefaultConsistencyChecks = false;
         fRequireStandard = true;
         fMineBlocksOnDemand = false;
-        fSkipProofOfWorkCheck = false;
         fHeadersFirstSyncingActive = false;
 
         nFulfilledRequestExpireTime = 60 * 60; // fulfilled requests expire in 1 hour
@@ -426,7 +425,6 @@ public:
         fRequireStandard = false;
         fMineBlocksOnDemand = false;
         fHeadersFirstSyncingActive = false;
-        fSkipProofOfWorkCheck = false;
 
         nFulfilledRequestExpireTime = 5*60; // fulfilled requests expire in 5 minutes
         strSporkKey = "034ffa41e5cffdd009f3b34a3e1482ec82b514bb218b7648948b5858cc5c035adb";
@@ -505,6 +503,7 @@ public:
         fAllowMinDifficultyBlocks = true;
         fDefaultConsistencyChecks = true;
         fRequireStandard = false;
+        fDifficultyRetargeting = false;
         fMineBlocksOnDemand = true;
     }
     const CCheckpointData& Checkpoints() const
@@ -532,6 +531,7 @@ public:
         fMiningRequiresPeers = false;
         fDefaultConsistencyChecks = true;
         fAllowMinDifficultyBlocks = false;
+        fDifficultyRetargeting = true;
         fMineBlocksOnDemand = true;
     }
 
@@ -548,7 +548,6 @@ public:
     virtual void setToCheckBlockUpgradeMajority(int anToCheckBlockUpgradeMajority) { nToCheckBlockUpgradeMajority = anToCheckBlockUpgradeMajority; }
     virtual void setDefaultConsistencyChecks(bool afDefaultConsistencyChecks) { fDefaultConsistencyChecks = afDefaultConsistencyChecks; }
     virtual void setAllowMinDifficultyBlocks(bool afAllowMinDifficultyBlocks) { fAllowMinDifficultyBlocks = afAllowMinDifficultyBlocks; }
-    virtual void setSkipProofOfWorkCheck(bool afSkipProofOfWorkCheck) { fSkipProofOfWorkCheck = afSkipProofOfWorkCheck; }
 };
 static CUnitTestParams unitTestParams;
 

--- a/divi/src/chainparams.h
+++ b/divi/src/chainparams.h
@@ -72,8 +72,6 @@ public:
     bool DefaultConsistencyChecks() const { return fDefaultConsistencyChecks; }
     /** Allow mining of a min-difficulty block */
     bool AllowMinDifficultyBlocks() const { return fAllowMinDifficultyBlocks; }
-    /** Skip proof-of-work check: allow mining of any difficulty block */
-    bool SkipProofOfWorkCheck() const { return fSkipProofOfWorkCheck; }
     /** Make standard checks */
     bool RequireStandard() const { return fRequireStandard; }
     int64_t TargetTimespan() const { return nTargetTimespan; }
@@ -83,6 +81,8 @@ public:
     CAmount MaxMoneyOut() const { return nMaxMoneyOut; }
     /** The masternode count that we will allow the see-saw reward payments to be off by */
     int MasternodeCountDrift() const { return nMasternodeCountDrift; }
+    /** Retarget difficulty? */
+    bool RetargetDifficulty() const { return fDifficultyRetargeting; }
     /** Make miner stop after a block is found. In RPC, don't return until nGenProcLimit blocks are generated */
     bool MineBlocksOnDemand() const { return fMineBlocksOnDemand; }
     /** Return the BIP70 network string (main, test or regtest) */
@@ -141,8 +141,8 @@ protected:
     bool fAllowMinDifficultyBlocks;
     bool fDefaultConsistencyChecks;
     bool fRequireStandard;
+    bool fDifficultyRetargeting;
     bool fMineBlocksOnDemand;
-    bool fSkipProofOfWorkCheck;
     bool fHeadersFirstSyncingActive;
     std::string strSporkKey;
     int64_t nStartMasternodePayments;
@@ -173,7 +173,6 @@ public:
     virtual void setToCheckBlockUpgradeMajority(int anToCheckBlockUpgradeMajority) = 0;
     virtual void setDefaultConsistencyChecks(bool aDefaultConsistencyChecks) = 0;
     virtual void setAllowMinDifficultyBlocks(bool aAllowMinDifficultyBlocks) = 0;
-    virtual void setSkipProofOfWorkCheck(bool aSkipProofOfWorkCheck) = 0;
 };
 
 

--- a/divi/src/pow.cpp
+++ b/divi/src/pow.cpp
@@ -32,6 +32,9 @@ unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHead
         return chainParameters.ProofOfWorkLimit().GetCompact();
     }
 
+    if (!chainParameters.RetargetDifficulty())
+        return BlockLastSolved->nBits;
+
     if (pindexLast->nHeight > chainParameters.LAST_POW_BLOCK()) {
         uint256 bnTargetLimit = (~uint256(0) >> 24);
         int64_t nTargetSpacing = 60;
@@ -112,9 +115,6 @@ bool CheckProofOfWork(uint256 hash, unsigned int nBits, const CChainParams& chai
     bool fNegative;
     bool fOverflow;
     uint256 bnTarget;
-
-    if (chainParameters.SkipProofOfWorkCheck())
-        return true;
 
     bnTarget.SetCompact(nBits, &fNegative, &fOverflow);
 


### PR DESCRIPTION
This adds a new chainparams flag that is used to disable difficulty retargeting on regtest (while keeping it of course everywhere else).  That allows mining blocks in tests much quicker, speeding up also the tests themselves (e.g. mining 100 blocks on regtest speeds up from 13s to 6s on my machine with this change).

We also remove an existing flag to skip the PoW check, which is not used anywhere (it was always disabled, even on regtest), and which would not apply to PoS.