### PR TITLE
UTXO hasher abstraction

### DIFF
--- a/divi/src/BlockMemoryPoolTransactionCollector.cpp
+++ b/divi/src/BlockMemoryPoolTransactionCollector.cpp
@@ -203,7 +203,7 @@ std::vector<TxPriority> BlockMemoryPoolTransactionCollector::PrioritizeMempoolTr
             // Read prev transaction
             if (!view.HaveCoins(txin.prevout.hash)) {
                 CTransaction prevTx;
-                if(!mempool_.lookup(txin.prevout.hash, prevTx)) {
+                if(!mempool_.lookupOutpoint(txin.prevout.hash, prevTx)) {
                     // This should never happen; all transactions in the memory
                     // pool should connect to either transactions in the chain
                     // or other transactions in the memory pool.
@@ -338,7 +338,7 @@ std::vector<PrioritizedTransactionData> BlockMemoryPoolTransactionCollector::Pri
         nBlockSigOps += nTxSigOps;
 
         CTxUndo txundo;
-        UpdateCoinsWithTransaction(tx, view, txundo, nHeight);
+        UpdateCoinsWithTransaction(tx, view, txundo, mempool_.GetUtxoHasher(), nHeight);
 
         if (fPrintPriority) {
             LogPrintf("priority %.1f fee %s txid %s\n",
@@ -346,7 +346,7 @@ std::vector<PrioritizedTransactionData> BlockMemoryPoolTransactionCollector::Pri
         }
 
         // Add transactions that depend on this one to the priority queue
-        AddDependingTransactionsToPriorityQueue(dependentTransactions, hash, vecPriority, comparer);
+        AddDependingTransactionsToPriorityQueue(dependentTransactions, mempool_.GetUtxoHasher().GetUtxoHash(tx), vecPriority, comparer);
     }
 
     LogPrintf("CreateNewBlock(): total size %u\n", nBlockSize);

--- a/divi/src/BlockTransactionChecker.h
+++ b/divi/src/BlockTransactionChecker.h
@@ -13,6 +13,7 @@ class CBlock;
 class CValidationState;
 class CCoinsViewCache;
 class CBlockRewards;
+class TransactionUtxoHasher;
 
 class TransactionLocationRecorder
 {
@@ -35,6 +36,7 @@ class BlockTransactionChecker
 private:
     CBlockUndo blockundo_;
     const CBlock& block_;
+    const TransactionUtxoHasher& utxoHasher_;
     CValidationState& state_;
     CBlockIndex* pindex_;
     CCoinsViewCache& view_;
@@ -43,6 +45,7 @@ private:
 public:
     BlockTransactionChecker(
         const CBlock& block,
+        const TransactionUtxoHasher& utxoHasher,
         CValidationState& state,
         CBlockIndex* pindex,
         CCoinsViewCache& view,

--- a/divi/src/IndexDatabaseUpdateCollector.cpp
+++ b/divi/src/IndexDatabaseUpdateCollector.cpp
@@ -81,7 +81,7 @@ void CollectUpdatesFromOutputs(
                     std::make_pair(CAddressIndexKey(addressType, uint160(hashBytes), txLocationRef.blockHeight, txLocationRef.transactionIndex, txLocationRef.hash, k, false), out.nValue));
                 // record unspent output
                 indexDatabaseUpdates.addressUnspentIndex.push_back(
-                    std::make_pair(CAddressUnspentKey(addressType, uint160(hashBytes), txLocationRef.hash, k), CAddressUnspentValue(out.nValue, out.scriptPubKey, txLocationRef.blockHeight)));
+                    std::make_pair(CAddressUnspentKey(addressType, uint160(hashBytes), txLocationRef.utxoHash, k), CAddressUnspentValue(out.nValue, out.scriptPubKey, txLocationRef.blockHeight)));
             } else {
                 continue;
             }
@@ -156,7 +156,7 @@ static void CollectUpdatesFromOutputs(
             // undo unspent index
             indexDBUpdates.addressUnspentIndex.push_back(
                 std::make_pair(
-                    CAddressUnspentKey(addressType, uint160(hashBytes), txLocationReference.hash, k),
+                    CAddressUnspentKey(addressType, uint160(hashBytes), txLocationReference.utxoHash, k),
                     CAddressUnspentValue()));
 
         }

--- a/divi/src/IndexDatabaseUpdates.cpp
+++ b/divi/src/IndexDatabaseUpdates.cpp
@@ -1,5 +1,8 @@
 #include <IndexDatabaseUpdates.h>
 
+#include <primitives/transaction.h>
+#include <UtxoCheckingAndUpdating.h>
+
 IndexDatabaseUpdates::IndexDatabaseUpdates(
     ): addressIndex()
     , addressUnspentIndex()
@@ -9,10 +12,12 @@ IndexDatabaseUpdates::IndexDatabaseUpdates(
 }
 
 TransactionLocationReference::TransactionLocationReference(
-    uint256 hashValue,
+    const TransactionUtxoHasher& utxoHasher,
+    const CTransaction& tx,
     unsigned blockheightValue,
     int transactionIndexValue
-    ): hash(hashValue)
+    ): hash(tx.GetHash())
+    , utxoHash(utxoHasher.GetUtxoHash(tx))
     , blockHeight(blockheightValue)
     , transactionIndex(transactionIndexValue)
 {

--- a/divi/src/IndexDatabaseUpdates.h
+++ b/divi/src/IndexDatabaseUpdates.h
@@ -6,6 +6,9 @@
 #include <spentindex.h>
 #include <uint256.h>
 
+class CTransaction;
+class TransactionUtxoHasher;
+
 struct IndexDatabaseUpdates
 {
     std::vector<std::pair<CAddressIndexKey, CAmount> > addressIndex;
@@ -19,11 +22,13 @@ struct IndexDatabaseUpdates
 struct TransactionLocationReference
 {
     uint256 hash;
+    uint256 utxoHash;
     unsigned blockHeight;
     int transactionIndex;
 
     TransactionLocationReference(
-        uint256 hashValue,
+        const TransactionUtxoHasher& utxoHasher,
+        const CTransaction& tx,
         unsigned blockheightValue,
         int transactionIndexValue);
 };

--- a/divi/src/Makefile.test.include
+++ b/divi/src/Makefile.test.include
@@ -63,6 +63,7 @@ BITCOIN_TESTS =\
   test/MockBlockIncentivesPopulator.h \
   test/MockBlockSubsidyProvider.h \
   test/MockPoSStakeModifierService.h \
+  test/MockUtxoHasher.cpp \
   test/MockVaultManagerDatabase.h \
   test/monthlywalletbackupcreator_tests.cpp \
   test/ActiveMasternode_tests.cpp \
@@ -101,6 +102,7 @@ BITCOIN_TESTS =\
   test/PoSStakeModifierService_tests.cpp \
   test/LegacyPoSStakeModifierService_tests.cpp \
   test/LotteryWinnersCalculatorTests.cpp \
+  test/UtxoCheckingAndUpdating_tests.cpp \
   test/VaultManager_tests.cpp \
   test/multi_wallet_tests.cpp
 

--- a/divi/src/MasternodeBroadcastFactory.cpp
+++ b/divi/src/MasternodeBroadcastFactory.cpp
@@ -17,7 +17,10 @@ extern CChain chainActive;
 extern bool fReindex;
 extern bool fImporting;
 
-bool CMasternodeBroadcastFactory::checkBlockchainSync(std::string& strErrorRet, bool fOffline)
+namespace
+{
+
+bool checkBlockchainSync(std::string& strErrorRet, bool fOffline)
 {
      if (!fOffline && !IsBlockchainSynced()) {
         strErrorRet = "Sync in progress. Must wait until sync is complete to start Masternode";
@@ -26,7 +29,7 @@ bool CMasternodeBroadcastFactory::checkBlockchainSync(std::string& strErrorRet, 
     }
     return true;
 }
-bool CMasternodeBroadcastFactory::setMasternodeKeys(
+bool setMasternodeKeys(
     const std::string& strKeyMasternode,
     std::pair<CKey,CPubKey>& masternodeKeyPair,
     std::string& strErrorRet)
@@ -38,7 +41,7 @@ bool CMasternodeBroadcastFactory::setMasternodeKeys(
     }
     return true;
 }
-bool CMasternodeBroadcastFactory::setMasternodeCollateralKeys(
+bool setMasternodeCollateralKeys(
     const std::string& txHash,
     const std::string& outputIndex,
     const std::string& service,
@@ -63,7 +66,7 @@ bool CMasternodeBroadcastFactory::setMasternodeCollateralKeys(
     return true;
 }
 
-bool CMasternodeBroadcastFactory::checkMasternodeCollateral(
+bool checkMasternodeCollateral(
     const CTxIn& txin,
     const std::string& txHash,
     const std::string& outputIndex,
@@ -95,7 +98,7 @@ bool CMasternodeBroadcastFactory::checkMasternodeCollateral(
     return true;
 }
 
-bool CMasternodeBroadcastFactory::createArgumentsFromConfig(
+bool createArgumentsFromConfig(
     const CMasternodeConfig::CMasternodeEntry configEntry,
     std::string& strErrorRet,
     bool fOffline,
@@ -120,6 +123,8 @@ bool CMasternodeBroadcastFactory::createArgumentsFromConfig(
     }
     return true;
 }
+
+} // anonymous namespace
 
 bool CMasternodeBroadcastFactory::Create(
     const CMasternodeConfig::CMasternodeEntry configEntry,
@@ -278,10 +283,10 @@ CMasternodePing createDelayedMasternodePing(const CMasternodeBroadcast& mnb)
 } // anonymous namespace
 
 void CMasternodeBroadcastFactory::createWithoutSignatures(
-    CTxIn txin,
-    CService service,
-    CPubKey pubKeyCollateralAddressNew,
-    CPubKey pubKeyMasternodeNew,
+    const CTxIn& txin,
+    const CService& service,
+    const CPubKey& pubKeyCollateralAddressNew,
+    const CPubKey& pubKeyMasternodeNew,
     const MasternodeTier nMasternodeTier,
     bool deferRelay,
     CMasternodeBroadcast& mnbRet)
@@ -299,12 +304,12 @@ void CMasternodeBroadcastFactory::createWithoutSignatures(
 }
 
 bool CMasternodeBroadcastFactory::Create(
-    CTxIn txin,
-    CService service,
-    CKey keyCollateralAddressNew,
-    CPubKey pubKeyCollateralAddressNew,
-    CKey keyMasternodeNew,
-    CPubKey pubKeyMasternodeNew,
+    const CTxIn& txin,
+    const CService& service,
+    const CKey& keyCollateralAddressNew,
+    const CPubKey& pubKeyCollateralAddressNew,
+    const CKey& keyMasternodeNew,
+    const CPubKey& pubKeyMasternodeNew,
     const MasternodeTier nMasternodeTier,
     std::string& strErrorRet,
     CMasternodeBroadcast& mnbRet,

--- a/divi/src/MasternodeBroadcastFactory.h
+++ b/divi/src/MasternodeBroadcastFactory.h
@@ -37,10 +37,10 @@ public:
         std::string& strErrorRet);
 private:
     static void createWithoutSignatures(
-        CTxIn txin,
-        CService service,
-        CPubKey pubKeyCollateralAddressNew,
-        CPubKey pubKeyMasternodeNew,
+        const CTxIn& txin,
+        const CService& service,
+        const CPubKey& pubKeyCollateralAddressNew,
+        const CPubKey& pubKeyMasternodeNew,
         MasternodeTier nMasternodeTier,
         bool deferRelay,
         CMasternodeBroadcast& mnbRet);
@@ -57,45 +57,15 @@ private:
         CMasternodeBroadcast& mnb,
         std::string& strErrorRet);
 
-    static bool Create(CTxIn vin,
-                        CService service,
-                        CKey keyCollateralAddressNew,
-                        CPubKey pubKeyCollateralAddressNew,
-                        CKey keyMasternodeNew,
-                        CPubKey pubKeyMasternodeNew,
-                        MasternodeTier nMasternodeTier,
-                        std::string& strErrorRet,
-                        CMasternodeBroadcast& mnbRet,
-                        bool deferRelay);
-    static bool checkBlockchainSync(
-        std::string& strErrorRet, bool fOffline);
-    static bool setMasternodeKeys(
-        const std::string& strKeyMasternode,
-        std::pair<CKey,CPubKey>& masternodeKeyPair,
-        std::string& strErrorRet);
-    static bool setMasternodeCollateralKeys(
-        const std::string& txHash,
-        const std::string& outputIndex,
-        const std::string& service,
-        bool collateralPrivKeyIsRemote,
-        CTxIn& txin,
-        std::pair<CKey,CPubKey>& masternodeCollateralKeyPair,
-        std::string& error);
-    static bool checkMasternodeCollateral(
-        const CTxIn& txin,
-        const std::string& txHash,
-        const std::string& outputIndex,
-        const std::string& service,
-        MasternodeTier& nMasternodeTier,
-        std::string& strErrorRet);
-    static bool createArgumentsFromConfig(
-        const CMasternodeConfig::CMasternodeEntry configEntry,
-        std::string& strErrorRet,
-        bool fOffline,
-        bool collateralPrivKeyIsRemote,
-        CTxIn& txin,
-        std::pair<CKey,CPubKey>& masternodeKeyPair,
-        std::pair<CKey,CPubKey>& masternodeCollateralKeyPair,
-        MasternodeTier& nMasternodeTier);
+    static bool Create(const CTxIn& vin,
+                       const CService& service,
+                       const CKey& keyCollateralAddressNew,
+                       const CPubKey& pubKeyCollateralAddressNew,
+                       const CKey& keyMasternodeNew,
+                       const CPubKey& pubKeyMasternodeNew,
+                       MasternodeTier nMasternodeTier,
+                       std::string& strErrorRet,
+                       CMasternodeBroadcast& mnbRet,
+                       bool deferRelay);
 };
 #endif //MASTERNODE_BROADCAST_FACTORY_H

--- a/divi/src/UtxoCheckingAndUpdating.h
+++ b/divi/src/UtxoCheckingAndUpdating.h
@@ -3,11 +3,14 @@
 #include <vector>
 #include <scriptCheck.h>
 #include <amount.h>
+#include <uint256.h>
 
 class CTransaction;
 class CValidationState;
 class CCoinsViewCache;
 class CTxUndo;
+class TransactionLocationReference;
+
 enum class TxReversalStatus
 {
     ABORT_NO_OTHER_ERRORS,
@@ -15,8 +18,49 @@ enum class TxReversalStatus
     CONTINUE_WITH_ERRORS,
     OK,
 };
-void UpdateCoinsWithTransaction(const CTransaction& tx, CCoinsViewCache& inputs, CTxUndo& txundo, int nHeight);
-TxReversalStatus UpdateCoinsReversingTransaction(const CTransaction& tx, CCoinsViewCache& inputs, const CTxUndo& txundo, int nHeight);
+
+/** Implementations of this interface translate transactions into the hashes
+ *  that will be used to refer to the UTXOs their outputs create.
+ *
+ *  This class abstracts away the segwit-light fork and its activation
+ *  from the places that need to refer to / update UTXOs.
+ *
+ *  For unit tests, this class can be subclassed and mocked.  */
+class TransactionUtxoHasher
+{
+
+public:
+
+  TransactionUtxoHasher() = default;
+  virtual ~TransactionUtxoHasher() = default;
+
+  TransactionUtxoHasher(const TransactionUtxoHasher&) = delete;
+  void operator=(const TransactionUtxoHasher&) = delete;
+
+  virtual uint256 GetUtxoHash(const CTransaction& tx) const = 0;
+
+};
+
+/** A TransactionUtxoHasher for transactions contained in a particular
+ *  block, e.g. for processing that block's connect or disconnect.  Initially
+ *  these are just the txid (as also with upstream Bitcoin), but for
+ *  segwit-light, they are changed to the bare txid.
+ *
+ *  This class abstracts away the segwit-light fork and its activation
+ *  from the places that need to refer to / update UTXOs.
+ *
+ *  For unit tests, this class can be subclassed and mocked.  */
+class BlockUtxoHasher : public TransactionUtxoHasher
+{
+
+public:
+
+  uint256 GetUtxoHash(const CTransaction& tx) const override;
+
+};
+
+void UpdateCoinsWithTransaction(const CTransaction& tx, CCoinsViewCache& inputs, CTxUndo& txundo, const TransactionUtxoHasher& hasher, int nHeight);
+TxReversalStatus UpdateCoinsReversingTransaction(const CTransaction& tx, const TransactionLocationReference& txLocationReference, CCoinsViewCache& inputs, const CTxUndo& txundo);
 bool CheckInputs(
     const CTransaction& tx,
     CValidationState& state,

--- a/divi/src/masternode-sync.h
+++ b/divi/src/masternode-sync.h
@@ -85,7 +85,7 @@ public:
     bool MasternodeWinnersListIsSync(CNode* pnode, const int64_t now);
     void Process(bool networkIsRegtest);
     bool IsSynced() const;
-    bool IsMasternodeListSynced() { return RequestedMasternodeAssets > MASTERNODE_SYNC_LIST; }
+    bool IsMasternodeListSynced() const { return RequestedMasternodeAssets > MASTERNODE_SYNC_LIST; }
     void AskForMN(CNode* pnode, const CTxIn& vin) const;
 };
 

--- a/divi/src/masternode.cpp
+++ b/divi/src/masternode.cpp
@@ -258,7 +258,10 @@ bool CMasternode::IsValidNetAddr() const
             (IsReachable(addr) && addr.IsRoutable());
 }
 
-CMasternodeBroadcast::CMasternodeBroadcast(CService newAddr, CTxIn newVin, CPubKey pubKeyCollateralAddressNew, CPubKey pubKeyMasternodeNew, const MasternodeTier nMasternodeTier, int protocolVersionIn)
+CMasternodeBroadcast::CMasternodeBroadcast(
+    const CService& newAddr, const CTxIn& newVin,
+    const CPubKey& pubKeyCollateralAddressNew, const CPubKey& pubKeyMasternodeNew,
+    const MasternodeTier nMasternodeTier, const int protocolVersionIn)
 {
     vin = newVin;
     addr = newAddr;

--- a/divi/src/masternode.h
+++ b/divi/src/masternode.h
@@ -146,15 +146,19 @@ public:
 
 class CMasternodeBroadcast : public CMasternode
 {
-public:
-    CMasternodeBroadcast() = default;
+private:
     CMasternodeBroadcast(
-        CService newAddr,
-        CTxIn newVin,
-        CPubKey pubKeyCollateralAddress,
-        CPubKey pubKeyMasternode,
+        const CService& newAddr,
+        const CTxIn& newVin,
+        const CPubKey& pubKeyCollateralAddress,
+        const CPubKey& pubKeyMasternode,
         MasternodeTier nMasternodeTier,
         int protocolVersionIn);
+
+    friend class CMasternodeBroadcastFactory;
+
+public:
+    CMasternodeBroadcast() = default;
     CMasternodeBroadcast(const CMasternode& mn);
 
     void Relay() const;

--- a/divi/src/masternodeconfig.cpp
+++ b/divi/src/masternodeconfig.cpp
@@ -23,10 +23,11 @@ boost::filesystem::path GetMasternodeConfigFile()
     if (!pathConfigFile.is_complete()) pathConfigFile = GetDataDir() / pathConfigFile;
     return pathConfigFile;
 }
-void CMasternodeConfig::add(std::string alias, std::string ip, std::string privKey, std::string txHash, std::string outputIndex)
+
+void CMasternodeConfig::add(const std::string& alias, const std::string& ip, const std::string& privKey,
+                            const std::string& txHash, const std::string& outputIndex)
 {
-    CMasternodeEntry cme(alias, ip, privKey, txHash, outputIndex);
-    entries.push_back(cme);
+    entries.emplace_back(alias, ip, privKey, txHash, outputIndex);
 }
 
 bool CMasternodeConfig::read(std::string& strErr)
@@ -94,15 +95,16 @@ CMasternodeConfig::CMasternodeConfig()
 {
     entries = std::vector<CMasternodeEntry>();
 }
+
 const std::vector<CMasternodeConfig::CMasternodeEntry>& CMasternodeConfig::getEntries() const
 {
     return entries;
 }
 
-int CMasternodeConfig::getCount()
+int CMasternodeConfig::getCount() const
 {
     int c = -1;
-    BOOST_FOREACH (CMasternodeEntry e, entries) {
+    for (const auto& e : entries) {
         if (e.getAlias() != "") c++;
     }
     return c;

--- a/divi/src/masternodeconfig.h
+++ b/divi/src/masternodeconfig.h
@@ -25,7 +25,9 @@ public:
         std::string outputIndex;
 
     public:
-        CMasternodeEntry(std::string alias, std::string ip, std::string privKey, std::string txHash, std::string outputIndex)
+        CMasternodeEntry(const std::string& alias, const std::string& ip,
+                         const std::string& privKey,
+                         const std::string& txHash, const std::string& outputIndex)
         {
             this->alias = alias;
             this->ip = ip;
@@ -91,9 +93,10 @@ public:
 
     void clear();
     bool read(std::string& strErr);
-    void add(std::string alias, std::string ip, std::string privKey, std::string txHash, std::string outputIndex);
+    void add(const std::string& alias, const std::string& ip, const std::string& privKey,
+             const std::string& txHash, const std::string& outputIndex);
     const std::vector<CMasternodeEntry>& getEntries() const;
-    int getCount();
+    int getCount() const;
 
 private:
     std::vector<CMasternodeEntry> entries;

--- a/divi/src/test/MockUtxoHasher.cpp
+++ b/divi/src/test/MockUtxoHasher.cpp
@@ -11,6 +11,11 @@ uint256 MockUtxoHasher::Add(const CTransaction& tx)
   return value;
 }
 
+void MockUtxoHasher::UseBareTxid(const CTransaction& tx)
+{
+  customHashes.emplace(tx.GetHash(), tx.GetBareTxid());
+}
+
 uint256 MockUtxoHasher::GetUtxoHash(const CTransaction& tx) const
 {
   const uint256 txid = tx.GetHash();

--- a/divi/src/test/MockUtxoHasher.cpp
+++ b/divi/src/test/MockUtxoHasher.cpp
@@ -1,0 +1,21 @@
+#include "MockUtxoHasher.h"
+
+#include "hash.h"
+#include "primitives/transaction.h"
+
+uint256 MockUtxoHasher::Add(const CTransaction& tx)
+{
+  ++cnt;
+  const uint256 value = Hash(&cnt, (&cnt) + 1);
+  customHashes.emplace(tx.GetHash(), value);
+  return value;
+}
+
+uint256 MockUtxoHasher::GetUtxoHash(const CTransaction& tx) const
+{
+  const uint256 txid = tx.GetHash();
+  const auto mit = customHashes.find(txid);
+  if (mit != customHashes.end())
+    return mit->second;
+  return txid;
+}

--- a/divi/src/test/MockUtxoHasher.h
+++ b/divi/src/test/MockUtxoHasher.h
@@ -32,6 +32,10 @@ public:
    *  is generated uniquely and returned from the function.  */
   uint256 Add(const CTransaction& tx);
 
+  /** Marks the given transaction for using the bare txid rather than
+   *  the normal txid.  */
+  void UseBareTxid(const CTransaction& tx);
+
   uint256 GetUtxoHash(const CTransaction& tx) const override;
 
 };

--- a/divi/src/test/MockUtxoHasher.h
+++ b/divi/src/test/MockUtxoHasher.h
@@ -1,0 +1,39 @@
+#ifndef MOCKUTXOHASHER_H
+#define MOCKUTXOHASHER_H
+
+#include "UtxoCheckingAndUpdating.h"
+
+#include "uint256.h"
+
+#include <map>
+
+class CTransaction;
+
+/** A TransactionUtxoHasher instance that returns normal txid's (as per before
+ *  segwit-light) by default, but can be instructed to return custom hashes
+ *  for certain transactions.  */
+class MockUtxoHasher : public TransactionUtxoHasher
+{
+
+private:
+
+  /** Custom hashes to return for given txid's.  */
+  std::map<uint256, uint256> customHashes;
+
+  /** Internal counter to produce unique fake hashes.  */
+  unsigned cnt = 0;
+
+public:
+
+  MockUtxoHasher()
+  {}
+
+  /** Marks the given transaction for returning a custom hash.  The hash
+   *  is generated uniquely and returned from the function.  */
+  uint256 Add(const CTransaction& tx);
+
+  uint256 GetUtxoHash(const CTransaction& tx) const override;
+
+};
+
+#endif // MOCKUTXOHASHER_H

--- a/divi/src/test/UtxoCheckingAndUpdating_tests.cpp
+++ b/divi/src/test/UtxoCheckingAndUpdating_tests.cpp
@@ -41,8 +41,8 @@ BOOST_AUTO_TEST_CASE(addsCorrectOutputs)
   const auto id2 = utxoHasher.Add(tx2);
 
   CTxUndo txundo;
-  UpdateCoins(tx1, coins, txundo, utxoHasher, 101);
-  UpdateCoins(tx2, coins, txundo, utxoHasher, 102);
+  UpdateCoinsWithTransaction(tx1, coins, txundo, utxoHasher, 101);
+  UpdateCoinsWithTransaction(tx2, coins, txundo, utxoHasher, 102);
 
   BOOST_CHECK(coins.HaveCoins(tx1.GetHash()));
   BOOST_CHECK(!coins.HaveCoins(tx2.GetHash()));

--- a/divi/src/test/UtxoCheckingAndUpdating_tests.cpp
+++ b/divi/src/test/UtxoCheckingAndUpdating_tests.cpp
@@ -1,0 +1,54 @@
+#include <test_only.h>
+#include <UtxoCheckingAndUpdating.h>
+
+#include "coins.h"
+#include "MockUtxoHasher.h"
+#include "primitives/transaction.h"
+
+namespace
+{
+
+class UpdateCoinsTestFixture
+{
+
+private:
+
+  /** Empty coins used as base in the cached view.  */
+  CCoinsView dummyCoins;
+
+protected:
+
+  CCoinsViewCache coins;
+  MockUtxoHasher utxoHasher;
+
+  UpdateCoinsTestFixture()
+    : coins(&dummyCoins)
+  {}
+
+};
+
+BOOST_FIXTURE_TEST_SUITE(UpdateCoins_tests, UpdateCoinsTestFixture)
+
+BOOST_AUTO_TEST_CASE(addsCorrectOutputs)
+{
+  CMutableTransaction mtx;
+  mtx.vout.emplace_back(1, CScript() << OP_TRUE);
+  const CTransaction tx1(mtx);
+
+  mtx.vout.clear();
+  mtx.vout.emplace_back(2, CScript() << OP_TRUE);
+  const CTransaction tx2(mtx);
+  const auto id2 = utxoHasher.Add(tx2);
+
+  CTxUndo txundo;
+  UpdateCoins(tx1, coins, txundo, utxoHasher, 101);
+  UpdateCoins(tx2, coins, txundo, utxoHasher, 102);
+
+  BOOST_CHECK(coins.HaveCoins(tx1.GetHash()));
+  BOOST_CHECK(!coins.HaveCoins(tx2.GetHash()));
+  BOOST_CHECK(coins.HaveCoins(id2));
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+} // anonymous namespace

--- a/divi/src/txmempool.cpp
+++ b/divi/src/txmempool.cpp
@@ -450,6 +450,11 @@ const TransactionUtxoHasher& CTxMemPool::GetUtxoHasher() const
     return *utxoHasher;
 }
 
+void CTxMemPool::SetUtxoHasherForTesting(std::unique_ptr<TransactionUtxoHasher> hasher)
+{
+    utxoHasher = std::move(hasher);
+}
+
 void CTxMemPool::addAddressIndex(const CTxMemPoolEntry &entry, const CCoinsViewCache &view)
 {
     LOCK(cs);

--- a/divi/src/txmempool.h
+++ b/divi/src/txmempool.h
@@ -158,6 +158,10 @@ public:
     /** Returns the UTXO hasher instance used in the mempool.  */
     const TransactionUtxoHasher& GetUtxoHasher() const;
 
+    /** Replaces the UTXO hasher used in the mempool with the given instance,
+     *  which allows dependency injection for unit tests.  */
+    void SetUtxoHasherForTesting(std::unique_ptr<TransactionUtxoHasher> hasher);
+
     void addAddressIndex(const CTxMemPoolEntry &entry, const CCoinsViewCache &view);
     bool getAddressIndex(std::vector<std::pair<uint160, int> > &addresses,
                          std::vector<std::pair<CMempoolAddressDeltaKey, CMempoolAddressDelta> > &results);


### PR DESCRIPTION
This creates a new `TransactionUtxoHasher` abstraction:  The class is responsible for mapping a given `CTransaction` to the `uint256` that is used to refer to the UTXOs created by the transaction.  This is currently just the normal txid (`tx.GetHash()`), but in the future with segwit-light (#61) will be changed.

For now, this PR just refactors the code to make it explicit where in the consensus and mempool (not yet the wallet) we actually use this concept of "UTXOs of a given transaction".  Apart from unit tests, the hasher always returns the txid that was used inline before, so this does not affect consensus or introduces a fork yet.  But it will make it easier to do so in the future.