### PR TITLE
Ensure wallet is unlocked for masternode RPCs

### DIFF
--- a/divi/src/rpcmasternode.cpp
+++ b/divi/src/rpcmasternode.cpp
@@ -97,12 +97,14 @@ Value allocatefunds(const Array& params, bool fHelp)
         throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid masternode tier");
     }
 
-	CWalletTx wtx;
+    EnsureWalletIsUnlocked();
+
+    CWalletTx wtx;
     SendMoney(acctAddr.Get(), CMasternode::GetTierCollateralAmount(nMasternodeTier), wtx);
 
-	Object obj;
+    Object obj;
     obj.push_back(Pair("txhash", wtx.GetHash().GetHex()));
-	return obj;
+    return obj;
 }
 
 Value fundmasternode(const Array& params, bool fHelp)
@@ -154,8 +156,8 @@ Value fundmasternode(const Array& params, bool fHelp)
         throw JSONRPCError(RPC_VERIFY_ERROR, "Couldn't verify transaction");
     }
 
-    if (!pwalletMain->IsLocked())
-        pwalletMain->TopUpKeyPool();
+    EnsureWalletIsUnlocked();
+    pwalletMain->TopUpKeyPool();
 
     // Generate a new key that is added to wallet
     CBitcoinAddress address = GetAccountAddress("reserved->" + alias);
@@ -242,6 +244,8 @@ Value setupmasternode(const Array& params, bool fHelp)
             "\"broadcast_data\"			    (string) funding transaction id necessary for next step.\n");
 
     Object result;
+
+    EnsureWalletIsUnlocked();
 
     CBitcoinAddress address = GetAccountAddress("reserved->" + params[0].get_str() );
     CKeyID keyID;
@@ -507,6 +511,8 @@ Value startmasternode(const Array& params, bool fHelp)
 
     std::string alias = params[0].get_str();
     bool deferRelay = (params.size() == 1)? false: params[1].get_bool();
+
+    EnsureWalletIsUnlocked();
 
     Object result;
     bool fFound = false;


### PR DESCRIPTION
Some of the masternode RPCs (those related to an owned masternode) require private keys from the local wallet.  For them, explicitly ensure the wallet is unlocked before proceeding.

Without this, the error message received by the user when the wallet is unlocked is confusing; with this change, they will get a clear message that the wallet needs to be unlocked (like they already do for e.g. `sendtoaddress`).