### PR TITLE
Relax time handling for PoS minting

### DIFF
--- a/divi/qa/rpc-tests/PowToPosTransition.py
+++ b/divi/qa/rpc-tests/PowToPosTransition.py
@@ -15,9 +15,59 @@ import shutil
 import random
 from datetime import datetime
 
-def createPoSStacks(node,node0_address,blocksToMine):
-    node.setgenerate(True,blocksToMine)
-    node.sendtoaddress(node0_address,30000.0)
+def createPoSStacks(nodes, all_nodes):
+    """Makes sure all listed nodes have a stack of coins that is
+    suitable for staking indefinitely.
+
+    Ideally this should be done right on top of a clean chain."""
+
+    # Make sure all nodes have matured coins.
+    for n in nodes:
+      n.setgenerate(True, 10)
+      sync_blocks(nodes)
+    nodes[0].setgenerate(True, 20)
+
+    # Split those coins up into many pieces that can each be used
+    # individually for staking.
+    parts = 20
+    value = 400
+    totalValue = parts * value
+    for n in nodes:
+      assert n.getbalance() > totalValue
+      to = {}
+      for _ in range(parts):
+        to[n.getnewaddress()] = value
+      n.sendmany("", to)
+
+    # Make sure to get all those transactions mined.
+    sync_mempools(nodes)
+    while len(nodes[0].getrawmempool()) > 0:
+      nodes[0].setgenerate(True, 1)
+    sync_blocks(all_nodes)
+
+def generatePoSBlocks(nodes, index, num):
+    """Generates num blocks with nodes[index], taking care of
+    setting the mock time as needed to do this with PoS."""
+
+    # Number of blocks to mine in one go, before bumping the mock time
+    # further.  This must be little enough so that the blocks are still
+    # accepted even if they are beyond the node time.  Ideally not too
+    # small either, as that will make it slower.
+    blocksPerStep = 100
+
+    node = nodes[index]
+    while True:
+      bestBlock = node.getblockheader(node.getbestblockhash())
+      set_node_times(nodes, bestBlock["time"])
+
+      if num == 0:
+        sync_blocks(nodes)
+        return
+
+      n = min(num, blocksPerStep)
+      assert n > 0
+      node.setgenerate(True, n)
+      num -= n
 
 class PowToPosTransitionTest(BitcoinTestFramework):
 
@@ -27,19 +77,26 @@ class PowToPosTransitionTest(BitcoinTestFramework):
         self.is_network_split = False
 
     def run_test(self):
-        targetNumberOfBlocks = 101
+        posStart = 100
+        targetNumberOfBlocks = posStart + 500
         node = self.nodes[0]
-        node0_address = node.getnewaddress("")
 
-        for j in range(2):
-            createPoSStacks(node,node0_address,50)
-        set_node_times(self.nodes, int(datetime.utcnow().strftime('%s')) + 60*60*60)
+        print ("Setting up PoS coins...")
+        createPoSStacks([node], self.nodes)
+        self.sync_all()
 
-        missing = targetNumberOfBlocks - node.getblockcount()
+        print ("Mining remaining PoW blocks...")
+        missing = posStart - node.getblockcount()
         assert missing > 0
         node.setgenerate(True, missing)
+        self.sync_all()
 
-        assert_equal(self.nodes[0].getblockcount(), targetNumberOfBlocks)
+        print ("Trying to mine PoS blocks now...")
+        missing = targetNumberOfBlocks - node.getblockcount()
+        assert missing > 0
+        generatePoSBlocks(self.nodes, 0, missing)
+
+        assert_equal(node.getblockcount(), targetNumberOfBlocks)
 
 if __name__ == '__main__':
     PowToPosTransitionTest().main()

--- a/divi/src/kernel.cpp
+++ b/divi/src/kernel.cpp
@@ -293,10 +293,18 @@ uint256 stakeHash(uint64_t stakeModifier, unsigned int nTimeTx, const COutPoint&
 //test hash vs target
 bool stakeTargetHit(const uint256& hashProofOfStake, int64_t nValueIn, const uint256& bnTargetPerCoinDay, int64_t nTimeWeight)
 {
-    uint256 bnCoinDayWeight = uint256(nValueIn) * nTimeWeight / COIN / 400;
+    const uint256 bnCoinDayWeight = uint256(nValueIn) * nTimeWeight / COIN / 400;
+
+    uint256 target = bnTargetPerCoinDay;
+    if (!target.MultiplyBy(bnCoinDayWeight)) {
+        // In regtest with minimal difficulty, it may happen that the
+        // modification overflows the uint256, in which case it just means
+        // that the target will always be hit.
+        return true;
+    }
 
     // Now check if proof-of-stake hash meets target protocol
-    return (hashProofOfStake < bnCoinDayWeight * bnTargetPerCoinDay);
+    return hashProofOfStake < target;
 }
 
 

--- a/divi/src/rpcmining.cpp
+++ b/divi/src/rpcmining.cpp
@@ -168,8 +168,10 @@ Value setgenerate(const Array& params, bool fHelp)
         CoinMinter minter(pwalletMain, chainActive, Params(),vNodes,masternodeSync,mapHashedBlocks,mempool,cs_main,coinstakeSearchInterval);
         while (nHeight < nHeightEnd)
         {
+            const bool fProofOfStake = (nHeight >= Params().LAST_POW_BLOCK());
+
             unsigned int nExtraNonce = 0;
-            bool newBlockAdded = minter.createNewBlock(nExtraNonce,reservekey,nHeight >= Params().LAST_POW_BLOCK());
+            const bool newBlockAdded = minter.createNewBlock(nExtraNonce, reservekey, fProofOfStake);
             nHeight +=  newBlockAdded;
             if(newBlockAdded)
             { // Don't keep cs_main locked
@@ -178,6 +180,10 @@ Value setgenerate(const Array& params, bool fHelp)
                 {
                     blockHashes.push_back(chainActive.Tip()->GetBlockHash().GetHex());
                 }
+            } else if (fProofOfStake)
+            {
+                LogPrintf("Failed to generate PoS block, sleeping\n");
+                MilliSleep(1000);
             }
         }
         return blockHashes;

--- a/divi/src/test/uint256_tests.cpp
+++ b/divi/src/test/uint256_tests.cpp
@@ -519,6 +519,24 @@ BOOST_AUTO_TEST_CASE( multiply )
     BOOST_CHECK((R2S * 0xFFFFFFFFUL).ToString() == "1c6f6c930353e17f7d6127213bb18d2883e2cd90");
 }
 
+BOOST_AUTO_TEST_CASE( multiply_overflow )
+{
+    const uint256 fourth = HalfL / 2;
+
+    uint256 value = fourth;
+    BOOST_CHECK(value.MultiplyBy(OneL * 2));
+    BOOST_CHECK(value == HalfL);
+
+    value = fourth;
+    BOOST_CHECK(value.MultiplyBy(OneL * 3));
+
+    value = fourth;
+    BOOST_CHECK(!value.MultiplyBy(OneL * 4));
+
+    value = fourth;
+    BOOST_CHECK(!value.MultiplyBy(HalfL));
+}
+
 BOOST_AUTO_TEST_CASE( divide )
 {
     uint256 D1L("AD7133AC1977FA2B7");

--- a/divi/src/uint256.h
+++ b/divi/src/uint256.h
@@ -186,6 +186,12 @@ public:
     base_uint& operator*=(const base_uint& b);
     base_uint& operator/=(const base_uint& b);
 
+    /** Multiplies with a given other base_uint.  Unlike *=, it does not return
+     *  the instance itself, but true if the multiplication "fit" into the
+     *  bit size.  In other words, if the function returns false, then an
+     *  overflow occured.  */
+    bool MultiplyBy(const base_uint& b);
+
     base_uint& operator++()
     {
         // prefix operator


### PR DESCRIPTION
This set of changes fixes a potential overflow with the regtest difficulty and PoS (where the difficulty target is reduced further depending on coin age), and also relaxes handling of the node time when minting PoS blocks.  It does not affect the consensus-level validation logic (except indirectly through the `uint256` changes, which should be reviewed carefully).

Specifically, the miner no longer enforces that the node's local (adjusted) time is beyond the best block; instead, the timestamps of the staking tx and minted block will just be pushed forward as needed, which is possible within some limits.  With this change, it is easily and quickly possible to generate hundreds of PoS blocks on regtest as needed.