### PR TITLE
Basic implementation of bare txid's

### DIFF
--- a/divi/src/Makefile.test.include
+++ b/divi/src/Makefile.test.include
@@ -35,6 +35,7 @@ GENERATED_TEST_FILES = $(JSON_TEST_FILES:.json=.json.h) $(RAW_TEST_FILES:.raw=.r
 
 BITCOIN_TESTS =\
   test/allocator_tests.cpp \
+  test/BareTxid_tests.cpp \
   test/base32_tests.cpp \
   test/base58_tests.cpp \
   test/base64_tests.cpp \

--- a/divi/src/primitives/transaction.cpp
+++ b/divi/src/primitives/transaction.cpp
@@ -104,6 +104,14 @@ void CTransaction::UpdateHash() const
     *const_cast<uint256*>(&hash) = SerializeHash(*this);
 }
 
+uint256 CTransaction::GetBareTxid () const
+{
+    CMutableTransaction withoutSigs(*this);
+    for (auto& in : withoutSigs.vin)
+      in.scriptSig.clear();
+    return withoutSigs.GetHash();
+}
+
 CTransaction::CTransaction() : hash(), nVersion(CTransaction::CURRENT_VERSION), vin(), vout(), nLockTime(0) { }
 
 CTransaction::CTransaction(const CMutableTransaction &tx) : nVersion(tx.nVersion), vin(tx.vin), vout(tx.vout), nLockTime(tx.nLockTime) {

--- a/divi/src/primitives/transaction.h
+++ b/divi/src/primitives/transaction.h
@@ -221,6 +221,16 @@ public:
         return hash;
     }
 
+    /** Returns the "bare transaction ID".  This is a hash of the transaction
+     *  as per GetHash, but it does not include any of the signature data
+     *  (i.e. all scriptSig's are set empty).
+     *
+     *  This means that it commits to the data relevant for the transaction,
+     *  without being affected by malleability.  This transaction ID is used
+     *  to refer to outputs from follow-up transactions after activating
+     *  "segwit light".  */
+    uint256 GetBareTxid () const;
+
     // Return sum of txouts.
     CAmount GetValueOut() const;
     // GetValueIn() is a method on CCoinsViewCache, because
@@ -276,6 +286,11 @@ struct CMutableTransaction
      * fly, as opposed to GetHash() in CTransaction, which uses a cached result.
      */
     uint256 GetHash() const;
+
+    uint256 GetBareTxid() const
+    {
+        return CTransaction(*this).GetBareTxid();
+    }
 
     std::string ToString() const;
 

--- a/divi/src/rpcrawtransaction.cpp
+++ b/divi/src/rpcrawtransaction.cpp
@@ -65,6 +65,7 @@ void TxToJSONExpanded(const CTransaction& tx, const uint256 hashBlock, Object& e
 
     uint256 txid = tx.GetHash();
     entry.push_back(Pair("txid", txid.GetHex()));
+    entry.push_back(Pair("baretxid", tx.GetBareTxid().GetHex()));
     entry.push_back(Pair("version", tx.nVersion));
     entry.push_back(Pair("locktime", (int64_t)tx.nLockTime));
     Array vin;
@@ -143,6 +144,7 @@ void TxToJSONExpanded(const CTransaction& tx, const uint256 hashBlock, Object& e
 void TxToJSON(const CTransaction& tx, const uint256 hashBlock, Object& entry)
 {
     entry.push_back(Pair("txid", tx.GetHash().GetHex()));
+    entry.push_back(Pair("baretxid", tx.GetBareTxid().GetHex()));
     entry.push_back(Pair("version", tx.nVersion));
     entry.push_back(Pair("locktime", (int64_t)tx.nLockTime));
     Array vin;
@@ -213,6 +215,7 @@ Value getrawtransaction(const Array& params, bool fHelp)
             "{\n"
             "  \"hex\" : \"data\",       (string) The serialized, hex-encoded data for 'txid'\n"
             "  \"txid\" : \"id\",        (string) The transaction id (same as provided)\n"
+            "  \"baretxid\" : \"baretxid\", (string) The bare txid (without signatures)\n"
             "  \"version\" : n,          (numeric) The version\n"
             "  \"locktime\" : ttt,       (numeric) The lock time\n"
             "  \"vin\" : [               (array of json objects)\n"
@@ -520,6 +523,7 @@ Value decoderawtransaction(const Array& params, bool fHelp)
             "\nResult:\n"
             "{\n"
             "  \"txid\" : \"id\",        (string) The transaction id\n"
+            "  \"baretxid\" : \"baretxid\", (string) The bare txid (without signatures)\n"
             "  \"version\" : n,          (numeric) The version\n"
             "  \"locktime\" : ttt,       (numeric) The lock time\n"
             "  \"vin\" : [               (array of json objects)\n"

--- a/divi/src/rpcwallet.cpp
+++ b/divi/src/rpcwallet.cpp
@@ -73,6 +73,7 @@ void WalletTxToJSON(const CWalletTx& wtx, Object& entry)
     }
     uint256 hash = wtx.GetHash();
     entry.push_back(Pair("txid", hash.GetHex()));
+    entry.push_back(Pair("baretxid", wtx.GetBareTxid().GetHex()));
     Array conflicts;
     if(pwalletMain)
     {
@@ -1731,6 +1732,7 @@ Value listtransactions(const Array& params, bool fHelp)
                 "    \"blockindex\": n,          (numeric) The block index containing the transaction. Available for 'send' and 'receive'\n"
                 "                                          category of transactions.\n"
                 "    \"txid\": \"transactionid\", (string) The transaction id. Available for 'send' and 'receive' category of transactions.\n"
+                "    \"baretxid\" : \"baretxid\", (string) The bare txid (without signatures)\n"
                 "    \"time\": xxx,              (numeric) The transaction time in seconds since epoch (midnight Jan 1 1970 GMT).\n"
                 "    \"timereceived\": xxx,      (numeric) The time received in seconds since epoch (midnight Jan 1 1970 GMT). Available \n"
                 "                                          for 'send' and 'receive' category of transactions.\n"
@@ -1899,6 +1901,7 @@ Value listsinceblock(const Array& params, bool fHelp)
                 "    \"blockindex\": n,          (numeric) The block index containing the transaction. Available for 'send' and 'receive' category of transactions.\n"
                 "    \"blocktime\": xxx,         (numeric) The block time in seconds since epoch (1 Jan 1970 GMT).\n"
                 "    \"txid\": \"transactionid\",  (string) The transaction id. Available for 'send' and 'receive' category of transactions.\n"
+                "    \"baretxid\" : \"baretxid\",  (string) The bare txid (without signatures)\n"
                 "    \"time\": xxx,              (numeric) The transaction time in seconds since epoch (Jan 1 1970 GMT).\n"
                 "    \"timereceived\": xxx,      (numeric) The time received in seconds since epoch (Jan 1 1970 GMT). Available for 'send' and 'receive' category of transactions.\n"
                 "    \"comment\": \"...\",       (string) If a comment is associated with the transaction.\n"
@@ -1974,6 +1977,7 @@ Value gettransaction(const Array& params, bool fHelp)
                 "  \"blockindex\" : xx,       (numeric) The block index\n"
                 "  \"blocktime\" : ttt,       (numeric) The time in seconds since epoch (1 Jan 1970 GMT)\n"
                 "  \"txid\" : \"transactionid\",   (string) The transaction id.\n"
+                "  \"baretxid\" : \"baretxid\",    (string) The bare txid (without signatures)\n"
                 "  \"time\" : ttt,            (numeric) The transaction time in seconds since epoch (1 Jan 1970 GMT)\n"
                 "  \"timereceived\" : ttt,    (numeric) The time received in seconds since epoch (1 Jan 1970 GMT)\n"
                 "  \"details\" : [\n"

--- a/divi/src/test/BareTxid_tests.cpp
+++ b/divi/src/test/BareTxid_tests.cpp
@@ -1,0 +1,115 @@
+#include <test/test_only.h>
+
+#include <hash.h>
+#include <primitives/transaction.h>
+
+#include <boost/test/unit_test.hpp>
+
+namespace {
+
+uint256
+HashStr (const std::string& str)
+{
+  return Hash (str.begin (), str.end ());
+}
+
+std::vector<unsigned char>
+HashToVec (const std::string& str)
+{
+    const uint256 val = HashStr (str);
+    return std::vector<unsigned char> (val.begin (), val.end ());
+}
+
+class BareTxidTestFixture
+{
+
+public:
+
+  /* Just a "normal" transaction with non-trivial data, inputs and outputs,
+     in both read-only and mutable form.  */
+  CMutableTransaction mtx;
+  CTransaction tx;
+
+  BareTxidTestFixture ()
+  {
+    mtx.nVersion = 1;
+    mtx.nLockTime = 1234567890;
+
+    mtx.vin.emplace_back (HashStr ("in 1"), 4, CScript () << OP_TRUE << OP_FALSE);
+    mtx.vin.emplace_back (HashStr ("in 2"), 2, CScript () << OP_DUP);
+
+    mtx.vout.emplace_back (1 * COIN, CScript () << OP_TRUE);
+    mtx.vout.emplace_back (0, CScript () << OP_META << HashToVec ("data"));
+
+    tx = CTransaction (mtx);
+  }
+
+  /** Helper function that returns the bare txid of mtx.  */
+  uint256
+  GetMtxBareTxid () const
+  {
+    return CTransaction (mtx).GetBareTxid ();
+  }
+
+};
+
+BOOST_FIXTURE_TEST_SUITE (BareTxid_tests, BareTxidTestFixture)
+
+BOOST_AUTO_TEST_CASE (commitsToTxVersion)
+{
+  mtx.nVersion = 42;
+  BOOST_CHECK (GetMtxBareTxid () != tx.GetBareTxid ());
+}
+
+BOOST_AUTO_TEST_CASE (commitsToLockTime)
+{
+  mtx.nLockTime = 100;
+  BOOST_CHECK (GetMtxBareTxid () != tx.GetBareTxid ());
+}
+
+BOOST_AUTO_TEST_CASE (commitsToInputs)
+{
+  mtx.vin.emplace_back ();
+  BOOST_CHECK (GetMtxBareTxid () != tx.GetBareTxid ());
+}
+
+BOOST_AUTO_TEST_CASE (commitsToInputPrevout)
+{
+  mtx.vin[0].prevout.n = 42;
+  BOOST_CHECK (GetMtxBareTxid () != tx.GetBareTxid ());
+}
+
+BOOST_AUTO_TEST_CASE (commitsToInputSequence)
+{
+  mtx.vin[0].nSequence = 123;
+  BOOST_CHECK (GetMtxBareTxid () != tx.GetBareTxid ());
+}
+
+BOOST_AUTO_TEST_CASE (commitsToOutputs)
+{
+  mtx.vout.emplace_back ();
+  BOOST_CHECK (GetMtxBareTxid () != tx.GetBareTxid ());
+}
+
+BOOST_AUTO_TEST_CASE (commitsToOutputValue)
+{
+  mtx.vout[0].nValue = 20 * COIN;
+  BOOST_CHECK (GetMtxBareTxid () != tx.GetBareTxid ());
+}
+
+BOOST_AUTO_TEST_CASE (commitsToOutputScript)
+{
+  mtx.vout[1].scriptPubKey = CScript () << OP_META << HashToVec ("other data");
+  BOOST_CHECK (GetMtxBareTxid () != tx.GetBareTxid ());
+}
+
+BOOST_AUTO_TEST_CASE (doesNotCommitToInputSignature)
+{
+  mtx.vin[0].scriptSig.clear ();
+  mtx.vin[1].scriptSig = CScript () << OP_META << HashToVec ("foo");
+  BOOST_CHECK (GetMtxBareTxid () == tx.GetBareTxid ());
+}
+
+BOOST_AUTO_TEST_SUITE_END ()
+
+} // anonymous namespace

--- a/divi/src/txmempool.h
+++ b/divi/src/txmempool.h
@@ -119,6 +119,11 @@ private:
 
     std::map<uint256, std::pair<double, CAmount> > mapDeltas;
 
+    /** Maps bare txid's of transactions to the corresponding mempool entries.
+     *  This is used for lookups of outputs available in the mempool instead
+     *  of mapTx in case of segwit light.  */
+    std::map<uint256, const CTxMemPoolEntry*> mapBareTxid;
+
 public:
     mutable CCriticalSection cs;
     std::map<uint256, CTxMemPoolEntry> mapTx;
@@ -172,13 +177,20 @@ public:
         return totalTxSize;
     }
 
-    bool exists(uint256 hash)
+    bool exists(const uint256& hash)
     {
         LOCK(cs);
         return (mapTx.count(hash) != 0);
     }
 
-    bool lookup(uint256 hash, CTransaction& result) const;
+    bool existsBareTxid(const uint256& hash)
+    {
+        LOCK(cs);
+        return (mapBareTxid.count(hash) != 0);
+    }
+
+    bool lookup(const uint256& hash, CTransaction& result) const;
+    bool lookupBareTxid(const uint256& btxid, CTransaction& result) const;
 
     /** Estimate fee rate needed to get into the next nBlocks */
     CFeeRate estimateFee(int nBlocks) const;


### PR DESCRIPTION
This implements the "bare txid" as a new concept.  It is a hash of a transaction just like the normal `txid`, but it does not take signatures into account.  Like the normal `txid`, it still commits to the "important" parts of a transactions (which outputs are spent and where the money goes).  Unlike it, the bare txid is can not be malleated through changes in the signatures.

For now, this PR just introduces the concept, returns it from some RPCs in addition to the normal `txid`, and adds an index on the mempool by bare txid with corresponding lookup functions (but without using them).

This is a preparation for segwit-light, which will make use of the bare txid from consensus code.