### PR TITLE
Various cleanups in the masternode code

### DIFF
--- a/divi/src/main.cpp
+++ b/divi/src/main.cpp
@@ -4280,7 +4280,7 @@ bool static AlreadyHave(const CInv& inv)
     case MSG_SPORK:
         return mapSporks.count(inv.hash);
     case MSG_MASTERNODE_WINNER:
-        if (masternodePayments.mapMasternodePayeeVotes.count(inv.hash)) {
+        if (masternodePayments.GetPaymentWinnerForHash(inv.hash) != nullptr) {
             masternodeSync.AddedMasternodeWinner(inv.hash);
             return true;
         }
@@ -4424,10 +4424,11 @@ void static ProcessGetData(CNode* pfrom)
                     }
                 }
                 if (!pushed && inv.type == MSG_MASTERNODE_WINNER) {
-                    if (masternodePayments.mapMasternodePayeeVotes.count(inv.hash)) {
+                    const auto* winner = masternodePayments.GetPaymentWinnerForHash(inv.hash);
+                    if (winner != nullptr) {
                         CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
                         ss.reserve(1000);
-                        ss << masternodePayments.mapMasternodePayeeVotes[inv.hash];
+                        ss << *winner;
                         pfrom->PushMessage("mnw", ss);
                         pushed = true;
                     }

--- a/divi/src/masternode-payments.cpp
+++ b/divi/src/masternode-payments.cpp
@@ -293,7 +293,7 @@ void CMasternodePayments::FillBlockPayee(CMutableTransaction& txNew, const CBloc
     CScript payee;
 
     //spork
-    if (!masternodePayments.GetBlockPayee(pindexPrev->nHeight + 1, payee)) {
+    if (!GetBlockPayee(pindexPrev->nHeight + 1, payee)) {
         //no masternode detected
         CMasternode* winningNode = mnodeman.GetCurrentMasterNode(1);
         if (winningNode) {
@@ -343,7 +343,7 @@ void CMasternodePayments::ProcessMessageMasternodePayments(CNode* pfrom, const s
         }
 
         netfulfilledman.AddFulfilledRequest(pfrom->addr, "mnget");
-        masternodePayments.Sync(pfrom, nCountNeeded);
+        Sync(pfrom, nCountNeeded);
         LogPrint("mnpayments", "mnget - Sent Masternode winners to peer %i\n", pfrom->GetId());
     } else if (strCommand == "mnw") { //Masternode Payments Declare Winner
         //this is required in litemodef
@@ -359,7 +359,7 @@ void CMasternodePayments::ProcessMessageMasternodePayments(CNode* pfrom, const s
             nHeight = chainActive.Tip()->nHeight;
         }
 
-        if (masternodePayments.GetPaymentWinnerForHash(winner.GetHash()) != nullptr) {
+        if (GetPaymentWinnerForHash(winner.GetHash()) != nullptr) {
             LogPrint("mnpayments", "mnw - Already seen - %s bestHeight %d\n", winner.GetHash().ToString().c_str(), nHeight);
             masternodeSync.AddedMasternodeWinner(winner.GetHash());
             return;
@@ -377,7 +377,7 @@ void CMasternodePayments::ProcessMessageMasternodePayments(CNode* pfrom, const s
             return;
         }
 
-        if (!masternodePayments.CanVote(winner.vinMasternode.prevout, winner.nBlockHeight)) {
+        if (!CanVote(winner.vinMasternode.prevout, winner.nBlockHeight)) {
             //  LogPrint("masternode","mnw - masternode already voted - %s\n", winner.vinMasternode.prevout.ToStringShort());
             return;
         }
@@ -396,7 +396,7 @@ void CMasternodePayments::ProcessMessageMasternodePayments(CNode* pfrom, const s
 
         //   LogPrint("mnpayments", "mnw - winning vote - Addr %s Height %d bestHeight %d - %s\n", address2.ToString().c_str(), winner.nBlockHeight, nHeight, winner.vinMasternode.prevout.ToStringShort());
 
-        if (masternodePayments.AddWinningMasternode(winner)) {
+        if (AddWinningMasternode(winner)) {
             winner.Relay();
             masternodeSync.AddedMasternodeWinner(winner.GetHash());
         }

--- a/divi/src/masternode-payments.h
+++ b/divi/src/masternode-payments.h
@@ -31,7 +31,7 @@ public:
     int nVotes;
 
     CMasternodePayee();
-    CMasternodePayee(CScript payee, int nVotesIn);
+    CMasternodePayee(const CScript& payee, int nVotesIn);
 
     ADD_SERIALIZE_METHODS;
 
@@ -47,7 +47,7 @@ public:
 class CMasternodeBlockPayees
 {
 private:
-    CCriticalSection cs_vecPayments;
+    mutable CCriticalSection cs_vecPayments;
 
 public:
     int nBlockHeight;
@@ -63,13 +63,13 @@ public:
       : nBlockHeight(o.nBlockHeight), vecPayments(std::move(o.vecPayments))
     {}
 
-    void AddPayee(CScript payeeIn, int nIncrement);
+    void AddPayee(const CScript& payeeIn, int nIncrement);
 
-    bool GetPayee(CScript& payee);
-    bool HasPayeeWithVotes(CScript payee, int nVotesReq);
+    bool GetPayee(CScript& payee) const;
+    bool HasPayeeWithVotes(const CScript& payee, int nVotesReq) const;
 
-    bool IsTransactionValid(const CTransaction& txNew);
-    std::string GetRequiredPaymentsString();
+    bool IsTransactionValid(const CTransaction& txNew) const;
+    std::string GetRequiredPaymentsString() const;
 
     ADD_SERIALIZE_METHODS;
 
@@ -92,16 +92,16 @@ public:
     std::vector<unsigned char> vchSig;
 
     CMasternodePaymentWinner();
-    CMasternodePaymentWinner(CTxIn vinIn);
+    CMasternodePaymentWinner(const CTxIn& vinIn);
 
     uint256 GetHash() const;
 
-    bool Sign(CKey& keyMasternode, CPubKey& pubKeyMasternode);
-    bool IsValid(CNode* pnode, std::string& strError);
-    bool SignatureValid();
-    void Relay();
+    bool Sign(const CKey& keyMasternode, const CPubKey& pubKeyMasternode);
+    bool IsValid(CNode* pnode, std::string& strError) const;
+    bool SignatureValid() const;
+    void Relay() const;
 
-    void AddPayee(CScript payeeIn);
+    void AddPayee(const CScript& payeeIn);
 
     ADD_SERIALIZE_METHODS;
 
@@ -114,7 +114,7 @@ public:
         READWRITE(vchSig);
     }
 
-    std::string ToString();
+    std::string ToString() const;
 };
 
 //
@@ -132,8 +132,8 @@ private:
     std::map<int, CMasternodeBlockPayees> mapMasternodeBlocks;
     std::map<uint256, int> mapMasternodesLastVote; //prevout.hash + prevout.n, nBlockHeight
 
-    CCriticalSection cs_mapMasternodeBlocks;
-    CCriticalSection cs_mapMasternodePayeeVotes;
+    mutable CCriticalSection cs_mapMasternodeBlocks;
+    mutable CCriticalSection cs_mapMasternodePayeeVotes;
 
 public:
 
@@ -146,18 +146,17 @@ public:
 
     void Sync(CNode* node, int nCountNeeded);
     void CheckAndRemove();
-    int LastPayment(CMasternode& mn);
 
-    bool GetBlockPayee(int nBlockHeight, CScript& payee);
-    bool IsTransactionValid(const CTransaction& txNew, int nBlockHeight);
-    bool IsScheduled(CMasternode& mn, int nNotBlockHeight);
+    bool GetBlockPayee(int nBlockHeight, CScript& payee) const;
+    bool IsTransactionValid(const CTransaction& txNew, int nBlockHeight) const;
+    bool IsScheduled(const CMasternode& mn, int nNotBlockHeight) const;
 
-    bool CanVote(COutPoint outMasternode, int nBlockHeight);
+    bool CanVote(const COutPoint& outMasternode, int nBlockHeight);
 
-    int GetMinMasternodePaymentsProto();
-    void ProcessMessageMasternodePayments(CNode* pfrom, std::string& strCommand, CDataStream& vRecv);
-    std::string GetRequiredPaymentsString(int nBlockHeight);
-    void FillBlockPayee(CMutableTransaction& txNew, const CBlockRewards &rewards, bool fProofOfStake);
+    int GetMinMasternodePaymentsProto() const;
+    void ProcessMessageMasternodePayments(CNode* pfrom, const std::string& strCommand, CDataStream& vRecv);
+    std::string GetRequiredPaymentsString(int nBlockHeight) const;
+    void FillBlockPayee(CMutableTransaction& txNew, const CBlockRewards &rewards, bool fProofOfStake) const;
     std::string ToString() const;
 
     /** Retrieves the payment winner for the given hash.  Returns null

--- a/divi/src/masternode-payments.h
+++ b/divi/src/masternode-payments.h
@@ -128,13 +128,14 @@ private:
     int nSyncedFromPeer;
     int nLastBlockHeight;
 
+    std::map<uint256, CMasternodePaymentWinner> mapMasternodePayeeVotes;
+    std::map<int, CMasternodeBlockPayees> mapMasternodeBlocks;
+    std::map<uint256, int> mapMasternodesLastVote; //prevout.hash + prevout.n, nBlockHeight
+
     CCriticalSection cs_mapMasternodeBlocks;
     CCriticalSection cs_mapMasternodePayeeVotes;
 
 public:
-    std::map<uint256, CMasternodePaymentWinner> mapMasternodePayeeVotes;
-    std::map<int, CMasternodeBlockPayees> mapMasternodeBlocks;
-    std::map<uint256, int> mapMasternodesLastVote; //prevout.hash + prevout.n, nBlockHeight
 
     CMasternodePayments();
 
@@ -158,6 +159,30 @@ public:
     std::string GetRequiredPaymentsString(int nBlockHeight);
     void FillBlockPayee(CMutableTransaction& txNew, const CBlockRewards &rewards, bool fProofOfStake);
     std::string ToString() const;
+
+    /** Retrieves the payment winner for the given hash.  Returns null
+     *  if there is no entry for that hash.  */
+    const CMasternodePaymentWinner* GetPaymentWinnerForHash(const uint256& hash) const {
+        return const_cast<CMasternodePayments*>(this)->GetPaymentWinnerForHash(hash);
+    }
+    CMasternodePaymentWinner* GetPaymentWinnerForHash(const uint256& hash) {
+        const auto mit = mapMasternodePayeeVotes.find(hash);
+        if (mit == mapMasternodePayeeVotes.end())
+            return nullptr;
+        return &mit->second;
+    }
+
+    /** Retrieves the payees for the given block.  Returns null if there is
+     *  no matching entry.  */
+    const CMasternodeBlockPayees* GetPayeesForHeight(const unsigned height) const {
+        return const_cast<CMasternodePayments*>(this)->GetPayeesForHeight(height);
+    }
+    CMasternodeBlockPayees* GetPayeesForHeight(const unsigned height) {
+        const auto mit = mapMasternodeBlocks.find(height);
+        if (mit == mapMasternodeBlocks.end())
+            return nullptr;
+        return &mit->second;
+    }
 
     ADD_SERIALIZE_METHODS;
 

--- a/divi/src/masternode-payments.h
+++ b/divi/src/masternode-payments.h
@@ -18,9 +18,6 @@ class CMasternodePayments;
 class CMasternodePaymentWinner;
 class CMasternodeBlockPayees;
 
-extern CCriticalSection cs_vecPayments;
-extern CCriticalSection cs_mapMasternodeBlocks;
-extern CCriticalSection cs_mapMasternodePayeeVotes;
 extern CMasternodePayments masternodePayments;
 
 bool IsBlockPayeeValid(const CTransaction &txNew, int nBlockHeight, CBlockIndex *prevIndex);
@@ -49,12 +46,22 @@ public:
 // Keep track of votes for payees from masternodes
 class CMasternodeBlockPayees
 {
+private:
+    CCriticalSection cs_vecPayments;
+
 public:
     int nBlockHeight;
     std::vector<CMasternodePayee> vecPayments;
 
     CMasternodeBlockPayees();
     CMasternodeBlockPayees(int nBlockHeightIn);
+
+    CMasternodeBlockPayees(const CMasternodeBlockPayees& o)
+      : nBlockHeight(o.nBlockHeight), vecPayments(o.vecPayments)
+    {}
+    CMasternodeBlockPayees(CMasternodeBlockPayees&& o)
+      : nBlockHeight(o.nBlockHeight), vecPayments(std::move(o.vecPayments))
+    {}
 
     void AddPayee(CScript payeeIn, int nIncrement);
 
@@ -120,6 +127,9 @@ class CMasternodePayments
 private:
     int nSyncedFromPeer;
     int nLastBlockHeight;
+
+    CCriticalSection cs_mapMasternodeBlocks;
+    CCriticalSection cs_mapMasternodePayeeVotes;
 
 public:
     std::map<uint256, CMasternodePaymentWinner> mapMasternodePayeeVotes;

--- a/divi/src/masternode-sync.cpp
+++ b/divi/src/masternode-sync.cpp
@@ -80,7 +80,7 @@ void CMasternodeSync::Reset()
     nAssetSyncStarted = GetTime();
 }
 
-void CMasternodeSync::AddedMasternodeList(uint256 hash)
+void CMasternodeSync::AddedMasternodeList(const uint256& hash)
 {
     if (mnodeman.mapSeenMasternodeBroadcast.count(hash)) {
         if (mapSeenSyncMNB[hash] < MASTERNODE_SYNC_THRESHOLD) {
@@ -93,9 +93,9 @@ void CMasternodeSync::AddedMasternodeList(uint256 hash)
     }
 }
 
-void CMasternodeSync::AddedMasternodeWinner(uint256 hash)
+void CMasternodeSync::AddedMasternodeWinner(const uint256& hash)
 {
-    if (masternodePayments.mapMasternodePayeeVotes.count(hash)) {
+    if (masternodePayments.GetPaymentWinnerForHash(hash) != nullptr) {
         if (mapSeenSyncMNW[hash] < MASTERNODE_SYNC_THRESHOLD) {
             lastMasternodeWinner = GetTime();
             mapSeenSyncMNW[hash]++;

--- a/divi/src/masternode-sync.h
+++ b/divi/src/masternode-sync.h
@@ -52,8 +52,8 @@ public:
 
     CMasternodeSync();
 
-    void AddedMasternodeList(uint256 hash);
-    void AddedMasternodeWinner(uint256 hash);
+    void AddedMasternodeList(const uint256& hash);
+    void AddedMasternodeWinner(const uint256& hash);
     void GetNextAsset();
     std::string GetSyncStatus();
     void ProcessMessage(CNode* pfrom, std::string& strCommand, CDataStream& vRecv);

--- a/divi/src/masternode.cpp
+++ b/divi/src/masternode.cpp
@@ -455,12 +455,13 @@ int64_t CMasternode::GetLastPaid()
         }
         n++;
 
-        if (masternodePayments.mapMasternodeBlocks.count(BlockReading->nHeight)) {
+        auto* masternodePayees = masternodePayments.GetPayeesForHeight(BlockReading->nHeight);
+        if (masternodePayees != nullptr) {
             /*
                 Search for this payee, with at least 2 votes. This will aid in consensus allowing the network
                 to converge on the same payees quickly, then keep the same schedule.
             */
-            if (masternodePayments.mapMasternodeBlocks[BlockReading->nHeight].HasPayeeWithVotes(mnpayee, 2)) {
+            if (masternodePayees->HasPayeeWithVotes(mnpayee, 2)) {
                 return BlockReading->nTime + nOffset;
             }
         }

--- a/divi/src/masternode.cpp
+++ b/divi/src/masternode.cpp
@@ -249,7 +249,7 @@ void CMasternode::Disable()
     lastPing = CMasternodePing();
 }
 
-bool CMasternode::IsEnabled()
+bool CMasternode::IsEnabled() const
 {
     return activeState == MASTERNODE_ENABLED;
 }

--- a/divi/src/masternode.h
+++ b/divi/src/masternode.h
@@ -207,7 +207,7 @@ public:
 
     void Disable();
 
-    bool IsEnabled();
+    bool IsEnabled() const;
 
     int GetMasternodeInputAge();
 

--- a/divi/src/masternodeman.cpp
+++ b/divi/src/masternodeman.cpp
@@ -51,7 +51,7 @@ CMasternodeMan::CMasternodeMan()
     nDsqCount = 0;
 }
 
-bool CMasternodeMan::Add(CMasternode& mn)
+bool CMasternodeMan::Add(const CMasternode& mn)
 {
     LOCK(cs);
 
@@ -68,7 +68,7 @@ bool CMasternodeMan::Add(CMasternode& mn)
     return false;
 }
 
-void CMasternodeMan::AskForMN(CNode* pnode, CTxIn& vin)
+void CMasternodeMan::AskForMN(CNode* pnode, const CTxIn& vin)
 {
     std::map<COutPoint, int64_t>::iterator i = mWeAskedForMasternodeListEntry.find(vin.prevout);
     if (i != mWeAskedForMasternodeListEntry.end()) {
@@ -208,7 +208,7 @@ int CMasternodeMan::stable_size ()
     int64_t nMasternode_Min_Age = MN_WINNER_MINIMUM_AGE;
     int64_t nMasternode_Age = 0;
 
-    BOOST_FOREACH (CMasternode& mn, vMasternodes) {
+    for (auto& mn : vMasternodes) {
         if (mn.protocolVersion < nMinProtocol) {
             continue; // Skip obsolete versions
         }
@@ -228,12 +228,12 @@ int CMasternodeMan::stable_size ()
     return nStable_size;
 }
 
-int CMasternodeMan::CountEnabled(int protocolVersion)
+int CMasternodeMan::CountEnabled(int protocolVersion) const
 {
     int i = 0;
     protocolVersion = protocolVersion == -1 ? masternodePayments.GetMinMasternodePaymentsProto() : protocolVersion;
 
-    BOOST_FOREACH (CMasternode& mn, vMasternodes) {
+    for (const auto& mn : vMasternodes) {
         if (mn.protocolVersion < protocolVersion || !mn.IsEnabled()) continue;
         i++;
     }
@@ -449,7 +449,7 @@ int CMasternodeMan::GetMasternodeRank(const CTxIn& vin, int64_t nBlockHeight, in
     if (!GetBlockHash(hash, nBlockHeight)) return rankForNodesNotFound;
 
     // scan for winner
-    BOOST_FOREACH (CMasternode& mn, vMasternodes) {
+    for (auto& mn : vMasternodes) {
         if (mn.protocolVersion < minProtocol) {
             LogPrint("masternode","Skipping Masternode with obsolete version %d\n", mn.protocolVersion);
             continue;                                                       // Skip obsolete versions
@@ -475,9 +475,9 @@ int CMasternodeMan::GetMasternodeRank(const CTxIn& vin, int64_t nBlockHeight, in
     sort(vecMasternodeScores.rbegin(), vecMasternodeScores.rend(), CompareScoreTxIn());
 
     int rank = 0;
-    BOOST_FOREACH (PAIRTYPE(int64_t, CTxIn) & s, vecMasternodeScores) {
+    for (const auto& entry : vecMasternodeScores) {
         rank++;
-        if (s.second.prevout == vin.prevout) {
+        if (entry.second.prevout == vin.prevout) {
             return rank;
         }
     }
@@ -499,7 +499,7 @@ std::vector<std::pair<int, CMasternode> > CMasternodeMan::GetMasternodeRanks(int
 
     // scan for winner
     std::vector<std::pair<int64_t, CMasternode> > vecDisabledMasternodeScores;
-    BOOST_FOREACH (CMasternode& mn, vMasternodes) {
+    for (auto& mn : vMasternodes) {
         mn.Check();
 
         if (mn.protocolVersion < minProtocol) continue;
@@ -519,9 +519,9 @@ std::vector<std::pair<int, CMasternode> > CMasternodeMan::GetMasternodeRanks(int
     vecMasternodeScores.insert(vecMasternodeScores.end(),vecDisabledMasternodeScores.begin(),vecDisabledMasternodeScores.end());
 
     int rank = 0;
-    BOOST_FOREACH (PAIRTYPE(int64_t, CMasternode) & s, vecMasternodeScores) {
+    for (const auto& entry : vecMasternodeScores) {
         rank++;
-        vecMasternodeRanks.push_back(std::make_pair(rank, s.second));
+        vecMasternodeRanks.push_back(std::make_pair(rank, entry.second));
     }
 
     return vecMasternodeRanks;
@@ -548,10 +548,10 @@ CMasternode* CMasternodeMan::GetMasternodeByRank(int nRank, int64_t nBlockHeight
     sort(vecMasternodeScores.rbegin(), vecMasternodeScores.rend(), CompareScoreTxIn());
 
     int rank = 0;
-    BOOST_FOREACH (PAIRTYPE(int64_t, CTxIn) & s, vecMasternodeScores) {
+    for (const auto& entry : vecMasternodeScores) {
         rank++;
         if (rank == nRank) {
-            return Find(s.second);
+            return Find(entry.second);
         }
     }
 
@@ -695,7 +695,7 @@ void CMasternodeMan::ProcessMessage(CNode* pfrom, std::string& strCommand, CData
     }
 }
 
-void CMasternodeMan::Remove(CTxIn vin)
+void CMasternodeMan::Remove(const CTxIn& vin)
 {
     LOCK(cs);
 

--- a/divi/src/masternodeman.h
+++ b/divi/src/masternodeman.h
@@ -62,13 +62,13 @@ public:
     }
 
     CMasternodeMan();
-    CMasternodeMan(CMasternodeMan& other);
+    CMasternodeMan(const CMasternodeMan& other);
 
     /// Add an entry
-    bool Add(CMasternode& mn);
+    bool Add(const CMasternode& mn);
 
     /// Ask (source) node for mnb
-    void AskForMN(CNode* pnode, CTxIn& vin);
+    void AskForMN(CNode* pnode, const CTxIn& vin);
 
     /// Check all Masternodes
     void Check();
@@ -80,7 +80,7 @@ public:
     /// Clear Masternode vector
     void Clear();
 
-    int CountEnabled(int protocolVersion = -1);
+    int CountEnabled(int protocolVersion = -1) const;
 
     void CountNetworks(int protocolVersion, int& ipv4, int& ipv6, int& onion);
 
@@ -115,14 +115,14 @@ public:
     void ProcessMessage(CNode* pfrom, std::string& strCommand, CDataStream& vRecv);
 
     /// Return the number of (unique) Masternodes
-    int size() { return vMasternodes.size(); }
+    int size() const { return vMasternodes.size(); }
 
     /// Return the number of Masternodes older than (default) 8000 seconds
     int stable_size ();
 
     std::string ToString() const;
 
-    void Remove(CTxIn vin);
+    void Remove(const CTxIn& vin);
 
     /// Update masternode list and maps using provided CMasternodeBroadcast
     void UpdateMasternodeList(CMasternodeBroadcast mnb);


### PR DESCRIPTION
This is a collection of general clean-ups in the masternode code, without touching any functionality.  Some declarations are removed from headers when they are only needed internally in the source file, some globals are moved into classes, and a lot of functions are declared `const` that should be.