### PR TITLE
Fix flaky wallet tests

### DIFF
--- a/divi/qa/rpc-tests/wallet.py
+++ b/divi/qa/rpc-tests/wallet.py
@@ -50,8 +50,9 @@ class WalletTest (BitcoinTestFramework):
         # Second transaction will be child of first, and will require a fee
         self.nodes[0].sendtoaddress(self.nodes[2].getnewaddress(), 351)
         self.nodes[0].sendtoaddress(self.nodes[2].getnewaddress(), 350)
-        self.nodes[1].setgenerate(True, 16)
-        self.sync_all()
+        sync_mempools(self.nodes)
+        self.nodes[1].setgenerate(True, 1)
+        sync_blocks(self.nodes)
 
         # Compare the expected balances.  Give 1 coin leeway
         # for fees paid by node0 (which are burnt in Divi).


### PR DESCRIPTION
This fixes `wallet.py` and walletbackup.py`, which had random failures before due to missing syncs and expectations based on an "estimated" fee which had not the necessary tolerance.  Now both tests worked fine for me in 10 consecutive runs.