### PR TITLE
Set -nolistenonion in mnoperation.py

### DIFF
--- a/divi/qa/rpc-tests/mnoperation.py
+++ b/divi/qa/rpc-tests/mnoperation.py
@@ -27,7 +27,7 @@ class MnStatusTest (BitcoinTestFramework):
 
   def __init__ (self):
     super ().__init__ ()
-    self.base_args = ["-debug"]
+    self.base_args = ["-debug", "-nolistenonion"]
 
   def setup_chain (self):
     for i in range (7):


### PR DESCRIPTION
For some reason, `mnoperation.py` recently started to fail from time to time with an error message about not being able to find a masternode at some .onion address.  This gets fixed by explicitly disabling running hidden services, which we don't need or want on regtest anyway.