### PR TITLE
Regtest for masternode collateral

### DIFF
--- a/divi/qa/rpc-tests/masternode.py
+++ b/divi/qa/rpc-tests/masternode.py
@@ -1,0 +1,32 @@
+# Copyright (c) 2020 The DIVI developers
+# Distributed under the MIT/X11 software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+# Utilities for testing masternodes.
+
+from util import *
+
+
+class MnConfigLine (object):
+  """Wrapper class for working with masternode.conf lines."""
+
+  def __init__ (self, line):
+    parts = line.split (" ")
+    assert_equal (len (parts), 5)
+
+    self.line = line
+
+    self.alias = parts[0]
+    self.ip = parts[1]
+    self.privkey = parts[2]
+    self.txid = parts[3]
+    self.vout = int (parts[4])
+
+
+def fund_masternode (node, alias, tier, txid, ip):
+  """Calls fundmasternode with the given data and returns the
+  MnConfigLine instance."""
+
+  data = node.fundmasternode (alias, tier, txid, ip)
+  assert "config line" in data
+  return MnConfigLine (data["config line"])

--- a/divi/qa/rpc-tests/mncollateral.py
+++ b/divi/qa/rpc-tests/mncollateral.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python2
+# Copyright (c) 2020 The DIVI developers
+# Distributed under the MIT/X11 software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+# Tests wallet handling of masternode collateral.  In particular, we
+# allocate funds, assign it to a masternode (but without running the
+# masternode) and verify the expected locking of the collateral UTXO.
+
+from test_framework import BitcoinTestFramework
+from util import *
+from masternode import *
+
+
+class MnCollateralTest (BitcoinTestFramework):
+
+  def setup_network (self, config_line=None, extra_args=[]):
+    args = [(extra_args + ["-spendzeroconfchange"])] * 2
+    config_lines = [[]] * 2
+    if config_line is not None:
+      config_lines[0] = [config_line]
+    self.nodes = start_nodes(2, self.options.tmpdir, extra_args=args, mn_config_lines=config_lines)
+    connect_nodes_bi (self.nodes, 0, 1)
+    self.is_network_split = False
+    self.sync_all ()
+
+  def mine_blocks (self, n):
+    """Mines blocks with node 1.  We use node 0 for the test, so that
+    this ensures that node does not get unexpected coins."""
+
+    sync_mempools (self.nodes)
+    self.nodes[1].setgenerate(True, n)
+    sync_blocks (self.nodes)
+
+  def check_balance (self, expected, account="*"):
+    """Verifies that the balance of node 0 matches the expected amount,
+    up to some epsilon for fees."""
+
+    actual = self.nodes[0].getbalance (account)
+    eps = 1
+    assert_greater_than (actual, expected - eps)
+    assert_greater_than (expected + eps, actual)
+
+  def run_test (self):
+    # Give 1250 matured coins to node 0.  All future blocks will be mined
+    # with node 1, so that we can verify the expected balance.
+    node = self.nodes[0]
+    node.setgenerate (True, 1)
+    sync_blocks (self.nodes)
+    self.mine_blocks (20)
+    self.check_balance (1250)
+
+    # Allocate some funds and use them to construct a config line.
+    txid = node.allocatefunds ("masternode", "spent", "silver")["txhash"]
+    self.mine_blocks (1)
+    self.check_balance (300, "alloc->spent")
+    self.check_balance (1250)
+    cfg = fund_masternode (node, "spent", "silver", txid, "1.2.3.4")
+    assert_equal (cfg.alias, "spent")
+    assert_equal (cfg.ip, "1.2.3.4:51476")
+    assert_equal (cfg.txid, txid)
+    assert_equal (node.gettxout (cfg.txid, cfg.vout)["value"], 300)
+
+    # It should still be possible to spend the coins, invalidating the
+    # masternode funding.
+    node.sendtoaddress (node.getnewaddress (), 1000)
+    self.mine_blocks (1)
+    self.check_balance (1250)
+    assert_equal (node.gettxout (cfg.txid, cfg.vout), None)
+
+    # Allocate some more funds without spending them.
+    txid = node.allocatefunds ("masternode", "gold", "gold")["txhash"]
+    self.mine_blocks (1)
+    self.check_balance (1000, "alloc->gold")
+    self.check_balance (1250)
+    cfg = fund_masternode (node, "spent", "gold", txid, "1.2.3.4")
+    assert_equal (node.gettxout (cfg.txid, cfg.vout)["value"], 1000)
+
+    # Restart with the config line added.
+    stop_nodes (self.nodes)
+    wait_bitcoinds ()
+    self.setup_network (config_line=cfg.line)
+    node = self.nodes[0]
+
+    # Now spending the locked coins will not work (but spending less is fine).
+    assert_equal (node.listlockunspent (), [
+      {"txid": cfg.txid, "vout": cfg.vout},
+    ])
+    assert_raises(JSONRPCException, node.sendtoaddress, node.getnewaddress (), 500)
+    node.sendtoaddress (node.getnewaddress (), 200)
+    self.mine_blocks (1)
+    self.check_balance (1250)
+
+    # Restart without locking.
+    stop_nodes (self.nodes)
+    wait_bitcoinds ()
+    self.setup_network (extra_args=["-mnconflock=0"], config_line=cfg.line)
+    node = self.nodes[0]
+
+    # Now we can spend the collateral.
+    assert_equal (node.listlockunspent (), [])
+    node.sendtoaddress (node.getnewaddress (), 1200)
+    self.mine_blocks (1)
+    self.check_balance (1250)
+
+
+if __name__ == '__main__':
+  MnCollateralTest ().main ()

--- a/divi/qa/rpc-tests/rpcbind_test.py
+++ b/divi/qa/rpc-tests/rpcbind_test.py
@@ -40,7 +40,7 @@ class RpcBindTest(BitcoinTestFramework):
         if allow_ips:
             base_args += ['-rpcallowip=' + x for x in allow_ips]
         binds = ['-rpcbind='+addr for addr in addresses]
-        nodes = start_nodes(1, self.options.tmpdir, [base_args + binds], connect_to)
+        nodes = start_nodes(1, self.options.tmpdir, [base_args + binds], rpchost=connect_to)
         try:
             pid = bitcoind_processes[0].pid
             assert_equal(set(get_bind_addrs(pid)), set(expected))

--- a/divi/qa/rpc-tests/test_runner.py
+++ b/divi/qa/rpc-tests/test_runner.py
@@ -82,6 +82,7 @@ BASE_SCRIPTS = [
     'mempool_coinbase_spends.py',
     'mempool_resurrect_test.py',
     'mempool_spendcoinbase.py',
+    'mncollateral.py',
     'proxy_test.py',
     'receivedby.py',
     'reindex.py',
@@ -103,6 +104,7 @@ ALL_SCRIPTS = EXTENDED_SCRIPTS + BASE_SCRIPTS
 
 NON_SCRIPTS = [
     # These are script files that live in the functional tests directory, but are not test scripts.
+    'masternode.py',
     'netutil.py',
     'test_framework.py',
     'test_runner.py',

--- a/divi/qa/rpc-tests/util.py
+++ b/divi/qa/rpc-tests/util.py
@@ -68,6 +68,9 @@ def initialize_datadir(dirname, n):
     datadir = os.path.join(dirname, "node"+str(n))
     if not os.path.isdir(datadir):
         os.makedirs(datadir)
+    regtest = os.path.join(datadir, "regtest")
+    if not os.path.isdir(regtest):
+        os.makedirs(regtest)
     with open(os.path.join(datadir, "divi.conf"), 'w') as f:
         f.write("allowunencryptedwallet=1\n")
         f.write("regtest=1\n")
@@ -97,11 +100,13 @@ def _rpchost_to_args(rpchost):
         rv += ['-rpcport=' + rpcport]
     return rv
 
-def start_node(i, dirname, extra_args=None, rpchost=None):
+def start_node(i, dirname, extra_args=None, mn_config_lines=[], rpchost=None):
     """
     Start a divid and return RPC connection to it
     """
     datadir = os.path.join(dirname, "node"+str(i))
+    with open(os.path.join(datadir, "regtest", "masternode.conf"), "w") as f:
+      f.write("\n".join(mn_config_lines))
     args = [ os.getenv("BITCOIND", "divid"), "-datadir="+datadir, "-keypool=1", "-discover=0", "-rest" ]
     if extra_args is not None: args.extend(extra_args)
     bitcoind_processes[i] = subprocess.Popen(args)
@@ -115,12 +120,13 @@ def start_node(i, dirname, extra_args=None, rpchost=None):
     proxy.url = url # store URL on proxy for info
     return proxy
 
-def start_nodes(num_nodes, dirname, extra_args=None, rpchost=None):
+def start_nodes(num_nodes, dirname, extra_args=None, mn_config_lines=None, rpchost=None):
     """
     Start multiple divids, return RPC connections to them
     """
     if extra_args is None: extra_args = [ None for i in range(num_nodes) ]
-    return [ start_node(i, dirname, extra_args[i], rpchost) for i in range(num_nodes) ]
+    if mn_config_lines is None: mn_config_lines = [[]] * num_nodes
+    return [ start_node(i, dirname, extra_args[i], mn_config_lines[i], rpchost) for i in range(num_nodes) ]
 
 def log_filename(dirname, n_node, logname):
     return os.path.join(dirname, "node"+str(n_node), "regtest", logname)

--- a/divi/src/Makefile.am
+++ b/divi/src/Makefile.am
@@ -180,6 +180,7 @@ BITCOIN_CORE_H = \
   BlockIncentivesPopulator.h \
   SuperblockHelpers.h \
   SuperblockHeightValidator.h \
+  masternode-tier.h \
   masternode-sync.h \
   masternodeman.h \
   masternodeconfig.h \

--- a/divi/src/chainparams.cpp
+++ b/divi/src/chainparams.cpp
@@ -96,17 +96,20 @@ void MineGenesis(CBlock genesis)
     std::fflush(stdout);
 }
 
+namespace
+{
+
 //   What makes a good checkpoint block?
 // + Is surrounded by blocks with reasonable timestamps
 //   (no blocks before with a timestamp after, none after with
 //    timestamp before)
 // + Contains no strange transactions
-static MapCheckpoints mapCheckpoints =
+const MapCheckpoints mapCheckpoints =
         boost::assign::map_list_of
         (0, uint256("0x00000e258596876664989374c7ee36445cf5f4f80889af415cc32478214394ea"))
         (100, uint256("0x000000275b2b4a8af2c93ebdfd36ef8dd8c8ec710072bcc388ecbf5d0c8d3f9d"));
 
-static const CCheckpointData data = {
+const CCheckpointData data = {
     &mapCheckpoints,
     1538069980, // * UNIX timestamp of last checkpoint block
     100,    // * total number of transactions between genesis and last checkpoint
@@ -114,21 +117,42 @@ static const CCheckpointData data = {
     2000        // * estimated number of transactions per day after checkpoint
 };
 
-static MapCheckpoints mapCheckpointsTestnet =
+const MapCheckpoints mapCheckpointsTestnet =
         boost::assign::map_list_of(0, uint256("0x000000f351b8525f459c879f1e249b5d3d421b378ac6b760ea8b8e0df2454f33"));
-static const CCheckpointData dataTestnet = {
+const CCheckpointData dataTestnet = {
     &mapCheckpointsTestnet,
     1537971708,
     0,
     250};
 
-static MapCheckpoints mapCheckpointsRegtest =
+const MapCheckpoints mapCheckpointsRegtest =
         boost::assign::map_list_of(0, uint256("0x79ba0d9d15d36edee8d07cc300379ec65ab7e12765acd883e870aa618dbcc1a8"));
-static const CCheckpointData dataRegtest = {
+const CCheckpointData dataRegtest = {
     &mapCheckpointsRegtest,
     1518723178,
     0,
     100};
+
+const CChainParams::MNCollateralMapType mnCollateralsMainnet = {
+    {MasternodeTier::COPPER,    100000 * COIN},
+    {MasternodeTier::SILVER,    300000 * COIN},
+    {MasternodeTier::GOLD,     1000000 * COIN},
+    {MasternodeTier::PLATINUM, 3000000 * COIN},
+    {MasternodeTier::DIAMOND, 10000000 * COIN},
+};
+
+/* Masternode collaterals are significantly cheaper on regtest, so
+   that it is easy to generate them in tests without having to
+   mine hundreds of blocks.  */
+const CChainParams::MNCollateralMapType mnCollateralsRegtest = {
+    {MasternodeTier::COPPER,    100 * COIN},
+    {MasternodeTier::SILVER,    300 * COIN},
+    {MasternodeTier::GOLD,     1000 * COIN},
+    {MasternodeTier::PLATINUM, 3000 * COIN},
+    {MasternodeTier::DIAMOND, 10000 * COIN},
+};
+
+} // anonymous namespace
 
 class CMainParams : public CChainParams
 {
@@ -172,6 +196,7 @@ public:
         nTreasuryPaymentsStartBlock = 101;
         nTreasuryPaymentsCycle = 60 * 24 * 7 + 1;
         nMinCoinAgeForStaking = 60 * 60;
+        mnCollateralMap = &mnCollateralsMainnet;
 
         /**
         * Build the genesis block. Note that the output of the genesis coinbase cannot
@@ -487,6 +512,8 @@ public:
            around with mocktimes of perhaps multiple nodes in sync).  */
         nMinCoinAgeForStaking = 0;
 
+        mnCollateralMap = &mnCollateralsRegtest;
+
         nExtCoinType = 1;
 
         hashGenesisBlock = genesis.GetHash();
@@ -533,6 +560,7 @@ public:
         fAllowMinDifficultyBlocks = false;
         fDifficultyRetargeting = true;
         fMineBlocksOnDemand = true;
+        mnCollateralMap = &mnCollateralsMainnet;
     }
 
     const CCheckpointData& Checkpoints() const

--- a/divi/src/chainparams.h
+++ b/divi/src/chainparams.h
@@ -8,12 +8,16 @@
 #ifndef BITCOIN_CHAINPARAMS_H
 #define BITCOIN_CHAINPARAMS_H
 
+#include "amount.h"
 #include "chainparamsbase.h"
 #include "checkpoint_data.h"
 #include "primitives/block.h"
 #include "protocol.h"
 #include "uint256.h"
 
+#include "masternode-tier.h"
+
+#include <map>
 #include <vector>
 
 typedef unsigned char MessageStartChars[MESSAGE_START_SIZE];
@@ -33,6 +37,8 @@ struct CDNSSeedData {
 class CChainParams
 {
 public:
+    using MNCollateralMapType = std::map<MasternodeTier, CAmount>;
+
     enum Base58Type {
         PUBKEY_ADDRESS,
         SCRIPT_ADDRESS,
@@ -99,6 +105,11 @@ public:
     int GetTreasuryPaymentsStartBlock() const { return nTreasuryPaymentsStartBlock; }
     int GetTreasuryPaymentsCycle() const { return nTreasuryPaymentsCycle; }
     unsigned GetMinCoinAgeForStaking () const { return nMinCoinAgeForStaking; }
+    const MNCollateralMapType& MasternodeCollateralMap() const
+    {
+        assert(mnCollateralMap);
+        return *mnCollateralMap;
+    }
 
     /** Height or Time Based Activations **/
     int LAST_POW_BLOCK() const { return nLastPOWBlock; }
@@ -126,6 +137,7 @@ protected:
     int64_t nTargetSpacing;
     int nLastPOWBlock;
     unsigned nMinCoinAgeForStaking;
+    const MNCollateralMapType* mnCollateralMap;
     int nMasternodeCountDrift;
     int nMaturity;
     CAmount nMaxMoneyOut;

--- a/divi/src/masternode-tier.h
+++ b/divi/src/masternode-tier.h
@@ -1,0 +1,17 @@
+// Copyright (c) 2020 The DIVI developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef MASTERNODE_TIER_H
+#define MASTERNODE_TIER_H
+
+enum class MasternodeTier {
+    COPPER,
+    SILVER,
+    GOLD,
+    PLATINUM,
+    DIAMOND,
+    INVALID,
+};
+
+#endif // MASTERNODE_TIER_H

--- a/divi/src/masternode.cpp
+++ b/divi/src/masternode.cpp
@@ -30,12 +30,11 @@ const int TIER_PLATINUM_BASE_COLLATERAL = 3000000;
 const int TIER_DIAMOND_BASE_COLLATERAL  = 10000000;
 
 
-static CAmount getCollateralAmount(int tier)
+static CAmount getCollateralAmount(MasternodeTier tier)
 {
-  if(tier >= static_cast<int>(CMasternode::Tier::MASTERNODE_TIER_COPPER) &&
-    tier < static_cast<int>(CMasternode::Tier::MASTERNODE_TIER_INVALID) )
+  if(tier >= MasternodeTier::COPPER && tier < MasternodeTier::INVALID)
   {
-    return CMasternode::GetTierCollateralAmount(static_cast<CMasternode::Tier>(tier));
+    return CMasternode::GetTierCollateralAmount(tier);
   }
   else
   {
@@ -43,31 +42,31 @@ static CAmount getCollateralAmount(int tier)
   }
 }
 
-CAmount CMasternode::GetTierCollateralAmount(CMasternode::Tier tier)
+CAmount CMasternode::GetTierCollateralAmount(MasternodeTier tier)
 {
     switch(tier)
     {
-    case MASTERNODE_TIER_COPPER:   return TIER_COPPER_BASE_COLLATERAL * COIN;
-    case MASTERNODE_TIER_SILVER:   return TIER_SILVER_BASE_COLLATERAL * COIN;
-    case MASTERNODE_TIER_GOLD:     return TIER_GOLD_BASE_COLLATERAL * COIN;
-    case MASTERNODE_TIER_PLATINUM: return TIER_PLATINUM_BASE_COLLATERAL * COIN;
-    case MASTERNODE_TIER_DIAMOND:  return TIER_DIAMOND_BASE_COLLATERAL * COIN;
-    case MASTERNODE_TIER_INVALID: break;
+    case MasternodeTier::COPPER:   return TIER_COPPER_BASE_COLLATERAL * COIN;
+    case MasternodeTier::SILVER:   return TIER_SILVER_BASE_COLLATERAL * COIN;
+    case MasternodeTier::GOLD:     return TIER_GOLD_BASE_COLLATERAL * COIN;
+    case MasternodeTier::PLATINUM: return TIER_PLATINUM_BASE_COLLATERAL * COIN;
+    case MasternodeTier::DIAMOND:  return TIER_DIAMOND_BASE_COLLATERAL * COIN;
+    case MasternodeTier::INVALID: break;
     }
 
     return 0;
 }
 
-static size_t GetHashRoundsForTierMasternodes(CMasternode::Tier tier)
+static size_t GetHashRoundsForTierMasternodes(MasternodeTier tier)
 {
     switch(tier)
     {
-    case CMasternode::MASTERNODE_TIER_COPPER:   return 20;
-    case CMasternode::MASTERNODE_TIER_SILVER:   return 63;
-    case CMasternode::MASTERNODE_TIER_GOLD:     return 220;
-    case CMasternode::MASTERNODE_TIER_PLATINUM: return 690;
-    case CMasternode::MASTERNODE_TIER_DIAMOND:  return 2400;
-    case CMasternode::MASTERNODE_TIER_INVALID: break;
+    case MasternodeTier::COPPER:   return 20;
+    case MasternodeTier::SILVER:   return 63;
+    case MasternodeTier::GOLD:     return 220;
+    case MasternodeTier::PLATINUM: return 690;
+    case MasternodeTier::DIAMOND:  return 2400;
+    case MasternodeTier::INVALID: break;
     }
 
     return 0;
@@ -165,7 +164,7 @@ CMasternode::CMasternode()
     nScanningErrorCount = 0;
     nLastScanningErrorBlockHeight = 0;
     lastTimeChecked = 0;
-    nTier = MASTERNODE_TIER_INVALID;
+    nTier = MasternodeTier::INVALID;
 }
 
 CMasternode::CMasternode(const CMasternode& other)
@@ -338,7 +337,7 @@ uint256 CMasternode::CalculateScore(int mod, int64_t nBlockHeight)
         return 0;
     }
 
-    size_t nHashRounds = GetHashRoundsForTierMasternodes(static_cast<CMasternode::Tier>(nTier));
+    size_t nHashRounds = GetHashRoundsForTierMasternodes(static_cast<MasternodeTier>(nTier));
 
     CHashWriter ss(SER_GETHASH, PROTOCOL_VERSION);
     ss << hash;
@@ -385,52 +384,52 @@ void CMasternode::Check(bool forceCheck)
     activeState = MASTERNODE_ENABLED; // OK
 }
 
-CMasternode::Tier CMasternode::GetTierByCollateralAmount(CAmount nCollateral)
+MasternodeTier CMasternode::GetTierByCollateralAmount(CAmount nCollateral)
 {
     if(TIER_COPPER_BASE_COLLATERAL * COIN == nCollateral) {
-        return MASTERNODE_TIER_COPPER;
+        return MasternodeTier::COPPER;
     }
     else if(TIER_SILVER_BASE_COLLATERAL * COIN == nCollateral) {
-        return MASTERNODE_TIER_SILVER;
+        return MasternodeTier::SILVER;
     }
     else if(TIER_GOLD_BASE_COLLATERAL * COIN == nCollateral) {
-        return MASTERNODE_TIER_GOLD;
+        return MasternodeTier::GOLD;
     }
     else if(TIER_PLATINUM_BASE_COLLATERAL * COIN == nCollateral) {
-        return MASTERNODE_TIER_PLATINUM;
+        return MasternodeTier::PLATINUM;
     }
     else if(TIER_DIAMOND_BASE_COLLATERAL * COIN == nCollateral) {
-        return MASTERNODE_TIER_DIAMOND;
+        return MasternodeTier::DIAMOND;
     }
 
-    return MASTERNODE_TIER_INVALID;
+    return MasternodeTier::INVALID;
 }
 
-bool CMasternode::IsTierValid(CMasternode::Tier tier)
+bool CMasternode::IsTierValid(MasternodeTier tier)
 {
     switch(tier)
     {
-    case MASTERNODE_TIER_COPPER:
-    case MASTERNODE_TIER_SILVER:
-    case MASTERNODE_TIER_GOLD:
-    case MASTERNODE_TIER_PLATINUM:
-    case MASTERNODE_TIER_DIAMOND: return true;
-    case MASTERNODE_TIER_INVALID: break;
+    case MasternodeTier::COPPER:
+    case MasternodeTier::SILVER:
+    case MasternodeTier::GOLD:
+    case MasternodeTier::PLATINUM:
+    case MasternodeTier::DIAMOND: return true;
+    case MasternodeTier::INVALID: break;
     }
 
     return false;
 }
 
-std::string CMasternode::TierToString(CMasternode::Tier tier)
+std::string CMasternode::TierToString(MasternodeTier tier)
 {
     switch(tier)
     {
-    case MASTERNODE_TIER_COPPER: return "COPPER";
-    case MASTERNODE_TIER_SILVER: return "SILVER";
-    case MASTERNODE_TIER_GOLD: return "GOLD";
-    case MASTERNODE_TIER_PLATINUM: return "PLATINUM";
-    case MASTERNODE_TIER_DIAMOND: return "DIAMOND";
-    case MASTERNODE_TIER_INVALID: break;
+    case MasternodeTier::COPPER: return "COPPER";
+    case MasternodeTier::SILVER: return "SILVER";
+    case MasternodeTier::GOLD: return "GOLD";
+    case MasternodeTier::PLATINUM: return "PLATINUM";
+    case MasternodeTier::DIAMOND: return "DIAMOND";
+    case MasternodeTier::INVALID: break;
     }
 
     return "INVALID";
@@ -548,10 +547,10 @@ CMasternodeBroadcast::CMasternodeBroadcast()
     protocolVersion = PROTOCOL_VERSION;
     nScanningErrorCount = 0;
     nLastScanningErrorBlockHeight = 0;
-    nTier = MASTERNODE_TIER_INVALID;
+    nTier = MasternodeTier::INVALID;
 }
 
-CMasternodeBroadcast::CMasternodeBroadcast(CService newAddr, CTxIn newVin, CPubKey pubKeyCollateralAddressNew, CPubKey pubKeyMasternodeNew, Tier nMasternodeTier, int protocolVersionIn)
+CMasternodeBroadcast::CMasternodeBroadcast(CService newAddr, CTxIn newVin, CPubKey pubKeyCollateralAddressNew, CPubKey pubKeyMasternodeNew, const MasternodeTier nMasternodeTier, int protocolVersionIn)
 {
     vin = newVin;
     addr = newAddr;
@@ -643,10 +642,10 @@ bool CMasternodeBroadcastFactory::checkMasternodeCollateral(
     const std::string& txHash,
     const std::string& outputIndex,
     const std::string& service,
-    CMasternode::Tier& nMasternodeTier,
+    MasternodeTier& nMasternodeTier,
     std::string& strErrorRet)
 {
-    nMasternodeTier = CMasternode::Tier::MASTERNODE_TIER_INVALID;
+    nMasternodeTier = MasternodeTier::INVALID;
     auto walletTx = pwalletMain->GetWalletTx(txin.prevout.hash);
     uint256 blockHash;
     CTransaction fundingTx;
@@ -697,7 +696,7 @@ bool CMasternodeBroadcastFactory::createArgumentsFromConfig(
     CTxIn& txin,
     std::pair<CKey,CPubKey>& masternodeKeyPair,
     std::pair<CKey,CPubKey>& masternodeCollateralKeyPair,
-    CMasternode::Tier& nMasternodeTier
+    MasternodeTier& nMasternodeTier
     )
 {
     std::string strService = configEntry.getIp();
@@ -727,7 +726,7 @@ bool CMasternodeBroadcastFactory::Create(const CMasternodeConfig::CMasternodeEnt
     CTxIn txin;
     std::pair<CKey,CPubKey> masternodeCollateralKeyPair;
     std::pair<CKey,CPubKey> masternodeKeyPair;
-    CMasternode::Tier nMasternodeTier;
+    MasternodeTier nMasternodeTier;
 
     if(!createArgumentsFromConfig(
         configEntry,
@@ -775,7 +774,7 @@ bool CMasternodeBroadcastFactory::Create(
     CTxIn txin;
     std::pair<CKey,CPubKey> masternodeCollateralKeyPair;
     std::pair<CKey,CPubKey> masternodeKeyPair;
-    CMasternode::Tier nMasternodeTier;
+    MasternodeTier nMasternodeTier;
 
     if(!createArgumentsFromConfig(
         configEntry,
@@ -855,7 +854,7 @@ void CMasternodeBroadcastFactory::createWithoutSignatures(
     CService service,
     CPubKey pubKeyCollateralAddressNew,
     CPubKey pubKeyMasternodeNew,
-    CMasternode::Tier nMasternodeTier,
+    const MasternodeTier nMasternodeTier,
     bool deferRelay,
     CMasternodeBroadcast& mnbRet)
 {
@@ -875,7 +874,7 @@ bool CMasternodeBroadcastFactory::Create(
     CPubKey pubKeyCollateralAddressNew,
     CKey keyMasternodeNew,
     CPubKey pubKeyMasternodeNew,
-    CMasternode::Tier nMasternodeTier,
+    const MasternodeTier nMasternodeTier,
     std::string& strErrorRet,
     CMasternodeBroadcast& mnbRet,
     bool deferRelay)
@@ -903,8 +902,8 @@ bool CMasternodeBroadcast::CheckAndUpdate(int& nDos)
         return false;
     }
 
-    if(!CMasternode::IsTierValid(static_cast<CMasternode::Tier>(nTier))) {
-        LogPrintf("%s : mnb - Invalid tier: %d\n", __func__, nTier);
+    if(!CMasternode::IsTierValid(static_cast<MasternodeTier>(nTier))) {
+        LogPrintf("%s : mnb - Invalid tier: %d\n", __func__, static_cast<int>(nTier));
         nDos = 20;
         return false;
     }

--- a/divi/src/masternode.cpp
+++ b/divi/src/masternode.cpp
@@ -23,13 +23,6 @@ static std::map<int64_t, uint256> mapCacheBlockHashes;
 extern CChain chainActive;
 
 
-const int TIER_COPPER_BASE_COLLATERAL   = 100000;
-const int TIER_SILVER_BASE_COLLATERAL   = 300000;
-const int TIER_GOLD_BASE_COLLATERAL     = 1000000;
-const int TIER_PLATINUM_BASE_COLLATERAL = 3000000;
-const int TIER_DIAMOND_BASE_COLLATERAL  = 10000000;
-
-
 static CAmount getCollateralAmount(MasternodeTier tier)
 {
   if(tier >= MasternodeTier::COPPER && tier < MasternodeTier::INVALID)
@@ -42,19 +35,13 @@ static CAmount getCollateralAmount(MasternodeTier tier)
   }
 }
 
-CAmount CMasternode::GetTierCollateralAmount(MasternodeTier tier)
+CAmount CMasternode::GetTierCollateralAmount(const MasternodeTier tier)
 {
-    switch(tier)
-    {
-    case MasternodeTier::COPPER:   return TIER_COPPER_BASE_COLLATERAL * COIN;
-    case MasternodeTier::SILVER:   return TIER_SILVER_BASE_COLLATERAL * COIN;
-    case MasternodeTier::GOLD:     return TIER_GOLD_BASE_COLLATERAL * COIN;
-    case MasternodeTier::PLATINUM: return TIER_PLATINUM_BASE_COLLATERAL * COIN;
-    case MasternodeTier::DIAMOND:  return TIER_DIAMOND_BASE_COLLATERAL * COIN;
-    case MasternodeTier::INVALID: break;
-    }
-
-    return 0;
+    const auto& collateralMap = Params().MasternodeCollateralMap();
+    const auto mit = collateralMap.find(tier);
+    if (mit == collateralMap.end())
+        return 0;
+    return mit->second;
 }
 
 static size_t GetHashRoundsForTierMasternodes(MasternodeTier tier)
@@ -384,24 +371,11 @@ void CMasternode::Check(bool forceCheck)
     activeState = MASTERNODE_ENABLED; // OK
 }
 
-MasternodeTier CMasternode::GetTierByCollateralAmount(CAmount nCollateral)
+MasternodeTier CMasternode::GetTierByCollateralAmount(const CAmount nCollateral)
 {
-    if(TIER_COPPER_BASE_COLLATERAL * COIN == nCollateral) {
-        return MasternodeTier::COPPER;
-    }
-    else if(TIER_SILVER_BASE_COLLATERAL * COIN == nCollateral) {
-        return MasternodeTier::SILVER;
-    }
-    else if(TIER_GOLD_BASE_COLLATERAL * COIN == nCollateral) {
-        return MasternodeTier::GOLD;
-    }
-    else if(TIER_PLATINUM_BASE_COLLATERAL * COIN == nCollateral) {
-        return MasternodeTier::PLATINUM;
-    }
-    else if(TIER_DIAMOND_BASE_COLLATERAL * COIN == nCollateral) {
-        return MasternodeTier::DIAMOND;
-    }
-
+    for (const auto& entry : Params().MasternodeCollateralMap())
+        if (entry.second == nCollateral)
+            return entry.first;
     return MasternodeTier::INVALID;
 }
 

--- a/divi/src/masternode.h
+++ b/divi/src/masternode.h
@@ -14,6 +14,7 @@
 
 
 #include "masternodeconfig.h"
+#include "masternode-tier.h"
 
 #define MASTERNODE_MIN_CONFIRMATIONS 15
 #define MASTERNODE_MIN_MNP_SECONDS (10 * 60)
@@ -125,15 +126,6 @@ public:
         MASTERNODE_POS_ERROR
     };
 
-    enum Tier {
-        MASTERNODE_TIER_COPPER,
-        MASTERNODE_TIER_SILVER,
-        MASTERNODE_TIER_GOLD,
-        MASTERNODE_TIER_PLATINUM,
-        MASTERNODE_TIER_DIAMOND,
-        MASTERNODE_TIER_INVALID
-    };
-
     CTxIn vin;
     CService addr;
     CPubKey pubKeyCollateralAddress;
@@ -149,7 +141,7 @@ public:
     int nActiveState;
     int nScanningErrorCount;
     int nLastScanningErrorBlockHeight;
-    int nTier;
+    MasternodeTier nTier;
     CMasternodePing lastPing;
 
     CMasternode();
@@ -194,7 +186,13 @@ public:
         READWRITE(allowFreeTx);
         READWRITE(nScanningErrorCount);
         READWRITE(nLastScanningErrorBlockHeight);
-        READWRITE(nTier);
+
+        int tier;
+        if (!ser_action.ForRead ())
+            tier = static_cast<int> (nTier);
+        READWRITE(tier);
+        if (ser_action.ForRead ())
+            nTier = static_cast<MasternodeTier> (tier);
     }
 
     int64_t SecondsSincePayment();
@@ -213,10 +211,10 @@ public:
 
     int GetMasternodeInputAge();
 
-    static CAmount GetTierCollateralAmount(Tier tier);
-    static Tier GetTierByCollateralAmount(CAmount nCollateral);
-    static bool IsTierValid(Tier tier);
-    static std::string TierToString(Tier tier);
+    static CAmount GetTierCollateralAmount(MasternodeTier tier);
+    static MasternodeTier GetTierByCollateralAmount(CAmount nCollateral);
+    static bool IsTierValid(MasternodeTier tier);
+    static std::string TierToString(MasternodeTier tier);
 
     std::string GetStatus();
 
@@ -240,7 +238,7 @@ public:
         CTxIn newVin,
         CPubKey pubKeyCollateralAddress,
         CPubKey pubKeyMasternode,
-        Tier nMasternodeTier,
+        MasternodeTier nMasternodeTier,
         int protocolVersionIn);
     CMasternodeBroadcast(const CMasternode& mn);
 
@@ -263,7 +261,13 @@ public:
         READWRITE(sigTime);
         READWRITE(protocolVersion);
         READWRITE(lastPing);
-        READWRITE(nTier);
+
+        int tier;
+        if (!ser_action.ForRead ())
+            tier = static_cast<int> (nTier);
+        READWRITE(tier);
+        if (ser_action.ForRead ())
+            nTier = static_cast<MasternodeTier> (tier);
     }
 
     uint256 GetHash() const
@@ -297,7 +301,7 @@ private:
         CService service,
         CPubKey pubKeyCollateralAddressNew,
         CPubKey pubKeyMasternodeNew,
-        CMasternode::Tier nMasternodeTier,
+        MasternodeTier nMasternodeTier,
         bool deferRelay,
         CMasternodeBroadcast& mnbRet);
 
@@ -325,7 +329,7 @@ private:
                         CPubKey pubKeyCollateralAddressNew,
                         CKey keyMasternodeNew,
                         CPubKey pubKeyMasternodeNew,
-                        CMasternode::Tier nMasternodeTier,
+                        MasternodeTier nMasternodeTier,
                         std::string& strErrorRet,
                         CMasternodeBroadcast& mnbRet,
                         bool deferRelay);
@@ -347,7 +351,7 @@ private:
         const std::string& txHash,
         const std::string& outputIndex,
         const std::string& service,
-        CMasternode::Tier& nMasternodeTier,
+        MasternodeTier& nMasternodeTier,
         std::string& strErrorRet);
     static bool checkNetworkPort(
         const std::string& strService,
@@ -360,7 +364,7 @@ private:
         CTxIn& txin,
         std::pair<CKey,CPubKey>& masternodeKeyPair,
         std::pair<CKey,CPubKey>& masternodeCollateralKeyPair,
-        CMasternode::Tier& nMasternodeTier);
+        MasternodeTier& nMasternodeTier);
 };
 
 #endif

--- a/divi/src/masternodeman.cpp
+++ b/divi/src/masternodeman.cpp
@@ -593,7 +593,7 @@ void CMasternodeMan::ProcessMessage(CNode* pfrom, std::string& strCommand, CData
 
         // make sure the vout that was signed is related to the transaction that spawned the Masternode
         //  - this is expensive, so it's only done once per Masternode
-        if (!CObfuScationSigner::IsVinAssociatedWithPubkey(mnb.vin, mnb.pubKeyCollateralAddress, static_cast<CMasternode::Tier>(mnb.nTier))) {
+        if (!CObfuScationSigner::IsVinAssociatedWithPubkey(mnb.vin, mnb.pubKeyCollateralAddress, static_cast<MasternodeTier>(mnb.nTier))) {
             LogPrintf("%s : mnb - Got mismatched pubkey and vin\n", __func__);
             Misbehaving(pfrom->GetId(), 33);
             return;

--- a/divi/src/obfuscation.cpp
+++ b/divi/src/obfuscation.cpp
@@ -25,7 +25,7 @@
 
 extern const std::string strMessageMagic = "DarkNet Signed Message:\n";
 
-bool CObfuScationSigner::IsVinAssociatedWithPubkey(CTxIn& vin, CPubKey& pubkey, CMasternode::Tier nMasternodeTier)
+bool CObfuScationSigner::IsVinAssociatedWithPubkey(CTxIn& vin, CPubKey& pubkey, MasternodeTier nMasternodeTier)
 {
     CScript payee2;
     payee2 = GetScriptForDestination(pubkey.GetID());

--- a/divi/src/obfuscation.h
+++ b/divi/src/obfuscation.h
@@ -40,7 +40,7 @@ extern std::string strMasterNodePrivKey;
 struct CObfuScationSigner
 {
     /// Is the inputs associated with this public key? (and there is 10000 PIV - checking if valid masternode)
-    static bool IsVinAssociatedWithPubkey(CTxIn& vin, CPubKey& pubkey, CMasternode::Tier nMasternodeTier);
+    static bool IsVinAssociatedWithPubkey(CTxIn& vin, CPubKey& pubkey, MasternodeTier nMasternodeTier);
     /// Set the private/public key values, returns true if successful
     static bool GetKeysFromSecret(std::string strSecret, CKey& keyRet, CPubKey& pubkeyRet);
     /// Set the private/public key values, returns true if successful

--- a/divi/src/rpcmasternode.cpp
+++ b/divi/src/rpcmasternode.cpp
@@ -31,27 +31,27 @@ static T readFromHex(std::string hexString)
     return object;
 }
 
-static CMasternode::Tier GetMasternodeTierFromString(std::string str)
+static MasternodeTier GetMasternodeTierFromString(std::string str)
 {
     boost::algorithm::to_lower(str); // modifies str
 
     if(str == "copper") {
-        return CMasternode::MASTERNODE_TIER_COPPER;
+        return MasternodeTier::COPPER;
     }
     else if(str == "silver") {
-        return CMasternode::MASTERNODE_TIER_SILVER;
+        return MasternodeTier::SILVER;
     }
     else if(str == "gold") {
-        return CMasternode::MASTERNODE_TIER_GOLD;
+        return MasternodeTier::GOLD;
     }
     else if(str == "platinum") {
-        return CMasternode::MASTERNODE_TIER_PLATINUM;
+        return MasternodeTier::PLATINUM;
     }
     else if(str == "diamond") {
-        return CMasternode::MASTERNODE_TIER_DIAMOND;
+        return MasternodeTier::DIAMOND;
     }
 
-    return CMasternode::MASTERNODE_TIER_INVALID;
+    return MasternodeTier::INVALID;
 }
 
 Value debug(const Array& params, bool fHelp)
@@ -366,7 +366,7 @@ Value listmasternodes(const Array& params, bool fHelp)
             obj.push_back(Pair("lastseen", (int64_t)mn->lastPing.sigTime));
             obj.push_back(Pair("activetime", (int64_t)(mn->lastPing.sigTime - mn->sigTime)));
             obj.push_back(Pair("lastpaid", (int64_t)mn->GetLastPaid()));
-            obj.push_back(Pair("tier", CMasternode::TierToString(static_cast<CMasternode::Tier>(mn->nTier))));
+            obj.push_back(Pair("tier", CMasternode::TierToString(static_cast<MasternodeTier>(mn->nTier))));
 
             ret.push_back(obj);
         }


### PR DESCRIPTION
This adds a new regtest `mncollateral.py`, which verifies basic RPCs and behaviour related to masternode collateral (`allocatefunds`, `fundmasternode` and the locking of outputs from `masternode.conf`).

To make testing masternodes on regtest viable, this also reduces the collateral amounts on regtest by a factor of 1'000 (so that we do not have to mine hundreds of blocks to get enough coins).