### PR TITLE
Fix deferred start/broadcast of masternodes

### DIFF
--- a/divi/qa/rpc-tests/mnoperation.py
+++ b/divi/qa/rpc-tests/mnoperation.py
@@ -158,7 +158,10 @@ class MnStatusTest (BitcoinTestFramework):
     # cold node online.
     self.nodes[0].startmasternode ("mn1")
     time.sleep (0.1)
-    self.nodes[0].startmasternode ("mn2")
+    broadcast = self.nodes[0].startmasternode ("mn2", True)
+    assert_equal (broadcast["status"], "success")
+    res = self.nodes[2].broadcaststartmasternode (broadcast["broadcastData"])
+    assert_equal (res["status"], "success")
     time.sleep (0.1)
     self.stop_node (0)
     time.sleep (0.1)

--- a/divi/src/activemasternode.cpp
+++ b/divi/src/activemasternode.cpp
@@ -169,28 +169,14 @@ bool CActiveMasternode::SendMasternodePing(std::string& errorMessage)
     }
 }
 
-bool CActiveMasternode::Register(
-    const CMasternodeConfig::CMasternodeEntry& configEntry,
-    std::string& errorMessage,
-    CMasternodeBroadcast& mnb,
-    bool deferRelay)
-{
-    if(!CMasternodeBroadcastFactory::Create(
-            configEntry,
-            errorMessage,
-            mnb,
-            false,
-            deferRelay))
-    {
-        return false;
-    }
-
-    addrman.Add(CAddress(mnb.addr), CNetAddr("127.0.0.1"), 2 * 60 * 60);
-    return Register(mnb,deferRelay);
-}
-
 bool CActiveMasternode::Register(CMasternodeBroadcast &mnb, bool deferRelay)
 {
+    int nDoS = 0;
+    if(!mnb.CheckAndUpdate(nDoS) || !mnb.CheckInputsAndAdd(nDoS))
+        return false;
+
+    addrman.Add(CAddress(mnb.addr), CNetAddr("127.0.0.1"), 2 * 60 * 60);
+
     auto mnp = mnb.lastPing;
     mnodeman.mapSeenMasternodePing.insert(std::make_pair(mnp.GetHash(), mnp));
 

--- a/divi/src/activemasternode.h
+++ b/divi/src/activemasternode.h
@@ -30,9 +30,6 @@ private:
     /// Ping Masternode
     bool SendMasternodePing(std::string& errorMessage);
 
-    /// Register any Masternode
-    static bool Register(CMasternodeBroadcast &mnb, bool deferRelay = false);
-
     CMasternodeConfig& masternodeConfigurations_;
 
     bool& fMasterNode_;
@@ -61,12 +58,8 @@ public:
     void ManageStatus();
     std::string GetStatus();
 
-    /// Register remote Masternode
-    static bool Register(
-        const CMasternodeConfig::CMasternodeEntry& configEntry,
-        std::string& errorMessage,
-        CMasternodeBroadcast& mnb,
-        bool deferRelay = false);
+    /// Register any Masternode
+    static bool Register(CMasternodeBroadcast &mnb, bool deferRelay = false);
 
     /// Enable cold wallet mode (run a Masternode with no funds)
     bool EnableHotColdMasterNode(CTxIn& vin, CService& addr);

--- a/divi/src/masternode.cpp
+++ b/divi/src/masternode.cpp
@@ -276,9 +276,9 @@ bool CMasternode::UpdateFromNewBroadcast(CMasternodeBroadcast& mnb)
         addr = mnb.addr;
         lastTimeChecked = 0;
         int nDoS = 0;
-        if (mnb.lastPing == CMasternodePing() || (mnb.lastPing != CMasternodePing() && mnb.lastPing.CheckAndUpdate(nDoS, false))) {
-            lastPing = mnb.lastPing;
-            mnodeman.mapSeenMasternodePing.insert(std::make_pair(lastPing.GetHash(), lastPing));
+        if (mnb.lastPing != CMasternodePing() && mnb.lastPing.CheckAndUpdate(*this, nDoS, false)) {
+            mnodeman.RecordSeenPing(lastPing);
+            lastPing.Relay();
         }
         return true;
     }
@@ -1048,36 +1048,38 @@ bool CMasternodePing::Sign(CKey& keyMasternode, CPubKey& pubKeyMasternode, bool 
     return true;
 }
 
-bool CMasternodePing::CheckAndUpdate(int& nDos, bool fRequireEnabled)
+bool CMasternodePing::CheckAndUpdate(CMasternode& mn, int& nDos, bool fRequireEnabled) const
 {
     if (sigTime > GetAdjustedTime() + 60 * 60) {
-        LogPrint("masternode","CMasternodePing::CheckAndUpdate - Signature rejected, too far into the future %s\n", vin.prevout.hash.ToString());
+        LogPrint("masternode", "%s - Signature rejected, too far into the future %s\n",
+                 __func__, vin.prevout.hash.ToString());
         nDos = 1;
         return false;
     }
 
     if (sigTime <= GetAdjustedTime() - 60 * 60) {
-        LogPrint("masternode","CMasternodePing::CheckAndUpdate - Signature rejected, too far into the past %s - %d %d \n", vin.prevout.hash.ToString(), sigTime, GetAdjustedTime());
+        LogPrint("masternode", "%s - Signature rejected, too far into the past %s - %d %d\n",
+                 __func__, vin.prevout.hash.ToString(), sigTime, GetAdjustedTime());
         nDos = 1;
         return false;
     }
 
-    LogPrint("masternode","CMasternodePing::CheckAndUpdate - New Ping - %s - %lli\n", blockHash.ToString(), sigTime);
+    LogPrint("masternode", "%s - New Ping - %s - %lli\n", __func__, blockHash.ToString(), sigTime);
 
     // see if we have this Masternode
-    CMasternode* pmn = mnodeman.Find(vin);
-    if (pmn != NULL && pmn->protocolVersion >= masternodePayments.GetMinMasternodePaymentsProto()) {
-        if (fRequireEnabled && !pmn->IsEnabled()) return false;
+    if (mn.protocolVersion >= masternodePayments.GetMinMasternodePaymentsProto()) {
+        if (fRequireEnabled && !mn.IsEnabled()) return false;
 
         // LogPrint("masternode","mnping - Found corresponding mn for vin: %s\n", vin.ToString());
         // update only if there is no known ping for this masternode or
         // last ping was more then MASTERNODE_MIN_MNP_SECONDS-60 ago comparing to this one
-        if (!pmn->IsPingedWithin(MASTERNODE_MIN_MNP_SECONDS - 60, sigTime)) {
+        if (!mn.IsPingedWithin(MASTERNODE_MIN_MNP_SECONDS - 60, sigTime)) {
             std::string strMessage = vin.ToString() + blockHash.ToString() + boost::lexical_cast<std::string>(sigTime);
 
             std::string errorMessage = "";
-            if (!CObfuScationSigner::VerifyMessage(pmn->pubKeyMasternode, vchSig, strMessage, errorMessage)) {
-                LogPrint("masternode","CMasternodePing::CheckAndUpdate - Got bad Masternode address signature %s\n", vin.prevout.hash.ToString());
+            if (!CObfuScationSigner::VerifyMessage(mn.pubKeyMasternode, vchSig, strMessage, errorMessage)) {
+                LogPrint("masternode", "%s - Got bad Masternode address signature %s\n",
+                         __func__, vin.prevout.hash.ToString());
                 nDos = 33;
                 return false;
             }
@@ -1085,42 +1087,38 @@ bool CMasternodePing::CheckAndUpdate(int& nDos, bool fRequireEnabled)
             BlockMap::iterator mi = mapBlockIndex.find(blockHash);
             if (mi != mapBlockIndex.end() && (*mi).second) {
                 if ((*mi).second->nHeight < chainActive.Height() - 24) {
-                    LogPrint("masternode","CMasternodePing::CheckAndUpdate - Masternode %s block hash %s is too old\n", vin.prevout.hash.ToString(), blockHash.ToString());
+                    LogPrint("masternode", "%s - Masternode %s block hash %s is too old\n",
+                             __func__, vin.prevout.hash.ToString(), blockHash.ToString());
                     // Do nothing here (no Masternode update, no mnping relay)
                     // Let this node to be visible but fail to accept mnping
 
                     return false;
                 }
             } else {
-                if (fDebug) LogPrint("masternode","CMasternodePing::CheckAndUpdate - Masternode %s block hash %s is unknown\n", vin.prevout.hash.ToString(), blockHash.ToString());
+                LogPrint("masternode", "%s - Masternode %s block hash %s is unknown\n",
+                         __func__, vin.prevout.hash.ToString(), blockHash.ToString());
                 // maybe we stuck so we shouldn't ban this node, just fail to accept it
                 // TODO: or should we also request this block?
 
                 return false;
             }
 
-            pmn->lastPing = *this;
+            mn.lastPing = *this;
 
-            //mnodeman.mapSeenMasternodeBroadcast.lastPing is probably outdated, so we'll update it
-            CMasternodeBroadcast mnb(*pmn);
-            uint256 hash = mnb.GetHash();
-            if (mnodeman.mapSeenMasternodeBroadcast.count(hash)) {
-                mnodeman.mapSeenMasternodeBroadcast[hash].lastPing = *this;
-            }
+            mn.Check(true);
+            if (!mn.IsEnabled()) return false;
 
-            pmn->Check(true);
-            if (!pmn->IsEnabled()) return false;
-
-            LogPrint("masternode", "CMasternodePing::CheckAndUpdate - Masternode ping accepted, vin: %s\n", vin.prevout.hash.ToString());
-
-            Relay();
+            LogPrint("masternode", "%s - Masternode ping accepted, vin: %s\n",
+                     __func__, vin.prevout.hash.ToString());
             return true;
         }
-        LogPrint("masternode", "CMasternodePing::CheckAndUpdate - Masternode ping arrived too early, vin: %s\n", vin.prevout.hash.ToString());
+        LogPrint("masternode", "%s - Masternode ping arrived too early, vin: %s\n",
+                 __func__, vin.prevout.hash.ToString());
         //nDos = 1; //disable, this is happening frequently and causing banned peers
         return false;
     }
-    LogPrint("masternode", "CMasternodePing::CheckAndUpdate - Couldn't find compatible Masternode entry, vin: %s\n", vin.prevout.hash.ToString());
+    LogPrint("masternode", "%s - Couldn't find compatible Masternode entry, vin: %s\n",
+             __func__, vin.prevout.hash.ToString());
 
     return false;
 }

--- a/divi/src/masternode.h
+++ b/divi/src/masternode.h
@@ -74,7 +74,10 @@ public:
         READWRITE(vchSig);
     }
 
-    bool CheckAndUpdate(int& nDos, bool fRequireEnabled = true);
+    /** Verifies if the ping is valid for the given masternode.
+     *  If it is, the method returns true and updates the last
+     *  ping stored with the masternode.  */
+    bool CheckAndUpdate(CMasternode& mn, int& nDos, bool fRequireEnabled = true) const;
     std::string getMessageToSign() const;
     bool Sign(CKey& keyMasternode, CPubKey& pubKeyMasternode, bool updateTimeBeforeSigning = true);
     void Relay();

--- a/divi/src/masternode.h
+++ b/divi/src/masternode.h
@@ -44,7 +44,7 @@ bool GetBlockHashForScoring(uint256& hash, int nBlockHeight);
 bool GetBlockHashForScoring(uint256& hash,
                             const CBlockIndex* pindex, const int offset);
 
-int GetInputAge(CTxIn& vin);
+int GetInputAge(const CTxIn& vin);
 
 //
 // The Masternode Ping Class : Contains a different serialize method for sending pings from masternodes throughout the network
@@ -259,7 +259,7 @@ public:
     CMasternodeBroadcast(const CMasternode& mn);
 
     bool CheckAndUpdate(int& nDoS);
-    bool CheckInputsAndAdd(int& nDos);
+    bool CheckInputs(int& nDos) const;
     bool Sign(CKey& keyCollateralAddress, bool updateTimeBeforeSigning = true);
     void Relay() const;
     std::string getMessageToSign() const;

--- a/divi/src/masternodeman.cpp
+++ b/divi/src/masternodeman.cpp
@@ -746,25 +746,6 @@ void CMasternodeMan::Remove(const CTxIn& vin)
     }
 }
 
-void CMasternodeMan::UpdateMasternodeList(CMasternodeBroadcast mnb)
-{
-    LOCK(cs);
-    mapSeenMasternodePing.insert(std::make_pair(mnb.lastPing.GetHash(), mnb.lastPing));
-    mapSeenMasternodeBroadcast.insert(std::make_pair(mnb.GetHash(), mnb));
-
-    LogPrint("masternode","CMasternodeMan::UpdateMasternodeList -- masternode=%s\n", mnb.vin.prevout.ToStringShort());
-
-    CMasternode* pmn = Find(mnb.vin);
-    if (pmn == NULL) {
-        CMasternode mn(mnb);
-        if (Add(mn)) {
-            masternodeSync.AddedMasternodeList(mnb.GetHash());
-        }
-    } else if (pmn->UpdateFromNewBroadcast(mnb)) {
-        masternodeSync.AddedMasternodeList(mnb.GetHash());
-    }
-}
-
 void
 CMasternodeMan::ResetRankingCache()
 {

--- a/divi/src/masternodeman.h
+++ b/divi/src/masternodeman.h
@@ -124,6 +124,15 @@ public:
 
     void ProcessMasternodeConnections();
 
+    /** Processes a masternode broadcast.  It is verified first, and then
+     *  the masternode updated or added accordingly.
+     *
+     *  If pfrom is null, we assume this is a startmasternode or broadcaststartmasternode
+     *  command.  Otherwise, we apply any potential DoS banscore.
+     *
+     *  Returns true if all was valid, and false if not.  */
+    bool ProcessBroadcast(CNode* pfrom, CMasternodeBroadcast& mnb);
+
     void ProcessMessage(CNode* pfrom, std::string& strCommand, CDataStream& vRecv);
 
     /// Return the number of (unique) Masternodes

--- a/divi/src/masternodeman.h
+++ b/divi/src/masternodeman.h
@@ -124,6 +124,14 @@ public:
 
     void ProcessMasternodeConnections();
 
+    /** Records a ping in the list of our seen ping messages, and also updates the
+     *  list of known broadcasts if the ping corresponds to one we know (i.e. updates
+     *  the ping contained in the seen broadcast).
+     *
+     *  This method assumes that the ping has already been checked and is valid.
+     */
+    void RecordSeenPing(const CMasternodePing& mnp);
+
     /** Processes a masternode broadcast.  It is verified first, and then
      *  the masternode updated or added accordingly.
      *
@@ -132,6 +140,15 @@ public:
      *
      *  Returns true if all was valid, and false if not.  */
     bool ProcessBroadcast(CNode* pfrom, CMasternodeBroadcast& mnb);
+
+    /** Processes a masternode ping.  It is verified first, and if valid,
+     *  used to update our state and inserted into mapSeenMasternodePing.
+     *
+     *  If pfrom is null, we assume this is from a local RPC command.  Otherwise
+     *  we apply potential DoS banscores.
+     *
+     *  Returns true if the ping message was valid.  */
+    bool ProcessPing(CNode* pfrom, CMasternodePing& mnp);
 
     void ProcessMessage(CNode* pfrom, std::string& strCommand, CDataStream& vRecv);
 

--- a/divi/src/masternodeman.h
+++ b/divi/src/masternodeman.h
@@ -145,9 +145,6 @@ public:
 
     void Remove(const CTxIn& vin);
 
-    /// Update masternode list and maps using provided CMasternodeBroadcast
-    void UpdateMasternodeList(CMasternodeBroadcast mnb);
-
     void ResetRankingCache();
 };
 


### PR DESCRIPTION
Deferred start of masternodes (with `startmasternode ALIAS true` and then `broadcaststartmasternode`) does not work properly if the `broadcaststartmasternode` RPC call happens on another node than the `startmasternode`.  While the broadcasting node does parse and verify the broadcast and even adds the masternode locally, it failed to insert the broadcast into `mapSeenMasternodeBroadcast`.  Hence it would send out an `inv` to its peers, but on request for the corresponding data, would not be able to find and relay it.

But going even further, there were three distinct places in the code for "starting masternodes":  `startmasternode`, `broadcaststartmasternode` and processing of received `mnb` messages.  All three of them should more or less do the same core logic, with only slight tweaks.  Thus, in this PR we unify most of the handling for all three into a new function `CMasternodeMan::ProcessBroadcast`.  This simplifies the code in general, and also makes sure to avoid subtle differences and bugs in the future.

Finally, the `mnoperation.py` regtest is extended to use deferred start for one of the two masternodes.  The modified test fails without the other code changes, and passes with them.