### PR TITLE
Enforce C++11 and fix make_unique usage

### DIFF
--- a/divi/configure.ac
+++ b/divi/configure.ac
@@ -54,7 +54,10 @@ case $host in
   ;;
 esac
 dnl Require C++11 compiler (no GNU extensions)
+dnl We also want to enforce just C++11 (not allowing anything above,
+dnl like C++14-only features).
 AX_CXX_COMPILE_STDCXX([11], [noext], [mandatory])
+CXXFLAGS="${CXXFLAGS} -std=c++11"
 
 dnl Unless the user specified OBJCXX, force it to be the same as CXX. This ensures
 dnl that we get the same -std flags for both.

--- a/divi/src/rpcmining.cpp
+++ b/divi/src/rpcmining.cpp
@@ -256,7 +256,7 @@ public:
      *  on regtest meet the target always.  */
     void setCustomCoinstake(const CTransaction& tx)
     {
-        customCoinstake_ = std::make_unique<CTransaction>(tx);
+        customCoinstake_.reset(new CTransaction(tx));
     }
 
 };


### PR DESCRIPTION
This adds `-std=c++11` to the `CXXFLAGS`, to enforce that we want C++11 and no later standard.  Autoconf by itself would just look for something that supports C++11, but also accept later versions.

This in particular prevents accidental usage of `std::make_unique` from C++14, one instance of which is also fixed in this PR to bring the codebase back to working with C++11.