### PR TITLE
Regtest for OP_META

### DIFF
--- a/divi/qa/rpc-tests/messages.py
+++ b/divi/qa/rpc-tests/messages.py
@@ -1,0 +1,295 @@
+# Copyright (c) 2010 ArtForz -- public domain half-a-node
+# Copyright (c) 2012 Jeff Garzik
+# Copyright (c) 2010-2020 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test framework primitive and message structures
+
+CBlock, CTransaction, CBlockHeader, CTxIn, CTxOut, etc....:
+    data structures that should map to corresponding structures in
+    bitcoin/primitives
+
+ser_*, deser_*: functions that handle serialization/deserialization.
+
+Classes use __slots__ to ensure extraneous attributes aren't accidentally added
+by tests, compromising their intended effect.
+"""
+import binascii
+from codecs import encode
+import copy
+import hashlib
+from io import BytesIO
+import math
+import random
+import socket
+import struct
+import time
+
+COIN = 100000000  # 1 coin in satoshis
+
+# Serialization/deserialization tools
+def sha256(s):
+    return hashlib.new('sha256', s).digest()
+
+def hash256(s):
+    return sha256(sha256(s))
+
+def ser_compact_size(l):
+    r = b""
+    if l < 253:
+        r = struct.pack("B", l)
+    elif l < 0x10000:
+        r = struct.pack("<BH", 253, l)
+    elif l < 0x100000000:
+        r = struct.pack("<BI", 254, l)
+    else:
+        r = struct.pack("<BQ", 255, l)
+    return r
+
+def deser_compact_size(f):
+    nit = struct.unpack("<B", f.read(1))[0]
+    if nit == 253:
+        nit = struct.unpack("<H", f.read(2))[0]
+    elif nit == 254:
+        nit = struct.unpack("<I", f.read(4))[0]
+    elif nit == 255:
+        nit = struct.unpack("<Q", f.read(8))[0]
+    return nit
+
+def deser_string(f):
+    nit = deser_compact_size(f)
+    return f.read(nit)
+
+def ser_string(s):
+    return ser_compact_size(len(s)) + s
+
+def deser_uint256(f):
+    r = 0
+    for i in range(8):
+        t = struct.unpack("<I", f.read(4))[0]
+        r += t << (i * 32)
+    return r
+
+
+def ser_uint256(u):
+    rs = b""
+    for _ in range(8):
+        rs += struct.pack("<I", u & 0xFFFFFFFF)
+        u >>= 32
+    return rs
+
+
+def uint256_from_str(s):
+    r = 0
+    t = struct.unpack("<IIIIIIII", s[:32])
+    for i in range(8):
+        r += t[i] << (i * 32)
+    return r
+
+
+def uint256_from_compact(c):
+    nbytes = (c >> 24) & 0xFF
+    v = (c & 0xFFFFFF) << (8 * (nbytes - 3))
+    return v
+
+
+# deser_function_name: Allow for an alternate deserialization function on the
+# entries in the vector.
+def deser_vector(f, c, deser_function_name=None):
+    nit = deser_compact_size(f)
+    r = []
+    for _ in range(nit):
+        t = c()
+        if deser_function_name:
+            getattr(t, deser_function_name)(f)
+        else:
+            t.deserialize(f)
+        r.append(t)
+    return r
+
+
+# ser_function_name: Allow for an alternate serialization function on the
+# entries in the vector (we use this for serializing the vector of transactions
+# for a witness block).
+def ser_vector(l, ser_function_name=None):
+    r = ser_compact_size(len(l))
+    for i in l:
+        if ser_function_name:
+            r += getattr(i, ser_function_name)()
+        else:
+            r += i.serialize()
+    return r
+
+
+def deser_uint256_vector(f):
+    nit = deser_compact_size(f)
+    r = []
+    for _ in range(nit):
+        t = deser_uint256(f)
+        r.append(t)
+    return r
+
+
+def ser_uint256_vector(l):
+    r = ser_compact_size(len(l))
+    for i in l:
+        r += ser_uint256(i)
+    return r
+
+
+def deser_string_vector(f):
+    nit = deser_compact_size(f)
+    r = []
+    for _ in range(nit):
+        t = deser_string(f)
+        r.append(t)
+    return r
+
+
+def ser_string_vector(l):
+    r = ser_compact_size(len(l))
+    for sv in l:
+        r += ser_string(sv)
+    return r
+
+
+# Deserialize from a hex string representation (eg from RPC)
+def FromHex(obj, hex_string):
+    obj.deserialize(BytesIO(binascii.unhexlify(hex_string)))
+    return obj
+
+# Convert a binary-serializable object to hex (eg for submission via RPC)
+def ToHex(obj):
+    return obj.serialize().hex()
+
+# Objects that map to divid objects, which can be serialized/deserialized
+
+
+class COutPoint:
+    __slots__ = ("hash", "n")
+
+    def __init__(self, txid="", hash=0, n=0):
+        if hash:
+          self.hash = hash
+        elif txid:
+          self.hash = int (txid, 16)
+        else:
+          self.hash = 0
+        self.n = n
+
+    def deserialize(self, f):
+        self.hash = deser_uint256(f)
+        self.n = struct.unpack("<I", f.read(4))[0]
+
+    def serialize(self):
+        r = b""
+        r += ser_uint256(self.hash)
+        r += struct.pack("<I", self.n)
+        return r
+
+    def __repr__(self):
+        return "COutPoint(hash=%064x n=%i)" % (self.hash, self.n)
+
+
+class CTxIn:
+    __slots__ = ("nSequence", "prevout", "scriptSig")
+
+    def __init__(self, outpoint=None, scriptSig=b"", nSequence=0):
+        if outpoint is None:
+            self.prevout = COutPoint()
+        else:
+            self.prevout = outpoint
+        self.scriptSig = scriptSig
+        self.nSequence = nSequence
+
+    def deserialize(self, f):
+        self.prevout = COutPoint()
+        self.prevout.deserialize(f)
+        self.scriptSig = deser_string(f)
+        self.nSequence = struct.unpack("<I", f.read(4))[0]
+
+    def serialize(self):
+        r = b""
+        r += self.prevout.serialize()
+        r += ser_string(self.scriptSig)
+        r += struct.pack("<I", self.nSequence)
+        return r
+
+    def __repr__(self):
+        return "CTxIn(prevout=%s scriptSig=%s nSequence=%i)" \
+            % (repr(self.prevout), binascii.hexlify(self.scriptSig),
+               self.nSequence)
+
+
+class CTxOut:
+    __slots__ = ("nValue", "scriptPubKey")
+
+    def __init__(self, nValue=0, scriptPubKey=b""):
+        self.nValue = nValue
+        self.scriptPubKey = scriptPubKey
+
+    def deserialize(self, f):
+        self.nValue = struct.unpack("<q", f.read(8))[0]
+        self.scriptPubKey = deser_string(f)
+
+    def serialize(self):
+        r = b""
+        r += struct.pack("<q", self.nValue)
+        r += ser_string(self.scriptPubKey)
+        return r
+
+    def __repr__(self):
+        return "CTxOut(nValue=%i.%08i scriptPubKey=%s)" \
+            % (self.nValue // COIN, self.nValue % COIN,
+               binascii.hexlify(self.scriptPubKey))
+
+
+class CTransaction:
+    __slots__ = ("hash", "nLockTime", "nVersion", "sha256", "vin", "vout")
+
+    def __init__(self, tx=None):
+        if tx is None:
+            self.nVersion = 1
+            self.vin = []
+            self.vout = []
+            self.nLockTime = 0
+            self.sha256 = None
+            self.hash = None
+        else:
+            self.nVersion = tx.nVersion
+            self.vin = copy.deepcopy(tx.vin)
+            self.vout = copy.deepcopy(tx.vout)
+            self.nLockTime = tx.nLockTime
+            self.sha256 = tx.sha256
+            self.hash = tx.hash
+
+    def deserialize(self, f):
+        self.nVersion = struct.unpack("<i", f.read(4))[0]
+        self.vin = deser_vector(f, CTxIn)
+        self.vout = deser_vector(f, CTxOut)
+        self.nLockTime = struct.unpack("<I", f.read(4))[0]
+        self.sha256 = None
+        self.hash = None
+
+    def serialize(self):
+        r = b""
+        r += struct.pack("<i", self.nVersion)
+        r += ser_vector(self.vin)
+        r += ser_vector(self.vout)
+        r += struct.pack("<I", self.nLockTime)
+        return r
+
+    # Recalculate the txid
+    def rehash(self):
+        self.sha256 = None
+        self.calc_sha256()
+        return self.hash
+
+    def calc_sha256(self):
+        if self.sha256 is None:
+            self.sha256 = uint256_from_str(hash256(self.serialize()))
+        self.hash = encode(hash256(self.serialize())[::-1], 'hex_codec').decode('ascii')
+
+    def __repr__(self):
+        return "CTransaction(nVersion=%i vin=%s vout=%s nLockTime=%i)" \
+            % (self.nVersion, repr(self.vin), repr(self.vout), self.nLockTime)

--- a/divi/qa/rpc-tests/op_meta.py
+++ b/divi/qa/rpc-tests/op_meta.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+# Copyright (c) 2020 The DIVI developers
+# Distributed under the MIT/X11 software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+# Tests basic behaviour (standardness, fees) of OP_META transactions.
+
+from test_framework import BitcoinTestFramework
+from authproxy import JSONRPCException
+from messages import *
+from util import *
+from script import *
+from PowToPosTransition import createPoSStacks, generatePoSBlocks
+
+import codecs
+from decimal import Decimal
+
+
+class OpMetaTest (BitcoinTestFramework):
+
+    def setup_network (self, split=False):
+        args = ["-debug"]
+        self.nodes = start_nodes (1, self.options.tmpdir, extra_args=[args])
+        self.node = self.nodes[0]
+        self.is_network_split = False
+
+    def build_op_meta_tx (self, utxos, payload, fee):
+        """
+        Builds a transaction with an OP_META output that has the given
+        payload data (byte string) and the given absolute fee.  We use
+        one of the UTXOs from the passed-in list (as per listunspent)
+        and remove it from the list. Returned is the constructed transaction
+        as hex string.
+
+        Before actually building the OP_META transaction, the chosen UTXO
+        will be spent in a normal transaction first; this ensures that the
+        resulting OP_META transaction does not have any "priority" and will
+        not be accepted as a free transaction (i.e. that we can test proper
+        fee requirements for it).
+        """
+
+        if type (payload) != list:
+          payload = [payload]
+
+        required = Decimal ('1.00000000') + fee
+        inp = None
+        for i in range (len (utxos)):
+          if utxos[i]["amount"] >= required:
+            inp = utxos[i]
+            del utxos[i]
+            break
+        assert inp is not None, "found no suitable output"
+
+        # Spend the chosen output back to us to create a low-priority
+        # input for the actual transaction.
+        change = Decimal (inp["amount"]) - fee
+        assert_greater_than (change, 0)
+        changeAddr = self.node.getnewaddress ()
+        tx = self.node.createrawtransaction ([inp], {changeAddr: change})
+        signed = self.node.signrawtransaction (tx)
+        assert_equal (signed["complete"], True)
+        txid = self.node.sendrawtransaction (signed["hex"])
+        inp["txid"] = txid
+        inp["vout"] = 0
+        inp["amount"] = change
+
+        # Now build the actual OP_META transaction.
+        change = int ((Decimal (inp["amount"]) - fee) * COIN)
+        assert_greater_than (change, 0)
+        changeAddr = self.node.getnewaddress ()
+        data = self.node.validateaddress (changeAddr)
+
+        tx = CTransaction ()
+        tx.vin.append (CTxIn (COutPoint (txid=inp["txid"], n=inp["vout"])))
+        tx.vout.append (CTxOut (change, codecs.decode (data["scriptPubKey"], "hex")))
+
+        for p in payload:
+          meta = CScript ([OP_META, p])
+          tx.vout.append (CTxOut (0, meta))
+
+        unsigned = tx.serialize ().hex ()
+        signed = self.node.signrawtransaction (unsigned)
+        assert_equal (signed["complete"], True)
+
+        decoded = self.node.decoderawtransaction (signed["hex"])
+
+        return signed["hex"], decoded["txid"]
+
+    def check_confirmed (self, txid):
+        if type (txid) == list:
+          for t in txid:
+            self.check_confirmed (t)
+          return
+
+        assert_greater_than (self.node.gettransaction (txid)["confirmations"], 0)
+
+    def find_min_fee (self, utxos, payload):
+        """
+        Runs a binary search on what fee is needed to accept
+        an OP_META transaction with one of the UTXOs and the
+        given payload.
+        """
+
+        def is_sufficient (fee):
+          tx, _ = self.build_op_meta_tx (utxos, payload, fee)
+          try:
+            self.node.sendrawtransaction (tx)
+            return True
+          except JSONRPCException as exc:
+            assert_equal (exc.error["code"], -26)
+            return False
+
+        eps = Decimal ('0.00000001')
+        lower = eps
+        while not is_sufficient (2 * lower):
+          lower *= 2
+        upper = 2 * lower
+
+        while upper - lower > eps:
+          mid = ((upper + lower) / 2).quantize (eps)
+          assert mid > lower
+          assert upper > mid
+          if is_sufficient (mid):
+            upper = mid
+          else:
+            lower = mid
+
+        return upper
+
+    def run_test (self):
+        # Advance to PoS blocks to make sure we have the correct
+        # fee rules active.
+        print ("Advancing to PoS blocks...")
+        createPoSStacks ([self.node], self.nodes)
+        generatePoSBlocks (self.nodes, 0, 100)
+
+        # Test sending OP_META transactions with a size around the limit
+        # for being a standard transaction.  Larger ones are still valid
+        # for inside a block, just not accepted to the mempool by default.
+        print ("Testing OP_META standardness size limit...")
+        utxos = self.node.listunspent ()
+        standard, txid1 = self.build_op_meta_tx (utxos, b"x" * 599, Decimal ('0.1'))
+        nonstandard, txid2 = self.build_op_meta_tx (utxos, b"x" * 600, Decimal ('0.1'))
+        self.node.sendrawtransaction (standard)
+        assert_raises (JSONRPCException, self.node.sendrawtransaction,
+                       nonstandard)
+        self.node.generateblock ({"extratx": [nonstandard]})
+        self.check_confirmed ([txid1, txid2])
+
+        # More than one OP_META output is not standard in any case.
+        print ("Testing multiple OP_META outputs...")
+        utxos = self.node.listunspent ()
+        nonstandard, txid = self.build_op_meta_tx (utxos, [b"abc", b"def"], Decimal ('0.1'))
+        assert_raises (JSONRPCException, self.node.sendrawtransaction,
+                       nonstandard)
+        self.node.generateblock ({"extratx": [nonstandard]})
+        self.check_confirmed (txid)
+
+        # Check what fee is required for small and large OP_META transactions.
+        print ("Checking required fees...")
+        utxos = self.node.listunspent ()
+        for p in [b"x", b"x" * 599]:
+          fee = self.find_min_fee (utxos, p)
+          print ("For payload size %d: %.8f DIVI" % (len (p), fee))
+
+
+if __name__ == '__main__':
+    OpMetaTest ().main ()

--- a/divi/qa/rpc-tests/script.py
+++ b/divi/qa/rpc-tests/script.py
@@ -1,0 +1,578 @@
+# Copyright (c) 2015-2020 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Functionality to build scripts, as well as signature hash functions.
+
+This file is modified from python-bitcoinlib.
+"""
+
+from collections import namedtuple
+import hashlib
+import struct
+import unittest
+
+from messages import sha256
+
+OPCODE_NAMES = {}  # type: Dict[CScriptOp, str]
+
+def hash160(s):
+    return hashlib.new('ripemd160', sha256(s)).digest()
+
+def bn2vch(v):
+    """Convert number to bitcoin-specific little endian format."""
+    # We need v.bit_length() bits, plus a sign bit for every nonzero number.
+    n_bits = v.bit_length() + (v != 0)
+    # The number of bytes for that is:
+    n_bytes = (n_bits + 7) // 8
+    # Convert number to absolute value + sign in top bit.
+    encoded_v = 0 if v == 0 else abs(v) | ((v < 0) << (n_bytes * 8 - 1))
+    # Serialize to bytes
+    return encoded_v.to_bytes(n_bytes, 'little')
+
+_opcode_instances = []  # type: List[CScriptOp]
+class CScriptOp(int):
+    """A single script opcode"""
+    __slots__ = ()
+
+    @staticmethod
+    def encode_op_pushdata(d):
+        """Encode a PUSHDATA op, returning bytes"""
+        if len(d) < 0x4c:
+            return b'' + bytes([len(d)]) + d  # OP_PUSHDATA
+        elif len(d) <= 0xff:
+            return b'\x4c' + bytes([len(d)]) + d  # OP_PUSHDATA1
+        elif len(d) <= 0xffff:
+            return b'\x4d' + struct.pack(b'<H', len(d)) + d  # OP_PUSHDATA2
+        elif len(d) <= 0xffffffff:
+            return b'\x4e' + struct.pack(b'<I', len(d)) + d  # OP_PUSHDATA4
+        else:
+            raise ValueError("Data too long to encode in a PUSHDATA op")
+
+    @staticmethod
+    def encode_op_n(n):
+        """Encode a small integer op, returning an opcode"""
+        if not (0 <= n <= 16):
+            raise ValueError('Integer must be in range 0 <= n <= 16, got %d' % n)
+
+        if n == 0:
+            return OP_0
+        else:
+            return CScriptOp(OP_1 + n - 1)
+
+    def decode_op_n(self):
+        """Decode a small integer opcode, returning an integer"""
+        if self == OP_0:
+            return 0
+
+        if not (self == OP_0 or OP_1 <= self <= OP_16):
+            raise ValueError('op %r is not an OP_N' % self)
+
+        return int(self - OP_1 + 1)
+
+    def is_small_int(self):
+        """Return true if the op pushes a small integer to the stack"""
+        if 0x51 <= self <= 0x60 or self == 0:
+            return True
+        else:
+            return False
+
+    def __str__(self):
+        return repr(self)
+
+    def __repr__(self):
+        if self in OPCODE_NAMES:
+            return OPCODE_NAMES[self]
+        else:
+            return 'CScriptOp(0x%x)' % self
+
+    def __new__(cls, n):
+        try:
+            return _opcode_instances[n]
+        except IndexError:
+            assert len(_opcode_instances) == n
+            _opcode_instances.append(super().__new__(cls, n))
+            return _opcode_instances[n]
+
+# Populate opcode instance table
+for n in range(0xff + 1):
+    CScriptOp(n)
+
+
+# push value
+OP_0 = CScriptOp(0x00)
+OP_FALSE = OP_0
+OP_PUSHDATA1 = CScriptOp(0x4c)
+OP_PUSHDATA2 = CScriptOp(0x4d)
+OP_PUSHDATA4 = CScriptOp(0x4e)
+OP_1NEGATE = CScriptOp(0x4f)
+OP_RESERVED = CScriptOp(0x50)
+OP_1 = CScriptOp(0x51)
+OP_TRUE = OP_1
+OP_2 = CScriptOp(0x52)
+OP_3 = CScriptOp(0x53)
+OP_4 = CScriptOp(0x54)
+OP_5 = CScriptOp(0x55)
+OP_6 = CScriptOp(0x56)
+OP_7 = CScriptOp(0x57)
+OP_8 = CScriptOp(0x58)
+OP_9 = CScriptOp(0x59)
+OP_10 = CScriptOp(0x5a)
+OP_11 = CScriptOp(0x5b)
+OP_12 = CScriptOp(0x5c)
+OP_13 = CScriptOp(0x5d)
+OP_14 = CScriptOp(0x5e)
+OP_15 = CScriptOp(0x5f)
+OP_16 = CScriptOp(0x60)
+
+# control
+OP_NOP = CScriptOp(0x61)
+OP_VER = CScriptOp(0x62)
+OP_IF = CScriptOp(0x63)
+OP_NOTIF = CScriptOp(0x64)
+OP_VERIF = CScriptOp(0x65)
+OP_VERNOTIF = CScriptOp(0x66)
+OP_ELSE = CScriptOp(0x67)
+OP_ENDIF = CScriptOp(0x68)
+OP_VERIFY = CScriptOp(0x69)
+OP_META = CScriptOp(0x6a)
+
+# stack ops
+OP_TOALTSTACK = CScriptOp(0x6b)
+OP_FROMALTSTACK = CScriptOp(0x6c)
+OP_2DROP = CScriptOp(0x6d)
+OP_2DUP = CScriptOp(0x6e)
+OP_3DUP = CScriptOp(0x6f)
+OP_2OVER = CScriptOp(0x70)
+OP_2ROT = CScriptOp(0x71)
+OP_2SWAP = CScriptOp(0x72)
+OP_IFDUP = CScriptOp(0x73)
+OP_DEPTH = CScriptOp(0x74)
+OP_DROP = CScriptOp(0x75)
+OP_DUP = CScriptOp(0x76)
+OP_NIP = CScriptOp(0x77)
+OP_OVER = CScriptOp(0x78)
+OP_PICK = CScriptOp(0x79)
+OP_ROLL = CScriptOp(0x7a)
+OP_ROT = CScriptOp(0x7b)
+OP_SWAP = CScriptOp(0x7c)
+OP_TUCK = CScriptOp(0x7d)
+
+# splice ops
+OP_CAT = CScriptOp(0x7e)
+OP_SUBSTR = CScriptOp(0x7f)
+OP_LEFT = CScriptOp(0x80)
+OP_RIGHT = CScriptOp(0x81)
+OP_SIZE = CScriptOp(0x82)
+
+# bit logic
+OP_INVERT = CScriptOp(0x83)
+OP_AND = CScriptOp(0x84)
+OP_OR = CScriptOp(0x85)
+OP_XOR = CScriptOp(0x86)
+OP_EQUAL = CScriptOp(0x87)
+OP_EQUALVERIFY = CScriptOp(0x88)
+OP_RESERVED1 = CScriptOp(0x89)
+OP_RESERVED2 = CScriptOp(0x8a)
+
+# numeric
+OP_1ADD = CScriptOp(0x8b)
+OP_1SUB = CScriptOp(0x8c)
+OP_2MUL = CScriptOp(0x8d)
+OP_2DIV = CScriptOp(0x8e)
+OP_NEGATE = CScriptOp(0x8f)
+OP_ABS = CScriptOp(0x90)
+OP_NOT = CScriptOp(0x91)
+OP_0NOTEQUAL = CScriptOp(0x92)
+
+OP_ADD = CScriptOp(0x93)
+OP_SUB = CScriptOp(0x94)
+OP_MUL = CScriptOp(0x95)
+OP_DIV = CScriptOp(0x96)
+OP_MOD = CScriptOp(0x97)
+OP_LSHIFT = CScriptOp(0x98)
+OP_RSHIFT = CScriptOp(0x99)
+
+OP_BOOLAND = CScriptOp(0x9a)
+OP_BOOLOR = CScriptOp(0x9b)
+OP_NUMEQUAL = CScriptOp(0x9c)
+OP_NUMEQUALVERIFY = CScriptOp(0x9d)
+OP_NUMNOTEQUAL = CScriptOp(0x9e)
+OP_LESSTHAN = CScriptOp(0x9f)
+OP_GREATERTHAN = CScriptOp(0xa0)
+OP_LESSTHANOREQUAL = CScriptOp(0xa1)
+OP_GREATERTHANOREQUAL = CScriptOp(0xa2)
+OP_MIN = CScriptOp(0xa3)
+OP_MAX = CScriptOp(0xa4)
+
+OP_WITHIN = CScriptOp(0xa5)
+
+# crypto
+OP_RIPEMD160 = CScriptOp(0xa6)
+OP_SHA1 = CScriptOp(0xa7)
+OP_SHA256 = CScriptOp(0xa8)
+OP_HASH160 = CScriptOp(0xa9)
+OP_HASH256 = CScriptOp(0xaa)
+OP_CODESEPARATOR = CScriptOp(0xab)
+OP_CHECKSIG = CScriptOp(0xac)
+OP_CHECKSIGVERIFY = CScriptOp(0xad)
+OP_CHECKMULTISIG = CScriptOp(0xae)
+OP_CHECKMULTISIGVERIFY = CScriptOp(0xaf)
+
+# expansion
+OP_NOP1 = CScriptOp(0xb0)
+OP_CHECKLOCKTIMEVERIFY = CScriptOp(0xb1)
+OP_CHECKSEQUENCEVERIFY = CScriptOp(0xb2)
+OP_NOP4 = CScriptOp(0xb3)
+OP_NOP5 = CScriptOp(0xb4)
+OP_NOP6 = CScriptOp(0xb5)
+OP_NOP7 = CScriptOp(0xb6)
+OP_NOP8 = CScriptOp(0xb7)
+OP_NOP9 = CScriptOp(0xb8)
+OP_NOP10 = CScriptOp(0xb9)
+
+# BIP 342 opcodes (Tapscript)
+OP_CHECKSIGADD = CScriptOp(0xba)
+
+OP_INVALIDOPCODE = CScriptOp(0xff)
+
+OPCODE_NAMES.update({
+    OP_0: 'OP_0',
+    OP_PUSHDATA1: 'OP_PUSHDATA1',
+    OP_PUSHDATA2: 'OP_PUSHDATA2',
+    OP_PUSHDATA4: 'OP_PUSHDATA4',
+    OP_1NEGATE: 'OP_1NEGATE',
+    OP_RESERVED: 'OP_RESERVED',
+    OP_1: 'OP_1',
+    OP_2: 'OP_2',
+    OP_3: 'OP_3',
+    OP_4: 'OP_4',
+    OP_5: 'OP_5',
+    OP_6: 'OP_6',
+    OP_7: 'OP_7',
+    OP_8: 'OP_8',
+    OP_9: 'OP_9',
+    OP_10: 'OP_10',
+    OP_11: 'OP_11',
+    OP_12: 'OP_12',
+    OP_13: 'OP_13',
+    OP_14: 'OP_14',
+    OP_15: 'OP_15',
+    OP_16: 'OP_16',
+    OP_NOP: 'OP_NOP',
+    OP_VER: 'OP_VER',
+    OP_IF: 'OP_IF',
+    OP_NOTIF: 'OP_NOTIF',
+    OP_VERIF: 'OP_VERIF',
+    OP_VERNOTIF: 'OP_VERNOTIF',
+    OP_ELSE: 'OP_ELSE',
+    OP_ENDIF: 'OP_ENDIF',
+    OP_VERIFY: 'OP_VERIFY',
+    OP_META: 'OP_META',
+    OP_TOALTSTACK: 'OP_TOALTSTACK',
+    OP_FROMALTSTACK: 'OP_FROMALTSTACK',
+    OP_2DROP: 'OP_2DROP',
+    OP_2DUP: 'OP_2DUP',
+    OP_3DUP: 'OP_3DUP',
+    OP_2OVER: 'OP_2OVER',
+    OP_2ROT: 'OP_2ROT',
+    OP_2SWAP: 'OP_2SWAP',
+    OP_IFDUP: 'OP_IFDUP',
+    OP_DEPTH: 'OP_DEPTH',
+    OP_DROP: 'OP_DROP',
+    OP_DUP: 'OP_DUP',
+    OP_NIP: 'OP_NIP',
+    OP_OVER: 'OP_OVER',
+    OP_PICK: 'OP_PICK',
+    OP_ROLL: 'OP_ROLL',
+    OP_ROT: 'OP_ROT',
+    OP_SWAP: 'OP_SWAP',
+    OP_TUCK: 'OP_TUCK',
+    OP_CAT: 'OP_CAT',
+    OP_SUBSTR: 'OP_SUBSTR',
+    OP_LEFT: 'OP_LEFT',
+    OP_RIGHT: 'OP_RIGHT',
+    OP_SIZE: 'OP_SIZE',
+    OP_INVERT: 'OP_INVERT',
+    OP_AND: 'OP_AND',
+    OP_OR: 'OP_OR',
+    OP_XOR: 'OP_XOR',
+    OP_EQUAL: 'OP_EQUAL',
+    OP_EQUALVERIFY: 'OP_EQUALVERIFY',
+    OP_RESERVED1: 'OP_RESERVED1',
+    OP_RESERVED2: 'OP_RESERVED2',
+    OP_1ADD: 'OP_1ADD',
+    OP_1SUB: 'OP_1SUB',
+    OP_2MUL: 'OP_2MUL',
+    OP_2DIV: 'OP_2DIV',
+    OP_NEGATE: 'OP_NEGATE',
+    OP_ABS: 'OP_ABS',
+    OP_NOT: 'OP_NOT',
+    OP_0NOTEQUAL: 'OP_0NOTEQUAL',
+    OP_ADD: 'OP_ADD',
+    OP_SUB: 'OP_SUB',
+    OP_MUL: 'OP_MUL',
+    OP_DIV: 'OP_DIV',
+    OP_MOD: 'OP_MOD',
+    OP_LSHIFT: 'OP_LSHIFT',
+    OP_RSHIFT: 'OP_RSHIFT',
+    OP_BOOLAND: 'OP_BOOLAND',
+    OP_BOOLOR: 'OP_BOOLOR',
+    OP_NUMEQUAL: 'OP_NUMEQUAL',
+    OP_NUMEQUALVERIFY: 'OP_NUMEQUALVERIFY',
+    OP_NUMNOTEQUAL: 'OP_NUMNOTEQUAL',
+    OP_LESSTHAN: 'OP_LESSTHAN',
+    OP_GREATERTHAN: 'OP_GREATERTHAN',
+    OP_LESSTHANOREQUAL: 'OP_LESSTHANOREQUAL',
+    OP_GREATERTHANOREQUAL: 'OP_GREATERTHANOREQUAL',
+    OP_MIN: 'OP_MIN',
+    OP_MAX: 'OP_MAX',
+    OP_WITHIN: 'OP_WITHIN',
+    OP_RIPEMD160: 'OP_RIPEMD160',
+    OP_SHA1: 'OP_SHA1',
+    OP_SHA256: 'OP_SHA256',
+    OP_HASH160: 'OP_HASH160',
+    OP_HASH256: 'OP_HASH256',
+    OP_CODESEPARATOR: 'OP_CODESEPARATOR',
+    OP_CHECKSIG: 'OP_CHECKSIG',
+    OP_CHECKSIGVERIFY: 'OP_CHECKSIGVERIFY',
+    OP_CHECKMULTISIG: 'OP_CHECKMULTISIG',
+    OP_CHECKMULTISIGVERIFY: 'OP_CHECKMULTISIGVERIFY',
+    OP_NOP1: 'OP_NOP1',
+    OP_CHECKLOCKTIMEVERIFY: 'OP_CHECKLOCKTIMEVERIFY',
+    OP_CHECKSEQUENCEVERIFY: 'OP_CHECKSEQUENCEVERIFY',
+    OP_NOP4: 'OP_NOP4',
+    OP_NOP5: 'OP_NOP5',
+    OP_NOP6: 'OP_NOP6',
+    OP_NOP7: 'OP_NOP7',
+    OP_NOP8: 'OP_NOP8',
+    OP_NOP9: 'OP_NOP9',
+    OP_NOP10: 'OP_NOP10',
+    OP_CHECKSIGADD: 'OP_CHECKSIGADD',
+    OP_INVALIDOPCODE: 'OP_INVALIDOPCODE',
+})
+
+class CScriptInvalidError(Exception):
+    """Base class for CScript exceptions"""
+    pass
+
+class CScriptTruncatedPushDataError(CScriptInvalidError):
+    """Invalid pushdata due to truncation"""
+    def __init__(self, msg, data):
+        self.data = data
+        super().__init__(msg)
+
+
+# This is used, eg, for blockchain heights in coinbase scripts (bip34)
+class CScriptNum:
+    __slots__ = ("value",)
+
+    def __init__(self, d=0):
+        self.value = d
+
+    @staticmethod
+    def encode(obj):
+        r = bytearray(0)
+        if obj.value == 0:
+            return bytes(r)
+        neg = obj.value < 0
+        absvalue = -obj.value if neg else obj.value
+        while (absvalue):
+            r.append(absvalue & 0xff)
+            absvalue >>= 8
+        if r[-1] & 0x80:
+            r.append(0x80 if neg else 0)
+        elif neg:
+            r[-1] |= 0x80
+        return bytes([len(r)]) + r
+
+    @staticmethod
+    def decode(vch):
+        result = 0
+        # We assume valid push_size and minimal encoding
+        value = vch[1:]
+        if len(value) == 0:
+            return result
+        for i, byte in enumerate(value):
+            result |= int(byte) << 8 * i
+        if value[-1] >= 0x80:
+            # Mask for all but the highest result bit
+            num_mask = (2**(len(value) * 8) - 1) >> 1
+            result &= num_mask
+            result *= -1
+        return result
+
+
+class CScript(bytes):
+    """Serialized script
+
+    A bytes subclass, so you can use this directly whenever bytes are accepted.
+    Note that this means that indexing does *not* work - you'll get an index by
+    byte rather than opcode. This format was chosen for efficiency so that the
+    general case would not require creating a lot of little CScriptOP objects.
+
+    iter(script) however does iterate by opcode.
+    """
+    __slots__ = ()
+
+    @classmethod
+    def __coerce_instance(cls, other):
+        # Coerce other into bytes
+        if isinstance(other, CScriptOp):
+            other = bytes([other])
+        elif isinstance(other, CScriptNum):
+            if (other.value == 0):
+                other = bytes([CScriptOp(OP_0)])
+            else:
+                other = CScriptNum.encode(other)
+        elif isinstance(other, int):
+            if 0 <= other <= 16:
+                other = bytes([CScriptOp.encode_op_n(other)])
+            elif other == -1:
+                other = bytes([OP_1NEGATE])
+            else:
+                other = CScriptOp.encode_op_pushdata(bn2vch(other))
+        elif isinstance(other, (bytes, bytearray)):
+            other = CScriptOp.encode_op_pushdata(other)
+        return other
+
+    def __add__(self, other):
+        # add makes no sense for a CScript()
+        raise NotImplementedError
+
+    def join(self, iterable):
+        # join makes no sense for a CScript()
+        raise NotImplementedError
+
+    def __new__(cls, value=b''):
+        if isinstance(value, bytes) or isinstance(value, bytearray):
+            return super().__new__(cls, value)
+        else:
+            def coerce_iterable(iterable):
+                for instance in iterable:
+                    yield cls.__coerce_instance(instance)
+            # Annoyingly on both python2 and python3 bytes.join() always
+            # returns a bytes instance even when subclassed.
+            return super().__new__(cls, b''.join(coerce_iterable(value)))
+
+    def raw_iter(self):
+        """Raw iteration
+
+        Yields tuples of (opcode, data, sop_idx) so that the different possible
+        PUSHDATA encodings can be accurately distinguished, as well as
+        determining the exact opcode byte indexes. (sop_idx)
+        """
+        i = 0
+        while i < len(self):
+            sop_idx = i
+            opcode = self[i]
+            i += 1
+
+            if opcode > OP_PUSHDATA4:
+                yield (opcode, None, sop_idx)
+            else:
+                datasize = None
+                pushdata_type = None
+                if opcode < OP_PUSHDATA1:
+                    pushdata_type = 'PUSHDATA(%d)' % opcode
+                    datasize = opcode
+
+                elif opcode == OP_PUSHDATA1:
+                    pushdata_type = 'PUSHDATA1'
+                    if i >= len(self):
+                        raise CScriptInvalidError('PUSHDATA1: missing data length')
+                    datasize = self[i]
+                    i += 1
+
+                elif opcode == OP_PUSHDATA2:
+                    pushdata_type = 'PUSHDATA2'
+                    if i + 1 >= len(self):
+                        raise CScriptInvalidError('PUSHDATA2: missing data length')
+                    datasize = self[i] + (self[i + 1] << 8)
+                    i += 2
+
+                elif opcode == OP_PUSHDATA4:
+                    pushdata_type = 'PUSHDATA4'
+                    if i + 3 >= len(self):
+                        raise CScriptInvalidError('PUSHDATA4: missing data length')
+                    datasize = self[i] + (self[i + 1] << 8) + (self[i + 2] << 16) + (self[i + 3] << 24)
+                    i += 4
+
+                else:
+                    assert False  # shouldn't happen
+
+                data = bytes(self[i:i + datasize])
+
+                # Check for truncation
+                if len(data) < datasize:
+                    raise CScriptTruncatedPushDataError('%s: truncated data' % pushdata_type, data)
+
+                i += datasize
+
+                yield (opcode, data, sop_idx)
+
+    def __iter__(self):
+        """'Cooked' iteration
+
+        Returns either a CScriptOP instance, an integer, or bytes, as
+        appropriate.
+
+        See raw_iter() if you need to distinguish the different possible
+        PUSHDATA encodings.
+        """
+        for (opcode, data, sop_idx) in self.raw_iter():
+            if data is not None:
+                yield data
+            else:
+                opcode = CScriptOp(opcode)
+
+                if opcode.is_small_int():
+                    yield opcode.decode_op_n()
+                else:
+                    yield CScriptOp(opcode)
+
+    def __repr__(self):
+        def _repr(o):
+            if isinstance(o, bytes):
+                return "x('%s')" % o.hex()
+            else:
+                return repr(o)
+
+        ops = []
+        i = iter(self)
+        while True:
+            op = None
+            try:
+                op = _repr(next(i))
+            except CScriptTruncatedPushDataError as err:
+                op = '%s...<ERROR: %s>' % (_repr(err.data), err)
+                break
+            except CScriptInvalidError as err:
+                op = '<ERROR: %s>' % err
+                break
+            except StopIteration:
+                break
+            finally:
+                if op is not None:
+                    ops.append(op)
+
+        return "CScript([%s])" % ', '.join(ops)
+
+    def GetSigOpCount(self, fAccurate):
+        """Get the SigOp count.
+
+        fAccurate - Accurately count CHECKMULTISIG, see BIP16 for details.
+
+        Note that this is consensus-critical.
+        """
+        n = 0
+        lastOpcode = OP_INVALIDOPCODE
+        for (opcode, data, sop_idx) in self.raw_iter():
+            if opcode in (OP_CHECKSIG, OP_CHECKSIGVERIFY):
+                n += 1
+            elif opcode in (OP_CHECKMULTISIG, OP_CHECKMULTISIGVERIFY):
+                if fAccurate and (OP_1 <= lastOpcode <= OP_16):
+                    n += opcode.decode_op_n()
+                else:
+                    n += 20
+            lastOpcode = opcode
+        return n

--- a/divi/qa/rpc-tests/test_runner.py
+++ b/divi/qa/rpc-tests/test_runner.py
@@ -114,6 +114,7 @@ NON_SCRIPTS = [
     'netutil.py',
     'test_framework.py',
     'test_runner.py',
+    'script.py',
     'socks5.py',
     'util.py',
     'util.sh',

--- a/divi/qa/rpc-tests/test_runner.py
+++ b/divi/qa/rpc-tests/test_runner.py
@@ -110,6 +110,7 @@ NON_SCRIPTS = [
     # These are script files that live in the functional tests directory, but are not test scripts.
     'authproxy.py',
     'masternode.py',
+    'messages.py',
     'netutil.py',
     'test_framework.py',
     'test_runner.py',

--- a/divi/qa/rpc-tests/test_runner.py
+++ b/divi/qa/rpc-tests/test_runner.py
@@ -85,6 +85,7 @@ BASE_SCRIPTS = [
     'mempool_spendcoinbase.py',
     'mncollateral.py',
     'mnoperation.py',
+    'op_meta.py',
     'proxy_test.py',
     'receivedby.py',
     'reindex.py',

--- a/divi/src/chainparams.cpp
+++ b/divi/src/chainparams.cpp
@@ -249,7 +249,6 @@ public:
         fMiningRequiresPeers = false;
         fAllowMinDifficultyBlocks = false;
         fDefaultConsistencyChecks = false;
-        fRequireStandard = true;
         fDifficultyRetargeting = true;
         fMineBlocksOnDemand = false;
         fHeadersFirstSyncingActive = false;
@@ -363,7 +362,6 @@ public:
         fMiningRequiresPeers = true;
         fAllowMinDifficultyBlocks = false;
         fDefaultConsistencyChecks = false;
-        fRequireStandard = true;
         fMineBlocksOnDemand = false;
         fHeadersFirstSyncingActive = false;
 
@@ -447,7 +445,6 @@ public:
         fMiningRequiresPeers = true;
         fAllowMinDifficultyBlocks = true;
         fDefaultConsistencyChecks = false;
-        fRequireStandard = false;
         fMineBlocksOnDemand = false;
         fHeadersFirstSyncingActive = false;
 
@@ -529,7 +526,6 @@ public:
         fMiningRequiresPeers = false;
         fAllowMinDifficultyBlocks = true;
         fDefaultConsistencyChecks = true;
-        fRequireStandard = false;
         fDifficultyRetargeting = false;
         fMineBlocksOnDemand = true;
     }

--- a/divi/src/chainparams.h
+++ b/divi/src/chainparams.h
@@ -78,8 +78,6 @@ public:
     bool DefaultConsistencyChecks() const { return fDefaultConsistencyChecks; }
     /** Allow mining of a min-difficulty block */
     bool AllowMinDifficultyBlocks() const { return fAllowMinDifficultyBlocks; }
-    /** Make standard checks */
-    bool RequireStandard() const { return fRequireStandard; }
     int64_t TargetTimespan() const { return nTargetTimespan; }
     int64_t TargetSpacing() const { return nTargetSpacing; }
     int64_t Interval() const { return nTargetTimespan / nTargetSpacing; }
@@ -152,7 +150,6 @@ protected:
     bool fMiningRequiresPeers;
     bool fAllowMinDifficultyBlocks;
     bool fDefaultConsistencyChecks;
-    bool fRequireStandard;
     bool fDifficultyRetargeting;
     bool fMineBlocksOnDemand;
     bool fHeadersFirstSyncingActive;

--- a/divi/src/init.cpp
+++ b/divi/src/init.cpp
@@ -524,6 +524,7 @@ std::string HelpMessage(HelpMessageMode mode)
         strUsage += HelpMessageOpt("-limitfreerelay=<n>", strprintf(translate("Continuously rate-limit free transactions to <n>*1000 bytes per minute (default:%u)"), 15));
         strUsage += HelpMessageOpt("-relaypriority", strprintf(translate("Require high priority for relaying free or low-fee transactions (default:%u)"), 1));
         strUsage += HelpMessageOpt("-maxsigcachesize=<n>", strprintf(translate("Limit size of signature cache to <n> entries (default: %u)"), 50000));
+        strUsage += HelpMessageOpt("-acceptnonstandard", translate("Relay non-standard transactions"));
     }
     strUsage += HelpMessageOpt("-minrelaytxfee=<amt>", strprintf(translate("Fees (in DIV/Kb) smaller than this are considered zero fee for relaying (default: %s)"), FormatMoney(::minRelayTxFee.GetFeePerK())));
     strUsage += HelpMessageOpt("-printtoconsole", strprintf(translate("Send trace/debug info to console instead of debug.log file (default: %u)"), 0));

--- a/divi/src/main.cpp
+++ b/divi/src/main.cpp
@@ -962,6 +962,7 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState& state, const CTransa
     if (pfMissingInputs)
         *pfMissingInputs = false;
 
+    const bool requireStandard = !settings.GetBoolArg("-acceptnonstandard", false);
 
     if (!CheckTransaction(tx, true, state))
         return state.DoS(100, error("AcceptToMemoryPool: : CheckTransaction failed"), REJECT_INVALID, "bad-tx");
@@ -978,7 +979,7 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState& state, const CTransa
 
     // Rather not work on nonstandard transactions (unless -testnet/-regtest)
     string reason;
-    if (Params().RequireStandard() && !IsStandardTx(tx, reason))
+    if (requireStandard && !IsStandardTx(tx, reason))
         return state.DoS(0,
                          error("AcceptToMemoryPool : nonstandard transaction: %s", reason),
                          REJECT_NONSTANDARD, reason);
@@ -1060,7 +1061,7 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState& state, const CTransa
         }
 
         // Check for non-standard pay-to-script-hash in inputs
-        if (Params().RequireStandard() && !AreInputsStandard(tx, view))
+        if (requireStandard && !AreInputsStandard(tx, view))
             return error("AcceptToMemoryPool: : nonstandard transaction input");
 
         // Check that the transaction doesn't have an excessive number of


### PR DESCRIPTION
This adds a new regtest for `OP_META`, verifying the expected standardness and fee properties of `OP_META` transactions on the Divi network.  To do this, we also include two new regtest library modules from modern Bitcoin for building scripts and transactions directly in Python.

Finally, this also includes a change to remove the "require standard" flag from chainparams.  Instead, we require standard transactions on all networks by default; this ensures that regtest tests are as close as possible to production (mainnet) and can in particular verify standardness rules.  A new flag `-acceptnonstandard` can instead be used to selectively turn off standardness checks if desired for particular tests.