### PR TITLE
Store seedHash for masternodes on disk

### DIFF
--- a/divi/src/masternode-payments.h
+++ b/divi/src/masternode-payments.h
@@ -147,8 +147,13 @@ public:
         READWRITE(nBlockHeight);
         READWRITE(payee);
         READWRITE(vchSig);
-        if (ser_action.ForRead()) {
-            /* After parsing from a stream, the seedHash field is not set
+
+        if (nType == SER_DISK) {
+            /* For saving in the on-disk cache files, we include the
+               seed hash as well.  */
+            READWRITE(seedHash);
+        } else if (ser_action.ForRead()) {
+            /* After parsing from network, the seedHash field is not set
                and must not be accessed (e.g. through GetScoreHash) until
                ComputeScoreHash() has been called explicitly in a place
                that is convenient.  We do this (rather than computing here


### PR DESCRIPTION
When serialising a `CMasternodePaymentWinner` instance for on-disk storage (in the masternode caches), include the `seedHash` value.  Unlike network serialisation, it is fine to change the format for on-disk storage

Without this change, the entries might end up without `seedHash` and `assert` fail after being loaded from the cache (rather than being filled in and received over the wire, when the seedHash is explicitly computed).