### PR TITLE
Clean up "staking vault" fork activation

### DIFF
--- a/divi/src/BlockSigning.cpp
+++ b/divi/src/BlockSigning.cpp
@@ -4,7 +4,6 @@
 
 #include "BlockSigning.h"
 
-#include "ForkActivation.h"
 #include "keystore.h"
 #include "primitives/block.h"
 #include "script/standard.h"
@@ -117,12 +116,6 @@ CheckBlockSignature (const CBlock& block)
     if (block.vchBlockSig.empty())
         return false;
 
-    /* FIXME:  Once the staking vault fork has passed, we can get rid of
-       this condition here and just always accept vault signatures in addition
-       to the other types.  But initially we need to properly activate the
-       change to avoid an uncontrolled fork.  */
-    const bool acceptVault = ActivationState(block).IsActive(Fork::StakingVaults);
-
     if (whichType == TX_PUBKEY)
     {
         const auto& vchPubKey = vSolutions[0];
@@ -144,7 +137,7 @@ CheckBlockSignature (const CBlock& block)
 
         return keyID == pubkeyFromSig.GetID();
     }
-    else if (acceptVault && whichType == TX_VAULT)
+    else if (whichType == TX_VAULT)
     {
         const auto& vchPubKey = vSolutions[1];
         const CKeyID keyID = CKeyID(uint160(vchPubKey));

--- a/divi/src/ForkActivation.cpp
+++ b/divi/src/ForkActivation.cpp
@@ -16,14 +16,13 @@ extern Settings& settings;
 namespace
 {
 constexpr int64_t unixTimestampForDec31stMidnight = 1609459199;
-const std::set<Fork> manualOverrides = {Fork::StakingVaults,Fork::HardenedStakeModifier,Fork::UniformLotteryWinners};
+const std::set<Fork> manualOverrides = {Fork::HardenedStakeModifier,Fork::UniformLotteryWinners};
 /**
  * For forks that get activated at a certain block time, the associated
  * activation times.
  */
 const std::unordered_map<Fork, int64_t,std::hash<int>> ACTIVATION_TIMES = {
   {Fork::TestByTimestamp, 1000000000},
-  {Fork::StakingVaults, unixTimestampForDec31stMidnight},
   {Fork::HardenedStakeModifier, unixTimestampForDec31stMidnight},
   {Fork::UniformLotteryWinners, unixTimestampForDec31stMidnight},
 };

--- a/divi/src/ForkActivation.cpp
+++ b/divi/src/ForkActivation.cpp
@@ -22,8 +22,6 @@ const std::set<Fork> manualOverrides = {Fork::StakingVaults,Fork::HardenedStakeM
  * activation times.
  */
 const std::unordered_map<Fork, int64_t,std::hash<int>> ACTIVATION_TIMES = {
-  /* FIXME: Set real activation height for staking vaults once
-     the schedule has been finalised.  */
   {Fork::TestByTimestamp, 1000000000},
   {Fork::StakingVaults, unixTimestampForDec31stMidnight},
   {Fork::HardenedStakeModifier, unixTimestampForDec31stMidnight},

--- a/divi/src/ForkActivation.h
+++ b/divi/src/ForkActivation.h
@@ -20,11 +20,6 @@ enum Fork
 {
   /* Test forks not actually deployed / active but used for unit tests.  */
   TestByTimestamp,
-  /**
-   * Staking vaults with SCRIPT_REQUIRE_COINSTAKE and a couple of other,
-   * related changes.
-   */
-  StakingVaults,
   HardenedStakeModifier,
   UniformLotteryWinners,
 };

--- a/divi/src/kernel.cpp
+++ b/divi/src/kernel.cpp
@@ -310,7 +310,7 @@ bool CheckCoinstakeForVaults(const CTransaction& tx, const CBlockRewards& expect
                              const CCoinsViewCache& view)
 {
     if (!tx.IsCoinStake())
-        return error("%s: transaction is not a coinstake", __func__);
+        return true;
 
     CAmount nValueIn = 0;
     bool foundVault = false;

--- a/divi/src/kernel.cpp
+++ b/divi/src/kernel.cpp
@@ -269,17 +269,7 @@ bool CheckProofOfStakeContextAndRecoverStakingData(
     }
 
     //verify signature and script
-    // FIXME: Before the staking-vault fork was implemented, the flags used
-    // here disallowed upgradable NOPs (including OP_REQUIRE_COINSTAKE).
-    // This restriction is lifted with the fork, but the change needs to be
-    // properly activated.  Once the fork has passed, this can be cleaned up
-    // by instead applying the post-fork flags unconditionally retroactively.
-    unsigned flags = POS_SCRIPT_VERIFY_FLAGS;
-    if (!ActivationState (block).IsActive(Fork::StakingVaults)) {
-        flags &= ~SCRIPT_REQUIRE_COINSTAKE;
-        flags |= SCRIPT_VERIFY_DISCOURAGE_UPGRADABLE_NOPS;
-    }
-    if (!VerifyScript(txin.scriptSig, txPrev.vout[txin.prevout.n].scriptPubKey, flags, TransactionSignatureChecker(&tx, 0)))
+    if (!VerifyScript(txin.scriptSig, txPrev.vout[txin.prevout.n].scriptPubKey, POS_SCRIPT_VERIFY_FLAGS, TransactionSignatureChecker(&tx, 0)))
         return error("CheckProofOfStake() : VerifySignature failed on coinstake %s", tx.GetHash().ToString().c_str());
 
     CBlockIndex* pindex = NULL;

--- a/divi/src/script/standard.h
+++ b/divi/src/script/standard.h
@@ -25,7 +25,8 @@ extern unsigned nMaxDatacarrierBytes;
  * details.
  */
 static const unsigned int MANDATORY_SCRIPT_VERIFY_FLAGS = SCRIPT_VERIFY_P2SH |
-                                                          SCRIPT_VERIFY_DERSIG;
+                                                          SCRIPT_VERIFY_DERSIG |
+                                                          SCRIPT_REQUIRE_COINSTAKE;
 
 /**
  * Script flags that are used when verifying the coinstake signature in
@@ -35,8 +36,7 @@ static const unsigned int POS_SCRIPT_VERIFY_FLAGS = MANDATORY_SCRIPT_VERIFY_FLAG
                                                     SCRIPT_VERIFY_DERSIG |
                                                     SCRIPT_VERIFY_STRICTENC |
                                                     SCRIPT_VERIFY_MINIMALDATA |
-                                                    SCRIPT_VERIFY_NULLDUMMY |
-                                                    SCRIPT_REQUIRE_COINSTAKE;
+                                                    SCRIPT_VERIFY_NULLDUMMY;
 
 /**
  * Standard script verification flags that standard transactions will comply

--- a/divi/src/test/BlockSignature_tests.cpp
+++ b/divi/src/test/BlockSignature_tests.cpp
@@ -115,13 +115,8 @@ BOOST_AUTO_TEST_CASE(stakingVaultSignature)
     // Test
     BOOST_CHECK_MESSAGE(!SignBlock(ownerKeyStore, block), "Owner key could sign block");
 
-    block.nTime = 2000000000;
     BOOST_CHECK_MESSAGE(SignBlock(vaultKeyStore, block), "Failed to sign block with vault key");
     BOOST_CHECK_MESSAGE(CheckBlockSignature(block), "Failed to verify vault block signature");
-
-    block.nTime = 1000000000;
-    BOOST_CHECK_MESSAGE(SignBlock(vaultKeyStore, block), "Failed to sign block with vault key");
-    BOOST_CHECK_MESSAGE(!CheckBlockSignature(block), "Verified  disallowed signature type!");
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
The staking vaults fork has been activated; this allows us to clean up some of the activation code and simplify the logic.  There were two "parts" making up the entire fork, both of which we can actually activate from genesis onwards:

First, the extra restrictions put in place, namely `OP_REQUIRE_COINSTAKE` and the extra conditions for coinstakes spending vault scripts.  These are a soft fork, i.e. just adding extra restrictions.  It turns out that the blockchain since genesis actually conforms to those extra (stricter) rules already, so it is now possible to "backdate" the fork and apply it unconditionally.

Second, some restrictions in place have actually been lifted, e.g. related to signing PoS blocks with a vault script.  Since the pre-fork part of the blockchain is now enshrined in history and immutable, we can just as well lift those restrictions since the beginning.