### PR TITLE
Run regtests with Python3

### DIFF
--- a/divi/qa/rpc-tests/PowToPosTransition.py
+++ b/divi/qa/rpc-tests/PowToPosTransition.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # Copyright (c) 2014 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.

--- a/divi/qa/rpc-tests/StakingVaultFunding.py
+++ b/divi/qa/rpc-tests/StakingVaultFunding.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # Copyright (c) 2014 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.

--- a/divi/qa/rpc-tests/bipdersig.py
+++ b/divi/qa/rpc-tests/bipdersig.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # Copyright (c) 2014 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.

--- a/divi/qa/rpc-tests/forknotify.py
+++ b/divi/qa/rpc-tests/forknotify.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # Copyright (c) 2014 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.

--- a/divi/qa/rpc-tests/getchaintips.py
+++ b/divi/qa/rpc-tests/getchaintips.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # Copyright (c) 2014 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.

--- a/divi/qa/rpc-tests/httpbasics.py
+++ b/divi/qa/rpc-tests/httpbasics.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # Copyright (c) 2014 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
@@ -30,13 +30,13 @@ class HTTPBasicsTest (BitcoinTestFramework):
         # lowlevel check for http persistent connection #
         #################################################
         url = urlparse.urlparse(self.nodes[0].url)
-        authpair = url.username + ':' + url.password
-        headers = {"Authorization": "Basic " + base64.b64encode(authpair)}
+        authpair = (url.username + ':' + url.password).encode("ascii")
+        headers = {"Authorization": "Basic " + base64.b64encode(authpair).decode("ascii")}
         
         conn = httplib.HTTPConnection(url.hostname, url.port)
         conn.connect()
         conn.request('POST', '/', '{"method": "getbestblockhash"}', headers)
-        out1 = conn.getresponse().read();
+        out1 = conn.getresponse().read().decode("ascii")
         assert_equal('"error":null' in out1, True)
         assert_equal(conn.sock!=None, True) #according to http/1.1 connection must still be open!
         
@@ -48,53 +48,59 @@ class HTTPBasicsTest (BitcoinTestFramework):
         conn.close()
         
         #same should be if we add keep-alive because this should be the std. behaviour
-        headers = {"Authorization": "Basic " + base64.b64encode(authpair), "Connection": "keep-alive"}
+        headers = {
+            "Authorization": "Basic " + base64.b64encode(authpair).decode("ascii"),
+            "Connection": "keep-alive",
+        }
         
         conn = httplib.HTTPConnection(url.hostname, url.port)
         conn.connect()
         conn.request('POST', '/', '{"method": "getbestblockhash"}', headers)
-        out1 = conn.getresponse().read();
+        out1 = conn.getresponse().read().decode("ascii")
         assert_equal('"error":null' in out1, True)
         assert_equal(conn.sock!=None, True) #according to http/1.1 connection must still be open!
         
         #send 2nd request without closing connection
         conn.request('POST', '/', '{"method": "getchaintips"}', headers)
-        out2 = conn.getresponse().read();
+        out2 = conn.getresponse().read().decode("ascii")
         assert_equal('"error":null' in out1, True) #must also response with a correct json-rpc message
         assert_equal(conn.sock!=None, True) #according to http/1.1 connection must still be open!
         conn.close()
         
         #now do the same with "Connection: close"
-        headers = {"Authorization": "Basic " + base64.b64encode(authpair), "Connection":"close"}
+        headers = {
+            "Authorization": "Basic " + base64.b64encode(authpair).decode("ascii"),
+            "Connection":"close",
+        }
         
         conn = httplib.HTTPConnection(url.hostname, url.port)
         conn.connect()
         conn.request('POST', '/', '{"method": "getbestblockhash"}', headers)
-        out1 = conn.getresponse().read();
+        out1 = conn.getresponse().read().decode("ascii")
         assert_equal('"error":null' in out1, True)
         assert_equal(conn.sock!=None, False) #now the connection must be closed after the response        
         
         #node1 (2nd node) is running with disabled keep-alive option
         urlNode1 = urlparse.urlparse(self.nodes[1].url)
-        authpair = urlNode1.username + ':' + urlNode1.password
-        headers = {"Authorization": "Basic " + base64.b64encode(authpair)}
+        authpair = (urlNode1.username + ':' + urlNode1.password).encode("ascii")
+        headers = {"Authorization": "Basic " + base64.b64encode(authpair).decode("ascii")}
                 
         conn = httplib.HTTPConnection(urlNode1.hostname, urlNode1.port)
         conn.connect()
         conn.request('POST', '/', '{"method": "getbestblockhash"}', headers)
-        out1 = conn.getresponse().read();
+        out1 = conn.getresponse().read().decode("ascii")
         assert_equal('"error":null' in out1, True)
         assert_equal(conn.sock!=None, False) #connection must be closed because keep-alive was set to false
         
         #node2 (third node) is running with standard keep-alive parameters which means keep-alive is off
         urlNode2 = urlparse.urlparse(self.nodes[2].url)
-        authpair = urlNode2.username + ':' + urlNode2.password
-        headers = {"Authorization": "Basic " + base64.b64encode(authpair)}
+        authpair = (urlNode2.username + ':' + urlNode2.password).encode("ascii")
+        headers = {"Authorization": "Basic " + base64.b64encode(authpair).decode("ascii")}
                 
         conn = httplib.HTTPConnection(urlNode2.hostname, urlNode2.port)
         conn.connect()
         conn.request('POST', '/', '{"method": "getbestblockhash"}', headers)
-        out1 = conn.getresponse().read();
+        out1 = conn.getresponse().read().decode("ascii")
         assert_equal('"error":null' in out1, True)
         assert_equal(conn.sock!=None, True) #connection must be closed because bitcoind should use keep-alive by default
         

--- a/divi/qa/rpc-tests/invalidateblock.py
+++ b/divi/qa/rpc-tests/invalidateblock.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # Copyright (c) 2014 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
@@ -21,46 +21,46 @@ class InvalidateTest(BitcoinTestFramework):
         self.nodes.append(start_node(2, self.options.tmpdir, ["-debug"]))
         
     def run_test(self):
-        print "Make sure we repopulate setBlockIndexCandidates after InvalidateBlock:"
-        print "Mine 4 blocks on Node 0"
+        print("Make sure we repopulate setBlockIndexCandidates after InvalidateBlock:")
+        print("Mine 4 blocks on Node 0")
         self.nodes[0].setgenerate(True, 4)
         assert(self.nodes[0].getblockcount() == 4)
         besthash = self.nodes[0].getbestblockhash()
 
-        print "Mine competing 6 blocks on Node 1"
+        print("Mine competing 6 blocks on Node 1")
         self.nodes[1].setgenerate(True, 6)
         assert(self.nodes[1].getblockcount() == 6)
 
-        print "Connect nodes to force a reorg"
+        print("Connect nodes to force a reorg")
         connect_nodes_bi(self.nodes,0,1)
         sync_blocks(self.nodes[0:2])
         assert(self.nodes[0].getblockcount() == 6)
         badhash = self.nodes[1].getblockhash(2)
 
-        print "Invalidate block 2 on node 0 and verify we reorg to node 0's original chain"
+        print("Invalidate block 2 on node 0 and verify we reorg to node 0's original chain")
         self.nodes[0].invalidateblock(badhash)
         newheight = self.nodes[0].getblockcount()
         newhash = self.nodes[0].getbestblockhash()
         if (newheight != 4 or newhash != besthash):
             raise AssertionError("Wrong tip for node0, hash %s, height %d"%(newhash,newheight))
 
-        print "\nMake sure we won't reorg to a lower work chain:"
+        print("\nMake sure we won't reorg to a lower work chain:")
         connect_nodes_bi(self.nodes,1,2)
-        print "Sync node 2 to node 1 so both have 6 blocks"
+        print("Sync node 2 to node 1 so both have 6 blocks")
         sync_blocks(self.nodes[1:3])
         assert(self.nodes[2].getblockcount() == 6)
-        print "Invalidate block 5 on node 1 so its tip is now at 4"
+        print("Invalidate block 5 on node 1 so its tip is now at 4")
         self.nodes[1].invalidateblock(self.nodes[1].getblockhash(5))
         assert(self.nodes[1].getblockcount() == 4)
-        print "Invalidate block 3 on node 2, so its tip is now 2"
+        print("Invalidate block 3 on node 2, so its tip is now 2")
         self.nodes[2].invalidateblock(self.nodes[2].getblockhash(3))
         assert(self.nodes[2].getblockcount() == 2)
-        print "..and then mine a block"
+        print("..and then mine a block")
         self.nodes[2].setgenerate(True, 1)
-        print "Verify all nodes are at the right height"
+        print("Verify all nodes are at the right height")
         time.sleep(5)
-        for i in xrange(3):
-            print i,self.nodes[i].getblockcount()
+        for i in range(3):
+            print(i,self.nodes[i].getblockcount())
         assert(self.nodes[2].getblockcount() == 3)
         assert(self.nodes[0].getblockcount() == 4)
         node1height = self.nodes[1].getblockcount()

--- a/divi/qa/rpc-tests/keypool.py
+++ b/divi/qa/rpc-tests/keypool.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # Copyright (c) 2014 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
@@ -61,7 +61,7 @@ class KeypoolTest (BitcoinTestFramework):
         try:
             addr = node.getnewaddress()
             raise AssertionError('Keypool should be exhausted after one address')
-        except JSONRPCException,e:
+        except JSONRPCException as e:
             assert(e.error['code']==-12)
 
         # put three new keys in the keypool
@@ -84,7 +84,7 @@ class KeypoolTest (BitcoinTestFramework):
         try:
             addr = node.getrawchangeaddress()
             raise AssertionError('Keypool should be exhausted after three addresses')
-        except JSONRPCException,e:
+        except JSONRPCException as e:
             assert(e.error['code']==-12)
         assert_equal(node.getwalletinfo()["keypoolsize"], 3)
 
@@ -97,7 +97,7 @@ class KeypoolTest (BitcoinTestFramework):
         try:
             addr = node.getnewaddress()
             raise AssertionError('Keypool should be exhausted after three addresses')
-        except JSONRPCException,e:
+        except JSONRPCException as e:
             assert(e.error['code']==-12)
         assert_equal(node.getwalletinfo()["keypoolsize"], 0)
 

--- a/divi/qa/rpc-tests/listtransactions.py
+++ b/divi/qa/rpc-tests/listtransactions.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # Copyright (c) 2014 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.

--- a/divi/qa/rpc-tests/mempool_coinbase_spends.py
+++ b/divi/qa/rpc-tests/mempool_coinbase_spends.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # Copyright (c) 2014 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.

--- a/divi/qa/rpc-tests/mempool_resurrect_test.py
+++ b/divi/qa/rpc-tests/mempool_resurrect_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # Copyright (c) 2014 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.

--- a/divi/qa/rpc-tests/mempool_spendcoinbase.py
+++ b/divi/qa/rpc-tests/mempool_spendcoinbase.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # Copyright (c) 2014 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.

--- a/divi/qa/rpc-tests/mncollateral.py
+++ b/divi/qa/rpc-tests/mncollateral.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # Copyright (c) 2020 The DIVI developers
 # Distributed under the MIT/X11 software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.

--- a/divi/qa/rpc-tests/mnoperation.py
+++ b/divi/qa/rpc-tests/mnoperation.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # Copyright (c) 2020 The DIVI developers
 # Distributed under the MIT/X11 software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
@@ -26,7 +26,7 @@ import time
 class MnStatusTest (BitcoinTestFramework):
 
   def __init__ (self):
-    super (MnStatusTest, self).__init__ ()
+    super ().__init__ ()
     self.base_args = ["-debug"]
 
   def setup_chain (self):

--- a/divi/qa/rpc-tests/netutil.py
+++ b/divi/qa/rpc-tests/netutil.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python2
 # Copyright (c) 2014 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
@@ -45,7 +44,7 @@ def _convert_ip_port(array):
     # convert host from mangled-per-four-bytes form as used by kernel
     host = binascii.unhexlify(host)
     host_out = ''
-    for x in range(0, len(host)/4):
+    for x in range(0, len(host)//4):
         (val,) = struct.unpack('=I', host[x*4:(x+1)*4])
         host_out += '%08x' % val
 
@@ -94,7 +93,7 @@ def all_interfaces():
     max_possible = 8 # initial value
     while True:
         bytes = max_possible * struct_size
-        names = array.array('B', '\0' * bytes)
+        names = array.array('B', b'\0' * bytes)
         outbytes = struct.unpack('iL', fcntl.ioctl(
             s.fileno(),
             0x8912,  # SIOCGIFCONF
@@ -104,8 +103,8 @@ def all_interfaces():
             max_possible *= 2
         else:
             break
-    namestr = names.tostring()
-    return [(namestr[i:i+16].split('\0', 1)[0],
+    namestr = names.tobytes()
+    return [(namestr[i:i+16].split(b'\0', 1)[0],
              socket.inet_ntoa(namestr[i+20:i+24]))
             for i in range(0, outbytes, struct_size)]
 
@@ -136,4 +135,4 @@ def addr_to_hex(addr):
         addr = sub[0] + ([0] * nullbytes) + sub[1]
     else:
         raise ValueError('Could not parse address %s' % addr)
-    return binascii.hexlify(bytearray(addr))
+    return bytearray(addr).hex()

--- a/divi/qa/rpc-tests/proxy_test.py
+++ b/divi/qa/rpc-tests/proxy_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # Copyright (c) 2015 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.

--- a/divi/qa/rpc-tests/rawtransactions.py
+++ b/divi/qa/rpc-tests/rawtransactions.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # Copyright (c) 2020 The Divi developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.

--- a/divi/qa/rpc-tests/receivedby.py
+++ b/divi/qa/rpc-tests/receivedby.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # Copyright (c) 2014 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.

--- a/divi/qa/rpc-tests/reindex.py
+++ b/divi/qa/rpc-tests/reindex.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # Copyright (c) 2014 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
@@ -28,7 +28,7 @@ class ReindexTest(BitcoinTestFramework):
         wait_bitcoinds()
         self.nodes[0]=start_node(0, self.options.tmpdir, ["-debug", "-reindex", "-checkblockindex=1"])
         assert_equal(self.nodes[0].getblockcount(), 3)
-        print "Success"
+        print ("Success")
 
 if __name__ == '__main__':
     ReindexTest().main()

--- a/divi/qa/rpc-tests/remotestart.py
+++ b/divi/qa/rpc-tests/remotestart.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # Copyright (c) 2020 The DIVI developers
 # Distributed under the MIT/X11 software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
@@ -26,7 +26,7 @@ import time
 class MnRemoteStartTest (BitcoinTestFramework):
 
   def __init__ (self):
-    super (MnRemoteStartTest, self).__init__ ()
+    super ().__init__ ()
     self.base_args = ["-debug"]
 
   def setup_chain (self):

--- a/divi/qa/rpc-tests/rest.py
+++ b/divi/qa/rpc-tests/rest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # Copyright (c) 2014 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.

--- a/divi/qa/rpc-tests/rpcbind_test.py
+++ b/divi/qa/rpc-tests/rpcbind_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # Copyright (c) 2014 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
@@ -66,7 +66,7 @@ class RpcBindTest(BitcoinTestFramework):
             wait_bitcoinds()
 
     def run_test(self):
-        assert(sys.platform == 'linux2') # due to OS-specific network stats queries, this test works only on Linux
+        assert(sys.platform == 'linux') # due to OS-specific network stats queries, this test works only on Linux
         # find the first non-loopback interface for testing
         non_loopback_ip = None
         for name,ip in all_interfaces():
@@ -109,7 +109,7 @@ class RpcBindTest(BitcoinTestFramework):
         try:
             self.run_allowip_test(['1.1.1.1'], non_loopback_ip, defaultport)
             assert(not 'Connection not denied by rpcallowip as expected')
-        except ValueError:
+        except JSONRPCException:
             pass
 
 

--- a/divi/qa/rpc-tests/smartfees.py
+++ b/divi/qa/rpc-tests/smartfees.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # Copyright (c) 2014 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.

--- a/divi/qa/rpc-tests/socks5.py
+++ b/divi/qa/rpc-tests/socks5.py
@@ -5,7 +5,7 @@
 Dummy Socks5 server for testing.
 '''
 from __future__ import print_function, division, unicode_literals
-import socket, threading, Queue
+import socket, threading, queue
 import traceback, sys
 
 ### Protocol constants
@@ -99,12 +99,12 @@ class Socks5Connection(object):
                 raise IOError('Unhandled command %i in connect request' % cmd)
 
             if atyp == AddressType.IPV4:
-                addr = recvall(self.conn, 4)
+                addr = recvall(self.conn, 4).decode("ascii")
             elif atyp == AddressType.DOMAINNAME:
                 n = recvall(self.conn, 1)[0]
-                addr = str(recvall(self.conn, n))
+                addr = recvall(self.conn, n).decode("ascii")
             elif atyp == AddressType.IPV6:
-                addr = recvall(self.conn, 16)
+                addr = recvall(self.conn, 16).decode("ascii")
             else:
                 raise IOError('Unknown address type %i' % atyp)
             port_hi,port_lo = recvall(self.conn, 2)
@@ -117,7 +117,7 @@ class Socks5Connection(object):
             self.serv.queue.put(cmdin)
             print('Proxy: ', cmdin)
             # Fall through to disconnect
-        except Exception,e:
+        except Exception as e:
             traceback.print_exc(file=sys.stderr)
             self.serv.queue.put(e)
         finally:
@@ -132,7 +132,7 @@ class Socks5Server(object):
         self.s.listen(5)
         self.running = False
         self.thread = None
-        self.queue = Queue.Queue() # report connections and exceptions to client
+        self.queue = queue.Queue() # report connections and exceptions to client
 
     def run(self):
         while self.running:

--- a/divi/qa/rpc-tests/sync.py
+++ b/divi/qa/rpc-tests/sync.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # Copyright (c) 2014 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
@@ -14,7 +14,7 @@ import os
 import shutil
 import random
 from threading import Thread
-from Queue import Queue
+from queue import Queue
 
 def mineSingleBlock(miningQueue):
     while not miningQueue.empty():

--- a/divi/qa/rpc-tests/test_framework.py
+++ b/divi/qa/rpc-tests/test_framework.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python2
 # Copyright (c) 2014 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.

--- a/divi/qa/rpc-tests/txn_doublespend.py
+++ b/divi/qa/rpc-tests/txn_doublespend.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # Copyright (c) 2014 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.

--- a/divi/qa/rpc-tests/util.py
+++ b/divi/qa/rpc-tests/util.py
@@ -117,7 +117,13 @@ def start_node(i, dirname, extra_args=None, mn_config_lines=[], rpchost=None):
                           _rpchost_to_args(rpchost)  +
                           ["-rpcwait", "getblockcount"], stdout=devnull)
     devnull.close()
-    url = "http://rt:rt@%s:%d" % (rpchost or '127.0.0.1', rpc_port(i))
+    url = "http://rt:rt@"
+    if rpchost and re.match(".*:\\d+$", rpchost):
+      url += rpchost
+    elif rpchost:
+      url += "%s:%d" % (rpchost, rpc_port(i))
+    else:
+      url += "127.0.0.1:%d" % rpc_port(i)
     proxy = AuthServiceProxy(url)
     proxy.url = url # store URL on proxy for info
     return proxy

--- a/divi/qa/rpc-tests/wallet.py
+++ b/divi/qa/rpc-tests/wallet.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # Copyright (c) 2014 The Bitcoin Core developers
 # Distributed under the MIT/X11 software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
@@ -34,7 +34,7 @@ class WalletTest (BitcoinTestFramework):
         self.sync_all()
 
     def run_test (self):
-        print "Mining blocks..."
+        print ("Mining blocks...")
 
         self.nodes[0].setgenerate(True, 2)
 

--- a/divi/qa/rpc-tests/walletbackup.py
+++ b/divi/qa/rpc-tests/walletbackup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # Copyright (c) 2014 The Bitcoin Core developers
 # Distributed under the MIT/X11 software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.

--- a/divi/qa/rpc-tests/zapwallettxes.py
+++ b/divi/qa/rpc-tests/zapwallettxes.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # Copyright (c) 2014 The Bitcoin Core developers
 # Copyright (c) 2020 The DIVI developers
 # Distributed under the MIT/X11 software license, see the accompanying

--- a/divi/qa/rpc-tests/zmq_test.py
+++ b/divi/qa/rpc-tests/zmq_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # Copyright (c) 2015 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
@@ -10,7 +10,6 @@
 from test_framework import BitcoinTestFramework
 from util import *
 import zmq
-import binascii
 
 try:
     import http.client as httplib
@@ -20,9 +19,6 @@ try:
     import urllib.parse as urlparse
 except ImportError:
     import urlparse
-
-def bytes_to_hex_str(val):
-    return binascii.hexlify(val)
 
 class ZMQTest (BitcoinTestFramework):
 
@@ -47,7 +43,7 @@ class ZMQTest (BitcoinTestFramework):
         genhashes = self.nodes[0].setgenerate(True, 1)
         self.sync_all()
 
-        print "listen..."
+        print ("listen...")
         msg = self.zmqSubSocket.recv_multipart()
         topic = msg[0]
         body = msg[1]
@@ -55,7 +51,7 @@ class ZMQTest (BitcoinTestFramework):
         msg = self.zmqSubSocket.recv_multipart()
         topic = msg[0]
         body = msg[1]
-        blkhash = bytes_to_hex_str(body)
+        blkhash = body.hex()
 
         assert_equal(genhashes[0], blkhash) #blockhash from generate must be equal to the hash received over zmq
 
@@ -69,7 +65,7 @@ class ZMQTest (BitcoinTestFramework):
             topic = msg[0]
             body = msg[1]
             if topic == b"hashblock":
-                zmqHashes.append(bytes_to_hex_str(body))
+                zmqHashes.append(body.hex())
 
         for x in range(0,n):
             assert_equal(genhashes[x], zmqHashes[x]) #blockhash from generate must be equal to the hash received over zmq
@@ -84,7 +80,7 @@ class ZMQTest (BitcoinTestFramework):
         body = msg[1]
         hashZMQ = ""
         if topic == b"hashtx":
-            hashZMQ = bytes_to_hex_str(body)
+            hashZMQ = body.hex()
 
         assert_equal(hashRPC, hashZMQ) #tx hash from the RPC must be equal to the hash received over zmq
 


### PR DESCRIPTION
Change all of the regtests to run with Python3 instead of Python2.  Most of the files just needed updating the shebang line or trivial changes.  The more complex instances were related to the difference that Python3 makes between `bytes` and `str`.