### PR TITLE
Remove -reindexmoneysupply and other dead code

### DIFF
--- a/divi/src/init.cpp
+++ b/divi/src/init.cpp
@@ -401,7 +401,6 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += HelpMessageOpt("-pid=<file>", strprintf(translate("Specify pid file (default: %s)"), "divid.pid"));
 #endif
     strUsage += HelpMessageOpt("-reindex", translate("Rebuild block chain index from current blk000??.dat files") + " " + translate("on startup"));
-    strUsage += HelpMessageOpt("-reindexmoneysupply", translate("Reindex the DIV and zDIV money supply statistics") + " " + translate("on startup"));
     strUsage += HelpMessageOpt("-resync", translate("Delete blockchain folders and resync from scratch") + " " + translate("on startup"));
 #if !defined(WIN32)
     strUsage += HelpMessageOpt("-sysperms", translate("Create new files with system default permissions, instead of umask 077 (only effective with disabled wallet functionality)"));
@@ -1278,11 +1277,6 @@ bool TryToLoadBlocks(bool& fLoaded, std::string& strLoadError)
         if (fTxIndex != settings.GetBoolArg("-txindex", true)) {
             strLoadError = translate("You need to rebuild the database using -reindex to change -txindex");
             return skipLoadingDueToError;
-        }
-
-        // Recalculate money supply
-        if (settings.GetBoolArg("-reindexmoneysupply", false)) {
-            RecalculateDIVSupply(1);
         }
 
         uiInterface.InitMessage(translate("Verifying blocks..."));

--- a/divi/src/main.cpp
+++ b/divi/src/main.cpp
@@ -3024,26 +3024,6 @@ bool ContextualCheckBlockHeader(const CBlockHeader& block, CValidationState& sta
     return true;
 }
 
-bool IsBlockHashInChain(const uint256& hashBlock)
-{
-    if (hashBlock == 0 || !mapBlockIndex.count(hashBlock))
-        return false;
-
-    return chainActive.Contains(mapBlockIndex[hashBlock]);
-}
-
-bool IsTransactionInChain(uint256 txId, int& nHeightTx)
-{
-    uint256 hashBlock;
-    CTransaction tx;
-    GetTransaction(txId, tx, hashBlock, true);
-    if (!IsBlockHashInChain(hashBlock))
-        return false;
-
-    nHeightTx = mapBlockIndex.at(hashBlock)->nHeight;
-    return true;
-}
-
 bool ContextualCheckBlock(const CBlock& block, CValidationState& state, CBlockIndex* const pindexPrev)
 {
     const int nHeight = pindexPrev == NULL ? 0 : pindexPrev->nHeight + 1;

--- a/divi/src/main.h
+++ b/divi/src/main.h
@@ -231,8 +231,6 @@ void UpdateCoins(const CTransaction& tx, CCoinsViewCache& inputs, CTxUndo& txund
 
 /** Context-independent validity checks */
 bool CheckTransaction(const CTransaction& tx, bool fRejectBadUTXO, CValidationState& state);
-bool IsTransactionInChain(uint256 txId, int& nHeightTx);
-bool IsBlockHashInChain(const uint256& hashBlock);
 bool RecalculateDIVSupply(int nHeightStart);
 
 

--- a/divi/src/main.h
+++ b/divi/src/main.h
@@ -231,7 +231,6 @@ void UpdateCoins(const CTransaction& tx, CCoinsViewCache& inputs, CTxUndo& txund
 
 /** Context-independent validity checks */
 bool CheckTransaction(const CTransaction& tx, bool fRejectBadUTXO, CValidationState& state);
-bool RecalculateDIVSupply(int nHeightStart);
 
 
 /** Check for standard transaction types


### PR DESCRIPTION
This removes the `-reindexmoneysupply` option, which is not needed for anything in current DIVI, and also some other (completely) dead code.