### PR TITLE
Another PoS regtest fix & activate bipdersig.py

### DIFF
--- a/divi/qa/rpc-tests/bipdersig.py
+++ b/divi/qa/rpc-tests/bipdersig.py
@@ -13,6 +13,8 @@ from util import *
 import os
 import shutil
 
+from PowToPosTransition import createPoSStacks, generatePoSBlocks
+
 class BIP66Test(BitcoinTestFramework):
 
     def setup_network(self):
@@ -26,17 +28,17 @@ class BIP66Test(BitcoinTestFramework):
         self.sync_all()
 
     def run_test(self):
+        createPoSStacks(self.nodes[1:], self.nodes)
         cnt = self.nodes[0].getblockcount()
 
         # Mine some old-version blocks
-        self.nodes[1].setgenerate(True, 100)
+        generatePoSBlocks(self.nodes, 1, 100)
         self.sync_all()
         if (self.nodes[0].getblockcount() != cnt + 100):
             raise AssertionError("Failed to mine 100 version=2 blocks")
 
         # Mine 750 new-version blocks
-        for i in xrange(15):
-            self.nodes[2].setgenerate(True, 50)
+        generatePoSBlocks(self.nodes, 2, 750)
         self.sync_all()
         if (self.nodes[0].getblockcount() != cnt + 850):
             raise AssertionError("Failed to mine 750 version=3 blocks")
@@ -44,7 +46,7 @@ class BIP66Test(BitcoinTestFramework):
         # TODO: check that new DERSIG rules are not enforced
 
         # Mine 1 new-version block
-        self.nodes[2].setgenerate(True, 1)
+        generatePoSBlocks(self.nodes, 2, 1)
         self.sync_all()
         if (self.nodes[0].getblockcount() != cnt + 851):
             raise AssertionFailure("Failed to mine a version=3 blocks")
@@ -52,27 +54,26 @@ class BIP66Test(BitcoinTestFramework):
         # TODO: check that new DERSIG rules are enforced
 
         # Mine 198 new-version blocks
-        for i in xrange(2):
-            self.nodes[2].setgenerate(True, 99)
+        generatePoSBlocks(self.nodes, 2, 198)
         self.sync_all()
         if (self.nodes[0].getblockcount() != cnt + 1049):
             raise AssertionError("Failed to mine 198 version=3 blocks")
 
         # Mine 1 old-version block
-        self.nodes[1].setgenerate(True, 1)
+        generatePoSBlocks(self.nodes, 1, 1)
         self.sync_all()
         if (self.nodes[0].getblockcount() != cnt + 1050):
             raise AssertionError("Failed to mine a version=2 block after 949 version=3 blocks")
 
         # Mine 1 new-version blocks
-        self.nodes[2].setgenerate(True, 1)
+        generatePoSBlocks(self.nodes, 2, 1)
         self.sync_all()
         if (self.nodes[0].getblockcount() != cnt + 1051):
             raise AssertionError("Failed to mine a version=3 block")
 
         # Mine 1 old-version blocks
         try:
-            self.nodes[1].setgenerate(True, 1)
+            generatePoSBlocks(self.nodes, 1, 1)
             raise AssertionError("Succeeded to mine a version=2 block after 950 version=3 blocks")
         except JSONRPCException:
             pass
@@ -81,7 +82,7 @@ class BIP66Test(BitcoinTestFramework):
             raise AssertionError("Accepted a version=2 block after 950 version=3 blocks")
 
         # Mine 1 new-version blocks
-        self.nodes[2].setgenerate(True, 1)
+        generatePoSBlocks(self.nodes, 2, 1)
         self.sync_all()
         if (self.nodes[0].getblockcount() != cnt + 1052):
             raise AssertionError("Failed to mine a version=3 block")

--- a/divi/qa/rpc-tests/run-tests.sh
+++ b/divi/qa/rpc-tests/run-tests.sh
@@ -11,6 +11,7 @@ set -ex
 echo "$path"
 cd $path
 
+./bipdersig.py
 ./forknotify.py
 ./getchaintips.py
 ./httpbasics.py
@@ -20,10 +21,10 @@ cd $path
 ./mempool_coinbase_spends.py
 ./mempool_resurrect_test.py
 ./mempool_spendcoinbase.py
+./PowToPosTransition.py
 ./proxy_test.py
 ./receivedby.py
 ./reindex.py
-./PowToPosTransition.py
 ./rest.py
 ./rpcbind_test.py
 ./sync.py

--- a/divi/src/PoSTransactionCreator.cpp
+++ b/divi/src/PoSTransactionCreator.cpp
@@ -33,14 +33,16 @@ bool PoSTransactionCreator::SelectCoins(
 
     if (GetTime() - nLastStakeSetUpdate > wallet_.nStakeSetUpdateTime) {
         setStakeCoins.clear();
-        if (!wallet_.SelectStakeCoins(setStakeCoins, allowedStakingBalance))
-            return false;
+        if (!wallet_.SelectStakeCoins(setStakeCoins, allowedStakingBalance)) {
+            return error("failed to select coins for staking");
+        }
 
         nLastStakeSetUpdate = GetTime();
     }
 
-    if (setStakeCoins.empty())
-        return false;
+    if (setStakeCoins.empty()) {
+        return error("no coins available for staking");
+    }
 
     return true;
 }

--- a/divi/src/wallet.cpp
+++ b/divi/src/wallet.cpp
@@ -1615,6 +1615,14 @@ bool CWallet::SelectStakeCoins(std::set<std::pair<const CWalletTx*, unsigned int
         if (GetAdjustedTime() - nTxTime < Params().GetMinCoinAgeForStaking())
             continue;
 
+        // Make sure that the coin is large enough so that we do not end up
+        // with less than 400 DIVI seconds in coin age when spent, which will
+        // be rounded down to exact zero in the code.  Even if the minimum coin
+        // age is zero (as on regtest), the actual one used for blocks will be
+        // at least one, as the blocks are spaced with a second apart.
+        if (std::max<int64_t>(1, Params().GetMinCoinAgeForStaking()) * out.tx->vout[out.i].nValue < 400 * COIN)
+            continue;
+
         //check that it is matured
         if (out.nDepth < (out.tx->IsCoinStake() ? Params().COINBASE_MATURITY() : 10))
             continue;


### PR DESCRIPTION
This fixes and activates the `bipdersig.py` regtest, which mines more than 1'000 blocks and thus needs to use the new PoS-on-regtest functionality.  It also includes another fix needed for it, namely to only select coins for staking that will yield beyond 400 DIVI seconds in coin age even when staked with minimal age on regtest.  (Otherwise the weight gets truncated down to zero and the hash target becomes impossible.)