### PR TITLE
Implement fork for "staking vaults"

### DIFF
--- a/divi/qa/rpc-tests/test_runner.py
+++ b/divi/qa/rpc-tests/test_runner.py
@@ -97,6 +97,7 @@ BASE_SCRIPTS = [
     'sync.py',
     'txn_doublespend.py',
     'txn_doublespend.py --mineblock',
+    'vaultfork.py',
     'wallet.py',
     'walletbackup.py',
     'zapwallettxes.py',

--- a/divi/qa/rpc-tests/vaultfork.py
+++ b/divi/qa/rpc-tests/vaultfork.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+# Copyright (c) 2020 The DIVI developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+# Tests the logic around OP_REQUIRE_COINSTAKE that is forked active
+# at an activation time.
+
+from test_framework import BitcoinTestFramework
+from authproxy import JSONRPCException
+from util import *
+
+from PowToPosTransition import createPoSStacks, generatePoSBlocks
+
+ACTIVATION_TIME = 2_000_000_000
+
+
+class VaultForkTest (BitcoinTestFramework):
+
+    def setup_network (self):
+        self.nodes = []
+        args = ["-debug"]
+        self.nodes.append (start_node(0, self.options.tmpdir, extra_args=args))
+        self.nodes.append (start_node(1, self.options.tmpdir, extra_args=args))
+        connect_nodes (self.nodes[1], 0)
+        self.is_network_split = False
+        self.sync_all ()
+
+    def fund_vault (self, owner, staker, amount):
+        """
+        Sets up a vault between the two nodes with the given amount.
+        Returns the vault UTXO as dict with "vout" and "txid" fields.
+        """
+
+        txid = owner.fundvault (staker.getnewaddress (), amount)["txhash"]
+        outputs = owner.getrawtransaction (txid, 1)["vout"]
+        for n in range (len (outputs)):
+            if outputs[n]["scriptPubKey"]["type"] == "vault":
+                return {"txid": txid, "vout": n}
+
+        raise AssertionError ("constructed transaction has no vault output")
+
+    def sign_and_send (self, node, tx):
+        signed = node.signrawtransaction (tx)
+        assert_equal (signed["complete"], True)
+        return node.sendrawtransaction (signed["hex"])
+
+    def run_test (self):
+        # After the big bump in time, we need to make sure the nodes
+        # are connected still / again in case they timed out the
+        # connection between them.
+        set_node_times(self.nodes, ACTIVATION_TIME - 1_000)
+        connect_nodes (self.nodes[1], 0)
+        self.nodes[0].setgenerate (True, 1)
+        sync_blocks (self.nodes)
+        createPoSStacks(self.nodes, self.nodes)
+
+        # We need to activate PoS at least for some parts of the test.
+        print ("Activating PoS...")
+        generatePoSBlocks (self.nodes, 0, 100)
+
+        print ("Spending vault as owner before the fork...")
+        vault = self.fund_vault (self.nodes[0], self.nodes[1], 10)
+        generatePoSBlocks (self.nodes, 0, 1)
+        addr = self.nodes[0].getnewaddress ("unvaulted")
+        unsigned = self.nodes[0].createrawtransaction ([vault], {addr: 9})
+        self.sign_and_send (self.nodes[0], unsigned)
+        generatePoSBlocks (self.nodes, 0, 1)
+        assert_equal (self.nodes[0].getbalance ("unvaulted"), 9)
+
+        print ("Spending vault as staker before the fork...")
+        vault = self.fund_vault (self.nodes[0], self.nodes[1], 10)
+        generatePoSBlocks (self.nodes, 0, 1)
+        addr = self.nodes[1].getnewaddress ("stolen")
+        unsigned = self.nodes[1].createrawtransaction ([vault], {addr: 9})
+
+        # The signature will be added, even though it is considered as invalid
+        # by the applied standard flags (which include OP_REQUIRE_COINSTAKE
+        # independent of fork activation).  Also the mempool will not accept it.
+        signed = self.nodes[1].signrawtransaction (unsigned)
+        assert_equal (signed["complete"], False)
+        assert_raises (JSONRPCException, self.nodes[1].sendrawtransaction, signed["hex"])
+
+        # If we include the transaction directly in a block, it is valid.
+        self.nodes[0].generateblock ({"extratx": [signed["hex"]]})
+        sync_blocks (self.nodes)
+        assert_equal (self.nodes[1].getbalance ("stolen"), 9)
+
+        print ("Activating fork...")
+        blk = self.nodes[0].getblockheader (self.nodes[0].getbestblockhash ())
+        assert_greater_than (ACTIVATION_TIME, blk["time"])
+        set_node_times (self.nodes, ACTIVATION_TIME + 1_000)
+        self.nodes[0].setgenerate (True, 1)
+        connect_nodes (self.nodes[1], 0)
+        sync_blocks (self.nodes)
+        blk = self.nodes[0].getblockheader (self.nodes[0].getbestblockhash ())
+        assert_greater_than (blk["time"], ACTIVATION_TIME)
+
+        print ("Spending vault as staker with activated fork...")
+        vault = self.fund_vault (self.nodes[0], self.nodes[1], 10)
+        generatePoSBlocks (self.nodes, 1, 1)
+        addr = self.nodes[1].getnewaddress ("stolen again")
+        unsigned = self.nodes[1].createrawtransaction ([vault], {addr: 9})
+        signed = self.nodes[1].signrawtransaction (unsigned)
+        assert_raises (JSONRPCException, self.nodes[1].generateblock,
+                       {"extratx": [signed["hex"]]})
+        assert_equal (self.nodes[1].getbalance ("stolen again"), 0)
+
+        print ("Spending vault as owner after the fork...")
+        vault = self.fund_vault (self.nodes[0], self.nodes[1], 10)
+        generatePoSBlocks (self.nodes, 1, 1)
+        addr = self.nodes[0].getnewaddress ("unvaulted 2")
+        unsigned = self.nodes[0].createrawtransaction ([vault], {addr: 9})
+        self.sign_and_send (self.nodes[0], unsigned)
+        generatePoSBlocks (self.nodes, 1, 1)
+        assert_equal (self.nodes[0].getbalance ("unvaulted 2"), 9)
+
+
+if __name__ == '__main__':
+    VaultForkTest ().main ()

--- a/divi/src/BlockRewards.h
+++ b/divi/src/BlockRewards.h
@@ -14,12 +14,12 @@ struct CBlockRewards {
 
     std::string ToString() const;
 
-    const CAmount nStakeReward;
-    const CAmount nMasternodeReward;
-    const CAmount nTreasuryReward;
-    const CAmount nCharityReward;
-    const CAmount nLotteryReward;
-    const CAmount nProposalsReward;
+    CAmount nStakeReward;
+    CAmount nMasternodeReward;
+    CAmount nTreasuryReward;
+    CAmount nCharityReward;
+    CAmount nLotteryReward;
+    CAmount nProposalsReward;
 
     CAmount total() const;
 };

--- a/divi/src/ForkActivation.cpp
+++ b/divi/src/ForkActivation.cpp
@@ -17,6 +17,9 @@ namespace
  * activation times.
  */
 const std::unordered_map<Fork, int64_t> ACTIVATION_TIMES = {
+  /* FIXME: Set real activation height for staking vaults once
+     the schedule has been finalised.  */
+  {Fork::StakingVaults, 2000000000},
   {Fork::TestByTimestamp, 1000000000},
 };
 

--- a/divi/src/ForkActivation.h
+++ b/divi/src/ForkActivation.h
@@ -19,6 +19,12 @@ class CBlockIndex;
 enum class Fork
 {
 
+  /**
+   * Staking vaults with SCRIPT_REQUIRE_COINSTAKE and a couple of other,
+   * related changes.
+   */
+  StakingVaults,
+
   /* Test forks not actually deployed / active but used for unit tests.  */
   TestByTimestamp,
 

--- a/divi/src/kernel.cpp
+++ b/divi/src/kernel.cpp
@@ -300,7 +300,7 @@ bool CheckProofOfStakeContextAndRecoverStakingData(
     }
 
     //verify signature and script
-    if (!VerifyScript(txin.scriptSig, txPrev.vout[txin.prevout.n].scriptPubKey, STANDARD_SCRIPT_VERIFY_FLAGS, TransactionSignatureChecker(&tx, 0)))
+    if (!VerifyScript(txin.scriptSig, txPrev.vout[txin.prevout.n].scriptPubKey, POS_SCRIPT_VERIFY_FLAGS, TransactionSignatureChecker(&tx, 0)))
         return error("CheckProofOfStake() : VerifySignature failed on coinstake %s", tx.GetHash().ToString().c_str());
 
     CBlockIndex* pindex = NULL;

--- a/divi/src/script/sign.cpp
+++ b/divi/src/script/sign.cpp
@@ -183,7 +183,6 @@ bool SignSignature(const CKeyStore &keystore, const CScript& fromPubKey, CMutabl
     if (!ConstructScriptSigOrGetRedemptionScript(keystore, fromPubKey, hash, nHashType, txin.scriptSig, whichType))
         return false;
 
-    unsigned flags = STANDARD_SCRIPT_VERIFY_FLAGS;
     if (whichType == TX_SCRIPTHASH)
     {
         // Solver returns the subscript that need to be evaluated;
@@ -203,13 +202,10 @@ bool SignSignature(const CKeyStore &keystore, const CScript& fromPubKey, CMutabl
 
         whichType = subType;
     }
-    if(whichType == TX_VAULT)
-    {
-        flags |= SCRIPT_REQUIRE_COINSTAKE;
-    }
 
     // Test solution
-    return VerifyScript(txin.scriptSig, fromPubKey, flags, MutableTransactionSignatureChecker(&txTo, nIn));
+    return VerifyScript(txin.scriptSig, fromPubKey, STANDARD_SCRIPT_VERIFY_FLAGS,
+                        MutableTransactionSignatureChecker(&txTo, nIn));
 }
 
 bool SignSignature(const CKeyStore &keystore, const CTransaction& txFrom, CMutableTransaction& txTo, unsigned int nIn, int nHashType)

--- a/divi/src/script/standard.h
+++ b/divi/src/script/standard.h
@@ -28,15 +28,15 @@ static const unsigned int MANDATORY_SCRIPT_VERIFY_FLAGS = SCRIPT_VERIFY_P2SH |
                                                           SCRIPT_VERIFY_DERSIG;
 
 /**
- * Script flags that are used when verifying the signature on PoS blocks.  They
- * are consensus relevant as well and cannot be easily changed.
+ * Script flags that are used when verifying the coinstake signature in
+ * CheckProofOfStake.  They are consensus relevant as well.
  */
 static const unsigned int POS_SCRIPT_VERIFY_FLAGS = MANDATORY_SCRIPT_VERIFY_FLAGS |
                                                     SCRIPT_VERIFY_DERSIG |
                                                     SCRIPT_VERIFY_STRICTENC |
                                                     SCRIPT_VERIFY_MINIMALDATA |
                                                     SCRIPT_VERIFY_NULLDUMMY |
-                                                    SCRIPT_VERIFY_DISCOURAGE_UPGRADABLE_NOPS;
+                                                    SCRIPT_REQUIRE_COINSTAKE;
 
 /**
  * Standard script verification flags that standard transactions will comply
@@ -44,7 +44,7 @@ static const unsigned int POS_SCRIPT_VERIFY_FLAGS = MANDATORY_SCRIPT_VERIFY_FLAG
  * blocks and we must accept those blocks.
  */
 static const unsigned int STANDARD_SCRIPT_VERIFY_FLAGS = POS_SCRIPT_VERIFY_FLAGS |
-                                                         SCRIPT_REQUIRE_COINSTAKE;
+                                                         SCRIPT_VERIFY_DISCOURAGE_UPGRADABLE_NOPS;
 
 /** For convenience, standard but not mandatory verify flags. */
 static const unsigned int STANDARD_NOT_MANDATORY_VERIFY_FLAGS = STANDARD_SCRIPT_VERIFY_FLAGS & ~MANDATORY_SCRIPT_VERIFY_FLAGS;

--- a/divi/src/script/standard.h
+++ b/divi/src/script/standard.h
@@ -28,16 +28,23 @@ static const unsigned int MANDATORY_SCRIPT_VERIFY_FLAGS = SCRIPT_VERIFY_P2SH |
                                                           SCRIPT_VERIFY_DERSIG;
 
 /**
+ * Script flags that are used when verifying the signature on PoS blocks.  They
+ * are consensus relevant as well and cannot be easily changed.
+ */
+static const unsigned int POS_SCRIPT_VERIFY_FLAGS = MANDATORY_SCRIPT_VERIFY_FLAGS |
+                                                    SCRIPT_VERIFY_DERSIG |
+                                                    SCRIPT_VERIFY_STRICTENC |
+                                                    SCRIPT_VERIFY_MINIMALDATA |
+                                                    SCRIPT_VERIFY_NULLDUMMY |
+                                                    SCRIPT_VERIFY_DISCOURAGE_UPGRADABLE_NOPS;
+
+/**
  * Standard script verification flags that standard transactions will comply
  * with. However scripts violating these flags may still be present in valid
  * blocks and we must accept those blocks.
  */
-static const unsigned int STANDARD_SCRIPT_VERIFY_FLAGS = MANDATORY_SCRIPT_VERIFY_FLAGS |
-                                                         SCRIPT_VERIFY_DERSIG |
-                                                         SCRIPT_VERIFY_STRICTENC |
-                                                         SCRIPT_VERIFY_MINIMALDATA |
-                                                         SCRIPT_VERIFY_NULLDUMMY |
-                                                         SCRIPT_VERIFY_DISCOURAGE_UPGRADABLE_NOPS;
+static const unsigned int STANDARD_SCRIPT_VERIFY_FLAGS = POS_SCRIPT_VERIFY_FLAGS |
+                                                         SCRIPT_REQUIRE_COINSTAKE;
 
 /** For convenience, standard but not mandatory verify flags. */
 static const unsigned int STANDARD_NOT_MANDATORY_VERIFY_FLAGS = STANDARD_SCRIPT_VERIFY_FLAGS & ~MANDATORY_SCRIPT_VERIFY_FLAGS;

--- a/divi/src/test/BlockSignature_tests.cpp
+++ b/divi/src/test/BlockSignature_tests.cpp
@@ -103,4 +103,25 @@ BOOST_AUTO_TEST_CASE(willDisallowP2SHStakingVaultCoinstakeInBlock)
     BOOST_CHECK_MESSAGE(!CheckBlockSignature(block),"Verified  disallowed signature type!");
 }
 
+BOOST_AUTO_TEST_CASE(stakingVaultSignature)
+{
+    CScript redeemScript = CreateStakingVaultScript(
+            ToByteVector(ownerPKey.GetID()),
+            ToByteVector(vaultPKey.GetID()));
+
+    addStakingCoinstake(redeemScript, false);
+    // Preconditions
+    BOOST_CHECK_MESSAGE(block.IsProofOfStake(), "Block isnt PoS!");
+    // Test
+    BOOST_CHECK_MESSAGE(!SignBlock(ownerKeyStore, block), "Owner key could sign block");
+
+    block.nTime = 2000000000;
+    BOOST_CHECK_MESSAGE(SignBlock(vaultKeyStore, block), "Failed to sign block with vault key");
+    BOOST_CHECK_MESSAGE(CheckBlockSignature(block), "Failed to verify vault block signature");
+
+    block.nTime = 1000000000;
+    BOOST_CHECK_MESSAGE(SignBlock(vaultKeyStore, block), "Failed to sign block with vault key");
+    BOOST_CHECK_MESSAGE(!CheckBlockSignature(block), "Verified  disallowed signature type!");
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Based on the op-code changes (`OP_REQUIRE_COINSTAKE`) by @galpHub, this finishes the consensus-parts of the planned fork to implement staking vaults.  It introduces a new time-activated fork (currently at block time 2'000'000'000, to be scheduled with a follow-up change).  The changes to consensus are as follows:

1. Blocks after the activation time will enforce `OP_REQUIRE_COINSTAKE` in signature verification.
2. They also enforce new rules on the structure of coinstakes:  If a coinstake is spending a vault output, the coins used for staking and the staking reward have to be paid back to the same script in a single output.
3. From the fork, staking vault scripts are able to sign the blocks (in addition to P2PK and P2PKH scripts that are able to sign blocks before).
4. The extra signature verification done on the coinstake in `CheckProofOfStake` is no longer enforcing `SCRIPT_VERIFY_DISCOURAGE_UPGRADABLE_NOPS`, and it is also using `OP_REQUIRE_COINSTAKE`.

Note that 3) and 4) implement a **hard fork**, that is scheduled in parallel with the script changes which by themselves would only be a soft fork.  This hard fork just lifts some rules that were stricter before; so once all is through and activated for long enough, we can retro-actively remove the stricter rules until genesis and simplify the code for 3) and 4).