### PR TITLE
Avoid ambiguous block heights as much as possible in masternode code

### DIFF
--- a/divi/src/main.cpp
+++ b/divi/src/main.cpp
@@ -2094,7 +2094,7 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
                          REJECT_INVALID, "bad-cb-amount");
     }
 
-    if (!IsBlockPayeeValid(coinbaseTx, pindex->nHeight, pindex->pprev)) {
+    if (!IsBlockPayeeValid(coinbaseTx, pindex)) {
         mapRejectedBlocks.insert(std::make_pair(block.GetHash(), GetTime()));
         return state.DoS(0, error("ConnectBlock(): couldn't find masternode or superblock payments"),
                          REJECT_INVALID, "bad-cb-payee");

--- a/divi/src/masternode-payments.cpp
+++ b/divi/src/masternode-payments.cpp
@@ -639,7 +639,14 @@ bool CMasternodePaymentWinner::IsValid(CNode* pnode, std::string& strError) cons
         return false;
     }
 
-    const unsigned n = mnodeman.GetMasternodeRank(vinMasternode, nBlockHeight, ActiveProtocol(), 2 * MNPAYMENTS_SIGNATURES_TOTAL);
+    uint256 seedHash;
+    if (!GetBlockHashForScoring(seedHash, nBlockHeight)) {
+        strError = strprintf("Failed to get scoring hash for height %d", nBlockHeight);
+        LogPrint("masternode", "CMasternodePaymentWinner::IsValid - %s\n", strError);
+        return false;
+    }
+
+    const unsigned n = mnodeman.GetMasternodeRank(vinMasternode, seedHash, ActiveProtocol(), 2 * MNPAYMENTS_SIGNATURES_TOTAL);
 
     if (n > MNPAYMENTS_SIGNATURES_TOTAL) {
         //It's common to have masternodes mistakenly think they are in the top 10
@@ -672,7 +679,13 @@ bool CMasternodePayments::ProcessBlock(int nBlockHeight)
 
     //reference node - hybrid mode
 
-    const unsigned n = mnodeman.GetMasternodeRank(activeMasternode.vin, nBlockHeight, ActiveProtocol(), MNPAYMENTS_SIGNATURES_TOTAL);
+    uint256 seedHash;
+    if (!GetBlockHashForScoring(seedHash, nBlockHeight)) {
+        LogPrint("mnpayments", "CMasternodePayments::ProcessBlock - failed to look up seed hash for height %d\n", nBlockHeight);
+        return false;
+    }
+
+    const unsigned n = mnodeman.GetMasternodeRank(activeMasternode.vin, seedHash, ActiveProtocol(), MNPAYMENTS_SIGNATURES_TOTAL);
 
     if (n == static_cast<unsigned>(-1)) {
         LogPrint("mnpayments", "CMasternodePayments::ProcessBlock - Unknown Masternode\n");

--- a/divi/src/masternode-payments.cpp
+++ b/divi/src/masternode-payments.cpp
@@ -297,7 +297,7 @@ void CMasternodePayments::FillBlockPayee(CMutableTransaction& txNew, const CBloc
     //spork
     if (!GetBlockPayee(pindexPrev->nHeight + 1, payee)) {
         //no masternode detected
-        CMasternode* winningNode = mnodeman.GetCurrentMasterNode(1);
+        CMasternode* winningNode = mnodeman.GetCurrentMasterNode(0, 0);
         if (winningNode) {
             payee = GetScriptForDestination(winningNode->pubKeyCollateralAddress.GetID());
         } else {

--- a/divi/src/masternode-payments.cpp
+++ b/divi/src/masternode-payments.cpp
@@ -120,16 +120,16 @@ bool IsValidTreasuryPayment(const CTransaction &tx, int nHeight)
 
 } // anonymous namespace
 
-bool IsBlockPayeeValid(const CTransaction &txNew, int nBlockHeight, CBlockIndex *prevIndex)
+bool IsBlockPayeeValid(const CTransaction &txNew, const CBlockIndex* pindex)
 {
     SuperblockSubsidyContainer superblockSubsidies(Params());
     const I_SuperblockHeightValidator& heightValidator = superblockSubsidies.superblockHeightValidator();
-    if(heightValidator.IsValidTreasuryBlockHeight(nBlockHeight)) {
-        return IsValidTreasuryPayment(txNew, nBlockHeight);
+    if(heightValidator.IsValidTreasuryBlockHeight(pindex->nHeight)) {
+        return IsValidTreasuryPayment(txNew, pindex->nHeight);
     }
 
-    if(heightValidator.IsValidLotteryBlockHeight(nBlockHeight)) {
-        return IsValidLotteryPayment(txNew, nBlockHeight, prevIndex->vLotteryWinnersCoinstakes.getLotteryCoinstakes());
+    if(heightValidator.IsValidLotteryBlockHeight(pindex->nHeight)) {
+        return IsValidLotteryPayment(txNew, pindex->nHeight, pindex->pprev->vLotteryWinnersCoinstakes.getLotteryCoinstakes());
     }
 
     if (!masternodeSync.IsSynced()) { //there is no budget data to use to check anything -- find the longest chain
@@ -137,7 +137,7 @@ bool IsBlockPayeeValid(const CTransaction &txNew, int nBlockHeight, CBlockIndex 
         return true;
     }
     //check for masternode payee
-    if (masternodePayments.IsTransactionValid(txNew, nBlockHeight))
+    if (masternodePayments.IsTransactionValid(txNew, pindex->nHeight))
         return true;
     LogPrintf("%s : Invalid mn payment detected %s\n", __func__, txNew.ToString().c_str());
 

--- a/divi/src/masternode-payments.cpp
+++ b/divi/src/masternode-payments.cpp
@@ -466,7 +466,7 @@ bool CMasternodePayments::IsScheduled(const CMasternode& mn, int nNotBlockHeight
 bool CMasternodePayments::AddWinningMasternode(const CMasternodePaymentWinner& winnerIn)
 {
     uint256 blockHash = 0;
-    if (!GetBlockHash(blockHash, winnerIn.nBlockHeight - 100)) {
+    if (!GetMnBlockHash(blockHash, winnerIn.nBlockHeight - 100)) {
         return false;
     }
 

--- a/divi/src/masternode-payments.cpp
+++ b/divi/src/masternode-payments.cpp
@@ -466,11 +466,6 @@ bool CMasternodePayments::IsScheduled(const CMasternode& mn, int nNotBlockHeight
 
 bool CMasternodePayments::AddWinningMasternode(const CMasternodePaymentWinner& winnerIn)
 {
-    uint256 blockHash = 0;
-    if (!GetMnBlockHash(blockHash, winnerIn.nBlockHeight - 100)) {
-        return false;
-    }
-
     CMasternodeBlockPayees* payees;
     {
         LOCK2(cs_mapMasternodeBlocks, cs_mapMasternodePayeeVotes);
@@ -644,7 +639,7 @@ bool CMasternodePaymentWinner::IsValid(CNode* pnode, std::string& strError) cons
         return false;
     }
 
-    const unsigned n = mnodeman.GetMasternodeRank(vinMasternode, nBlockHeight - 100, ActiveProtocol(), 2 * MNPAYMENTS_SIGNATURES_TOTAL);
+    const unsigned n = mnodeman.GetMasternodeRank(vinMasternode, nBlockHeight, ActiveProtocol(), 2 * MNPAYMENTS_SIGNATURES_TOTAL);
 
     if (n > MNPAYMENTS_SIGNATURES_TOTAL) {
         //It's common to have masternodes mistakenly think they are in the top 10
@@ -677,7 +672,7 @@ bool CMasternodePayments::ProcessBlock(int nBlockHeight)
 
     //reference node - hybrid mode
 
-    const unsigned n = mnodeman.GetMasternodeRank(activeMasternode.vin, nBlockHeight - 100, ActiveProtocol(), MNPAYMENTS_SIGNATURES_TOTAL);
+    const unsigned n = mnodeman.GetMasternodeRank(activeMasternode.vin, nBlockHeight, ActiveProtocol(), MNPAYMENTS_SIGNATURES_TOTAL);
 
     if (n == static_cast<unsigned>(-1)) {
         LogPrint("mnpayments", "CMasternodePayments::ProcessBlock - Unknown Masternode\n");

--- a/divi/src/masternode-payments.cpp
+++ b/divi/src/masternode-payments.cpp
@@ -295,9 +295,10 @@ void CMasternodePayments::FillBlockPayee(CMutableTransaction& txNew, const CBloc
     CScript payee;
 
     //spork
-    if (!GetBlockPayee(pindexPrev->nHeight + 1, payee)) {
-        //no masternode detected
-        CMasternode* winningNode = mnodeman.GetCurrentMasterNode(0, 0);
+    const int nBlockHeight = pindexPrev->nHeight + 1;
+    if (!GetBlockPayee(nBlockHeight, payee)) {
+        // No masternode detected, fall back to our own queue.
+        const CMasternode* winningNode = mnodeman.GetNextMasternodeInQueueForPayment(nBlockHeight, true);
         if (winningNode) {
             payee = GetScriptForDestination(winningNode->pubKeyCollateralAddress.GetID());
         } else {

--- a/divi/src/masternode-payments.h
+++ b/divi/src/masternode-payments.h
@@ -20,7 +20,7 @@ class CMasternodeBlockPayees;
 
 extern CMasternodePayments masternodePayments;
 
-bool IsBlockPayeeValid(const CTransaction &txNew, int nBlockHeight, CBlockIndex *prevIndex);
+bool IsBlockPayeeValid(const CTransaction &txNew, const CBlockIndex *pindex);
 
 LotteryCoinstakeData CalculateLotteryWinners(const CBlock& block, const CBlockIndex *prevBlockIndex, int nHeight);
 

--- a/divi/src/masternode-payments.h
+++ b/divi/src/masternode-payments.h
@@ -188,7 +188,10 @@ public:
     void Clear();
 
     bool AddWinningMasternode(const CMasternodePaymentWinner &winner);
-    bool ProcessBlock(int nBlockHeight);
+    /** Processes anything that needs to be done (mostly computing
+     *  and broadcasting the mnw messages) for the given block height
+     *  when it comes within reach of the current tip.  */
+    bool ProcessBlock(const CBlockIndex* pindex, int offset);
 
     void Sync(CNode* node, int nCountNeeded);
     void CheckAndRemove();

--- a/divi/src/masternode.cpp
+++ b/divi/src/masternode.cpp
@@ -318,7 +318,7 @@ static uint256 CalculateScoreHelper(CHashWriter hashWritter, int round)
 // the proof of work for that block. The further away they are the better, the furthest will win the election
 // and get paid this block
 //
-uint256 CMasternode::CalculateScore(int mod, int64_t nBlockHeight)
+uint256 CMasternode::CalculateScore(int64_t nBlockHeight)
 {
     if (chainActive.Tip() == NULL) return 0;
 

--- a/divi/src/masternode.cpp
+++ b/divi/src/masternode.cpp
@@ -91,7 +91,7 @@ static bool IsCoinSpent(const COutPoint &outpoint, const CAmount expectedCollate
 
 
 //Get the last hash that matches the modulus given. Processed in reverse order
-bool GetBlockHash(uint256& hash, int nBlockHeight)
+bool GetMnBlockHash(uint256& hash, int nBlockHeight)
 {
     // cache block hashes as we calculate them
     static std::map<int64_t, uint256> mapCacheBlockHashes;
@@ -325,7 +325,7 @@ uint256 CMasternode::CalculateScore(int64_t nBlockHeight)
     const uint256 aux = vin.prevout.hash + vin.prevout.n;
 
     uint256 hash;
-    if (!GetBlockHash(hash, nBlockHeight)) {
+    if (!GetMnBlockHash(hash, nBlockHeight)) {
         LogPrint("masternode","CalculateScore ERROR - nHeight %d - Returned 0\n", nBlockHeight);
         return 0;
     }

--- a/divi/src/masternode.cpp
+++ b/divi/src/masternode.cpp
@@ -419,7 +419,11 @@ int64_t CMasternode::GetLastPaid()
         }
         n++;
 
-        auto* masternodePayees = masternodePayments.GetPayeesForHeight(BlockReading->nHeight);
+        uint256 seedHash;
+        if (!GetBlockHashForScoring(seedHash, BlockReading->nHeight))
+            continue;
+
+        auto* masternodePayees = masternodePayments.GetPayeesForScoreHash(seedHash);
         if (masternodePayees != nullptr) {
             /*
                 Search for this payee, with at least 2 votes. This will aid in consensus allowing the network

--- a/divi/src/masternode.cpp
+++ b/divi/src/masternode.cpp
@@ -93,44 +93,18 @@ static bool IsCoinSpent(const COutPoint &outpoint, const CAmount expectedCollate
 //Get the last hash that matches the modulus given. Processed in reverse order
 bool GetMnBlockHash(uint256& hash, int nBlockHeight)
 {
-    // cache block hashes as we calculate them
-    static std::map<int64_t, uint256> mapCacheBlockHashes;
-
-    if (chainActive.Tip() == NULL) return false;
+    if (chainActive.Tip() == nullptr)
+        return false;
 
     if (nBlockHeight == 0)
         nBlockHeight = chainActive.Tip()->nHeight;
 
-    if (mapCacheBlockHashes.count(nBlockHeight)) {
-        hash = mapCacheBlockHashes[nBlockHeight];
-        return true;
-    }
+    const auto* pindex = chainActive[nBlockHeight - 1];
+    if (pindex == nullptr)
+        return false;
 
-    const CBlockIndex* BlockReading = chainActive.Tip();
-
-    if (BlockReading == NULL || BlockReading->nHeight == 0 || chainActive.Tip()->nHeight + 1 < nBlockHeight) return false;
-
-    int nBlocksAgo = 0;
-    if (nBlockHeight > 0) nBlocksAgo = (chainActive.Tip()->nHeight + 1) - nBlockHeight;
-    assert(nBlocksAgo >= 0);
-
-    int n = 0;
-    while (BlockReading && BlockReading->nHeight > 0) {
-        if (n >= nBlocksAgo) {
-            hash = BlockReading->GetBlockHash();
-            mapCacheBlockHashes[nBlockHeight] = hash;
-            return true;
-        }
-        n++;
-
-        /* Since BlockReading->nHeight > 0 per our while condition, we are
-           always above the genesis block and thus there must be a previous
-           block pointer.  */
-        assert(BlockReading->pprev != nullptr);
-        BlockReading = BlockReading->pprev;
-    }
-
-    return false;
+    hash = pindex->GetBlockHash();
+    return true;
 }
 
 CMasternode::CMasternode()

--- a/divi/src/masternode.h
+++ b/divi/src/masternode.h
@@ -29,7 +29,10 @@ class CMasternodeBroadcast;
 class CMasternodeBroadcastFactory;
 class CMasternodePing;
 
-bool GetMnBlockHash(uint256& hash, int nBlockHeight);
+/** Returns the block hash that is used in the masternode scoring / ranking
+ *  logic for the winner of block nBlockHeight.  (It is the hash of the
+ *  block nBlockHeight-101, but that's an implementation detail.)  */
+bool GetBlockHashForScoring(uint256& hash, int nBlockHeight);
 
 int GetInputAge(CTxIn& vin);
 
@@ -162,7 +165,10 @@ public:
         return !(a.vin == b.vin);
     }
 
-    uint256 CalculateScore(int64_t nBlockHeight);
+    /** Calculates the score of the current masternode, based on the given
+     *  seed hash.  It should be the result of GetBlockHashForScoring of
+     *  the target block height.  */
+    uint256 CalculateScore(const uint256& seedHash) const;
 
     ADD_SERIALIZE_METHODS;
 

--- a/divi/src/masternode.h
+++ b/divi/src/masternode.h
@@ -162,7 +162,7 @@ public:
         return !(a.vin == b.vin);
     }
 
-    uint256 CalculateScore(int mod = 1, int64_t nBlockHeight = 0);
+    uint256 CalculateScore(int64_t nBlockHeight);
 
     ADD_SERIALIZE_METHODS;
 

--- a/divi/src/masternode.h
+++ b/divi/src/masternode.h
@@ -29,7 +29,7 @@ class CMasternodeBroadcast;
 class CMasternodeBroadcastFactory;
 class CMasternodePing;
 
-bool GetBlockHash(uint256& hash, int nBlockHeight);
+bool GetMnBlockHash(uint256& hash, int nBlockHeight);
 
 int GetInputAge(CTxIn& vin);
 

--- a/divi/src/masternode.h
+++ b/divi/src/masternode.h
@@ -34,6 +34,16 @@ class CMasternodePing;
  *  block nBlockHeight-101, but that's an implementation detail.)  */
 bool GetBlockHashForScoring(uint256& hash, int nBlockHeight);
 
+/** Returns the scoring hash corresponding to the given CBlockIndex
+ *  offset by N.  In other words, that is used to compute the winner
+ *  that should be payed in block pindex->nHeight+N.
+ *
+ *  In contrast to GetBlockHashForScoring, this works entirely independent
+ *  of chainActive, and is guaranteed to look into the correct ancestor
+ *  chain independent of potential reorgs.  */
+bool GetBlockHashForScoring(uint256& hash,
+                            const CBlockIndex* pindex, const int offset);
+
 int GetInputAge(CTxIn& vin);
 
 //

--- a/divi/src/masternodeman.cpp
+++ b/divi/src/masternodeman.cpp
@@ -434,7 +434,7 @@ std::vector<CMasternode*> CMasternodeMan::GetMasternodePaymentQueue(int nBlockHe
         if (mn.GetMasternodeInputAge() < nMnCount) continue;
 
         masternodeQueue.push_back(&mn);
-        masternodeScores[&mn] = mn.CalculateScore(1,nBlockHeight - 100);
+        masternodeScores[&mn] = mn.CalculateScore(nBlockHeight - 100);
     }
 
     //when the network is in the process of upgrading, don't penalize nodes that recently restarted
@@ -493,7 +493,7 @@ CMasternode* CMasternodeMan::FindRandomNotInVec(std::vector<CTxIn>& vecToExclude
     return NULL;
 }
 
-CMasternode* CMasternodeMan::GetCurrentMasterNode(int mod, int64_t nBlockHeight, int minProtocol)
+CMasternode* CMasternodeMan::GetCurrentMasterNode(int64_t nBlockHeight, int minProtocol)
 {
     int64_t score = 0;
     CMasternode* winner = NULL;
@@ -504,7 +504,7 @@ CMasternode* CMasternodeMan::GetCurrentMasterNode(int mod, int64_t nBlockHeight,
         if (mn.protocolVersion < minProtocol || !mn.IsEnabled()) continue;
 
         // calculate the score for each Masternode
-        uint256 n = mn.CalculateScore(mod, nBlockHeight);
+        uint256 n = mn.CalculateScore(nBlockHeight);
         int64_t n2 = n.GetCompact(false);
 
         // determine the winner
@@ -542,7 +542,7 @@ bool CheckAndGetScore(CMasternode& mn,
     if (!mn.IsEnabled ())
         return false;
 
-    const uint256 n = mn.CalculateScore(1, nBlockHeight);
+    const uint256 n = mn.CalculateScore(nBlockHeight);
     score = n.GetCompact(false);
 
     return true;

--- a/divi/src/masternodeman.cpp
+++ b/divi/src/masternodeman.cpp
@@ -493,30 +493,6 @@ CMasternode* CMasternodeMan::FindRandomNotInVec(std::vector<CTxIn>& vecToExclude
     return NULL;
 }
 
-CMasternode* CMasternodeMan::GetCurrentMasterNode(int64_t nBlockHeight, int minProtocol)
-{
-    int64_t score = 0;
-    CMasternode* winner = NULL;
-
-    // scan for winner
-    BOOST_FOREACH (CMasternode& mn, vMasternodes) {
-        mn.Check();
-        if (mn.protocolVersion < minProtocol || !mn.IsEnabled()) continue;
-
-        // calculate the score for each Masternode
-        uint256 n = mn.CalculateScore(nBlockHeight);
-        int64_t n2 = n.GetCompact(false);
-
-        // determine the winner
-        if (n2 > score) {
-            score = n2;
-            winner = &mn;
-        }
-    }
-
-    return winner;
-}
-
 namespace
 {
 

--- a/divi/src/masternodeman.h
+++ b/divi/src/masternodeman.h
@@ -100,8 +100,9 @@ public:
     CMasternode* Find(const CPubKey& pubKeyMasternode);
 
     /// Find an entry in the masternode list that is next to be paid
-    std::vector<CMasternode*> GetMasternodePaymentQueue(int nBlockHeight, bool fFilterSigTime);
-    CMasternode* GetNextMasternodeInQueueForPayment(int nBlockHeight, bool fFilterSigTime);
+    std::vector<CMasternode*> GetMasternodePaymentQueue(const uint256& seedHash, int nBlockHeight, bool fFilterSigTime);
+    std::vector<CMasternode*> GetMasternodePaymentQueue(const CBlockIndex* pindex, int offset, bool fFilterSigTime);
+    CMasternode* GetNextMasternodeInQueueForPayment(const CBlockIndex* pindex, int offset, bool fFilterSigTime);
 
     /// Find a random entry
     CMasternode* FindRandomNotInVec(std::vector<CTxIn>& vecToExclude, int protocolVersion = -1);

--- a/divi/src/masternodeman.h
+++ b/divi/src/masternodeman.h
@@ -107,7 +107,7 @@ public:
     CMasternode* FindRandomNotInVec(std::vector<CTxIn>& vecToExclude, int protocolVersion = -1);
 
     /// Get the current winner for this block
-    CMasternode* GetCurrentMasterNode(int mod = 1, int64_t nBlockHeight = 0, int minProtocol = 0);
+    CMasternode* GetCurrentMasterNode(int64_t nBlockHeight, int minProtocol);
 
     std::vector<CMasternode> GetFullMasternodeVector() const
     {

--- a/divi/src/masternodeman.h
+++ b/divi/src/masternodeman.h
@@ -106,9 +106,6 @@ public:
     /// Find a random entry
     CMasternode* FindRandomNotInVec(std::vector<CTxIn>& vecToExclude, int protocolVersion = -1);
 
-    /// Get the current winner for this block
-    CMasternode* GetCurrentMasterNode(int64_t nBlockHeight, int minProtocol);
-
     std::vector<CMasternode> GetFullMasternodeVector() const
     {
         return vMasternodes;

--- a/divi/src/masternodeman.h
+++ b/divi/src/masternodeman.h
@@ -117,8 +117,8 @@ public:
      *
      *  If the given node is not in the top-"nCheckNum" masternodes by rank, then
      *  nCheckNum + 1 is returned (instead of the exact rank).  */
-    unsigned GetMasternodeRank(const CTxIn& vin, int64_t nBlockHeight, int minProtocol,
-                               unsigned nCheckNum);
+    unsigned GetMasternodeRank(const CTxIn& vin, const uint256& seedHash,
+                               int minProtocol, unsigned nCheckNum);
 
     void ProcessMasternodeConnections();
 

--- a/divi/src/rpcmasternode.cpp
+++ b/divi/src/rpcmasternode.cpp
@@ -659,7 +659,9 @@ Value getmasternodewinners (const Array& params, bool fHelp)
         Object obj;
         obj.push_back(Pair("nHeight", i));
 
-        std::string strPayment = masternodePayments.GetRequiredPaymentsString(i);
+        uint256 seedHash;
+        if (!GetBlockHashForScoring(seedHash, i)) continue;
+        std::string strPayment = masternodePayments.GetRequiredPaymentsString(seedHash);
         if (strFilter != "" && strPayment.find(strFilter) == std::string::npos) continue;
 
         if (strPayment.find(',') != std::string::npos) {

--- a/divi/src/rpcmasternode.cpp
+++ b/divi/src/rpcmasternode.cpp
@@ -431,7 +431,10 @@ Value getmasternodecount (const Array& params, bool fHelp)
     Object obj;
     int ipv4 = 0, ipv6 = 0, onion = 0;
 
-    int nCount = chainActive.Tip()? static_cast<int>(mnodeman.GetMasternodePaymentQueue(chainActive.Tip()->nHeight, true).size()): 0;
+    int nCount = 0;
+    const CBlockIndex* tip = chainActive.Tip();
+    if (tip != nullptr)
+        nCount = mnodeman.GetMasternodePaymentQueue(tip, 0, true).size();
 
     mnodeman.CountNetworks(ActiveProtocol(), ipv4, ipv6, onion);
 
@@ -637,12 +640,14 @@ Value getmasternodewinners (const Array& params, bool fHelp)
             HelpExampleCli("getmasternodewinners", "") + HelpExampleRpc("getmasternodewinners", ""));
 
     int nHeight;
+    CBlockIndex* pindex = nullptr;
     {
         LOCK(cs_main);
-        CBlockIndex* pindex = chainActive.Tip();
+        pindex = chainActive.Tip();
         if(!pindex) return 0;
         nHeight = pindex->nHeight;
     }
+    assert(pindex != nullptr);
 
     int nLast = 10;
     std::string strFilter = "";
@@ -660,7 +665,7 @@ Value getmasternodewinners (const Array& params, bool fHelp)
         obj.push_back(Pair("nHeight", i));
 
         uint256 seedHash;
-        if (!GetBlockHashForScoring(seedHash, i)) continue;
+        if (!GetBlockHashForScoring(seedHash, pindex, i - nHeight)) continue;
         std::string strPayment = masternodePayments.GetRequiredPaymentsString(seedHash);
         if (strFilter != "" && strPayment.find(strFilter) == std::string::npos) continue;
 


### PR DESCRIPTION
A lot of the masternode code is using block heights for things like computing the payment winners or even as keys into caches and other in-memory maps.  This is problematic, as a block height may refer to more than one actual block in the case of reorgs.

In this set of changes, we change many of those to be based on block hashes.  For payment winners in particular, what matters is the *hash of the block 101 blocks earlier* (`GetBlockHashForScoring`, previously `GetBlockHash`).  We use this seed / scoring hash as main piece of data for keying winner-related data.

For actually computing the winner hash, we now use most of the time an explicit `CBlockIndex*` as basis, rather than `chainActive` (i.e. explicitly specify the chain in which we look for the ancestor at the required height).  This avoids using `chainActive` as a global, and makes the code more robust against reorgs in general.

The only place where we still use only block heights is the wire format for `CMasternodePaymentWinner` messages (i.e. processing a `mnw` received from a peer, as well as the hash used to identify them in a node's inventory).  Changing this to the seed hash would change the wire protocol, and thus make the change much more complex to do.

Finally, this also includes a simplification and potential fix to how votes for winners are tracked and duplicate votes by a single masternode prevented.