### PR TITLE
FakeWallet and other test refactorings

### DIFF
--- a/divi/src/BlockIncentivesPopulator.h
+++ b/divi/src/BlockIncentivesPopulator.h
@@ -1,5 +1,6 @@
 #ifndef BLOCK_INCENTIVES_POPULATOR_H
 #define BLOCK_INCENTIVES_POPULATOR_H
+#include "I_BlockIncentivesPopulator.h"
 #include <string>
 #include <amount.h>
 
@@ -15,7 +16,7 @@ class CTransaction;
 class CMasternodeSync;
 class CSporkManager;
 
-class BlockIncentivesPopulator
+class BlockIncentivesPopulator : public I_BlockIncentivesPopulator
 {
 private:
     const CChainParams& chainParameters_;
@@ -31,6 +32,7 @@ private:
 private:
     void FillTreasuryPayment(CMutableTransaction &tx, int nHeight) const;
     void FillLotteryPayment(CMutableTransaction &tx, const CBlockRewards &rewards, const CBlockIndex *currentBlockIndex) const;
+    bool HasValidMasternodePayee(const CTransaction &txNew, const CBlockIndex* pindex) const;
 
 public:
     BlockIncentivesPopulator(
@@ -41,10 +43,10 @@ public:
         const I_SuperblockHeightValidator& heightValidator,
         const I_BlockSubsidyProvider& blockSubsidies,
         const CSporkManager& sporkManager);
-    void FillBlockPayee(CMutableTransaction& txNew, const CBlockRewards &payments, const CBlockIndex* chainTip, bool fProofOfStake) const;
-    bool IsBlockValueValid(const CBlockRewards &nExpectedValue, CAmount nMinted, int nHeight) const;
-    bool HasValidPayees(const CTransaction &txNew, const CBlockIndex* pindex) const;
-    bool HasValidMasternodePayee(const CTransaction &txNew, const CBlockIndex* pindex) const;
+
+    void FillBlockPayee(CMutableTransaction& txNew, const CBlockRewards &payments, const CBlockIndex* chainTip, bool fProofOfStake) const override;
+    bool IsBlockValueValid(const CBlockRewards &nExpectedValue, CAmount nMinted, int nHeight) const override;
+    bool HasValidPayees(const CTransaction &txNew, const CBlockIndex* pindex) const override;
 };
 
 #endif // BLOCK_INCENTIVES_POPULATOR_H

--- a/divi/src/BlockMemoryPoolTransactionCollector.cpp
+++ b/divi/src/BlockMemoryPoolTransactionCollector.cpp
@@ -16,9 +16,10 @@
 #include <Settings.h>
 extern Settings& settings;
 
+extern CChain chainActive;
 extern CCoinsViewCache* pcoinsTip;
 
-bool IsFinalTx(const CTransaction& tx, int nBlockHeight = 0 , int64_t nBlockTime = 0);
+bool IsFinalTx(const CTransaction& tx, const CChain& activeChain, int nBlockHeight = 0 , int64_t nBlockTime = 0);
 
 unsigned int GetMaxBlockSize(unsigned int defaultMaxBlockSize, unsigned int maxBlockSizeCurrent)
 {
@@ -189,7 +190,7 @@ std::vector<TxPriority> BlockMemoryPoolTransactionCollector::PrioritizeMempoolTr
     vecPriority.reserve(mempool_.mapTx.size());
     for (auto mi = mempool_.mapTx.begin(); mi != mempool_.mapTx.end(); ++mi) {
         const CTransaction& tx = mi->second.GetTx();
-        if (tx.IsCoinBase() || tx.IsCoinStake() || !IsFinalTx(tx, nHeight)){
+        if (tx.IsCoinBase() || tx.IsCoinStake() || !IsFinalTx(tx, chainActive, nHeight)){
             continue;
         }
 

--- a/divi/src/I_BlockIncentivesPopulator.h
+++ b/divi/src/I_BlockIncentivesPopulator.h
@@ -1,0 +1,22 @@
+#ifndef I_BLOCK_INCENTIVES_POPULATOR_H
+#define _BLOCK_INCENTIVES_POPULATOR_H
+
+#include <amount.h>
+
+class CMutableTransaction;
+class CBlockRewards;
+class CBlockIndex;
+class CTransaction;
+
+class I_BlockIncentivesPopulator
+{
+public:
+    I_BlockIncentivesPopulator() = default;
+    virtual ~I_BlockIncentivesPopulator() = default;
+
+    virtual void FillBlockPayee(CMutableTransaction& txNew, const CBlockRewards &payments, const CBlockIndex* chainTip, bool fProofOfStake) const = 0;
+    virtual bool IsBlockValueValid(const CBlockRewards &nExpectedValue, CAmount nMinted, int nHeight) const = 0;
+    virtual bool HasValidPayees(const CTransaction &txNew, const CBlockIndex* pindex) const = 0;
+};
+
+#endif // I_BLOCK_INCENTIVES_POPULATOR_H

--- a/divi/src/Makefile.am
+++ b/divi/src/Makefile.am
@@ -159,6 +159,7 @@ BITCOIN_CORE_H = \
   i_walletBackupCreator.h \
   i_databaseWrapper.h \
   I_SuperblockHeightValidator.h \
+  I_BlockIncentivesPopulator.h \
   I_BlockSubsidyProvider.h \
   I_BIP9ActivationStateTracker.h \
   I_BIP9ActivationTrackerFactory.h \

--- a/divi/src/Makefile.test.include
+++ b/divi/src/Makefile.test.include
@@ -49,6 +49,7 @@ BITCOIN_TESTS =\
   test/crypto_tests.cpp \
   test/DoS_tests.cpp \
   test/FakeBlockIndexChain.cpp \
+  test/FakeWallet.cpp \
   test/ForkActivation_tests.cpp \
   test/getarg_tests.cpp \
   test/hash_tests.cpp \

--- a/divi/src/Makefile.test.include
+++ b/divi/src/Makefile.test.include
@@ -60,6 +60,7 @@ BITCOIN_TESTS =\
   test/MockFileSystem.cpp \
   test/MockCoinMinter.h \
   test/MockSuperblockHeightValidator.h \
+  test/MockBlockIncentivesPopulator.h \
   test/MockBlockSubsidyProvider.h \
   test/MockPoSStakeModifierService.h \
   test/MockVaultManagerDatabase.h \

--- a/divi/src/PoSTransactionCreator.cpp
+++ b/divi/src/PoSTransactionCreator.cpp
@@ -5,9 +5,9 @@
 #include <masternode-payments.h>
 #include <script/sign.h>
 #include <utilmoneystr.h>
+#include <I_BlockIncentivesPopulator.h>
 #include <I_BlockSubsidyProvider.h>
 #include <Settings.h>
-#include <BlockIncentivesPopulator.h>
 #include <blockmap.h>
 #include <chain.h>
 #include <chainparams.h>
@@ -49,10 +49,10 @@ public:
 
 PoSTransactionCreator::PoSTransactionCreator(
     const CChainParams& chainParameters,
-    CChain& activeChain,
+    const CChain& activeChain,
     const BlockMap& mapBlockIndex,
     const I_BlockSubsidyProvider& blockSubsidies,
-    const BlockIncentivesPopulator& incentives,
+    const I_BlockIncentivesPopulator& incentives,
     const I_ProofOfStakeGenerator& proofGenerator,
     CWallet& wallet,
     std::map<unsigned int, unsigned int>& hashedBlockTimestamps

--- a/divi/src/PoSTransactionCreator.h
+++ b/divi/src/PoSTransactionCreator.h
@@ -17,7 +17,7 @@ class CKeyStore;
 class CTransaction;
 class CChainParams;
 class I_SuperblockSubsidyContainer;
-class BlockIncentivesPopulator;
+class I_BlockIncentivesPopulator;
 class CChain;
 class I_PoSStakeModifierService;
 class I_ProofOfStakeGenerator;
@@ -30,10 +30,10 @@ class PoSTransactionCreator: public I_PoSTransactionCreator
 {
 private:
     const CChainParams& chainParameters_;
-    CChain& activeChain_;
+    const CChain& activeChain_;
     const BlockMap& mapBlockIndex_;
     const I_BlockSubsidyProvider& blockSubsidies_;
-    const BlockIncentivesPopulator& incentives_;
+    const I_BlockIncentivesPopulator& incentives_;
     const I_ProofOfStakeGenerator& proofGenerator_;
     std::unique_ptr<StakedCoins> stakedCoins_;
     CWallet& wallet_;
@@ -78,10 +78,10 @@ private:
 public:
     PoSTransactionCreator(
         const CChainParams& chainParameters,
-        CChain& activeChain,
+        const CChain& activeChain,
         const BlockMap& mapBlockIndex,
         const I_BlockSubsidyProvider& blockSubsidies,
-        const BlockIncentivesPopulator& incentives,
+        const I_BlockIncentivesPopulator& incentives,
         const I_ProofOfStakeGenerator& proofGenerator,
         CWallet& wallet,
         std::map<unsigned int, unsigned int>& hashedBlockTimestamps);

--- a/divi/src/init.cpp
+++ b/divi/src/init.cpp
@@ -1291,7 +1291,7 @@ bool TryToLoadBlocks(bool& fLoaded, std::string& strLoadError)
 bool CreateNewWalletIfOneIsNotAvailable(std::string strWalletFile, std::ostringstream& strErrors)
 {
     bool fFirstRun = true;
-    pwalletMain = new CWallet(strWalletFile);
+    pwalletMain = new CWallet(strWalletFile, chainActive, mapBlockIndex);
     DBErrors nLoadWalletRet = pwalletMain->LoadWallet(fFirstRun);
     if (nLoadWalletRet != DB_LOAD_OK) {
         if (nLoadWalletRet == DB_CORRUPT)
@@ -1620,7 +1620,7 @@ bool InitializeDivi(boost::thread_group& threadGroup)
         if (settings.GetBoolArg("-zapwallettxes", false)) {
             uiInterface.InitMessage(translate("Zapping all transactions from wallet..."));
 
-            pwalletMain = new CWallet(strWalletFile);
+            pwalletMain = new CWallet(strWalletFile, chainActive, mapBlockIndex);
             DBErrors nZapWalletRet = pwalletMain->ZapWalletTx(vWtx);
             if (nZapWalletRet != DB_LOAD_OK) {
                 uiInterface.InitMessage(translate("Error loading wallet.dat: Wallet corrupted"));

--- a/divi/src/main.cpp
+++ b/divi/src/main.cpp
@@ -89,7 +89,7 @@ bool fCheckBlockIndex = false;
 bool fVerifyingBlocks = false;
 unsigned int nCoinCacheSize = 5000;
 bool fAlerts = DEFAULT_ALERTS;
-bool IsFinalTx(const CTransaction& tx, int nBlockHeight = 0 , int64_t nBlockTime = 0);
+bool IsFinalTx(const CTransaction& tx, const CChain& activeChain, int nBlockHeight = 0 , int64_t nBlockTime = 0);
 
 CCheckpointServices checkpointsVerifier(GetCurrentChainCheckpoints);
 
@@ -673,7 +673,7 @@ bool IsStandardTx(const CTransaction& tx, string& reason)
     // Timestamps on the other hand don't get any special treatment, because we
     // can't know what timestamp the next block will have, and there aren't
     // timestamp applications where it matters.
-    if (!IsFinalTx(tx, chainActive.Height() + 1)) {
+    if (!IsFinalTx(tx, chainActive, chainActive.Height() + 1)) {
         reason = "non-final";
         return false;
     }
@@ -2812,7 +2812,7 @@ bool ContextualCheckBlock(const CBlock& block, CValidationState& state, CBlockIn
 
     // Check that all transactions are finalized
     for (const auto& tx : block.vtx)
-            if (!IsFinalTx(tx, nHeight, block.GetBlockTime())) {
+            if (!IsFinalTx(tx, chainActive, nHeight, block.GetBlockTime())) {
         return state.DoS(10, error("%s : contains a non-final transaction", __func__), REJECT_INVALID, "bad-txns-nonfinal");
     }
 

--- a/divi/src/rpcwallet.cpp
+++ b/divi/src/rpcwallet.cpp
@@ -903,7 +903,7 @@ Value getreceivedbyaddress(const Array& params, bool fHelp)
     for (std::vector<const CWalletTx*>::iterator it = walletTransactions.begin(); it != walletTransactions.end(); ++it)
     {
         const CWalletTx& wtx = *(*it);
-        if (wtx.IsCoinBase() || !IsFinalTx(wtx))
+        if (wtx.IsCoinBase() || !IsFinalTx(wtx, chainActive))
             continue;
 
         BOOST_FOREACH (const CTxOut& txout, wtx.vout)
@@ -949,7 +949,7 @@ Value getreceivedbyaccount(const Array& params, bool fHelp)
     for (std::vector<const CWalletTx*>::iterator it = walletTransactions.begin(); it != walletTransactions.end(); ++it)
     {
         const CWalletTx& wtx = *(*it);
-        if (wtx.IsCoinBase() || !IsFinalTx(wtx))
+        if (wtx.IsCoinBase() || !IsFinalTx(wtx, chainActive))
             continue;
 
         BOOST_FOREACH (const CTxOut& txout, wtx.vout) {
@@ -973,7 +973,7 @@ CAmount GetAccountBalance(CWalletDB& walletdb, const string& strAccount, int nMi
     for (std::vector<const CWalletTx*>::iterator it = walletTransactions.begin(); it != walletTransactions.end(); ++it)
     {
         const CWalletTx& wtx = *(*it);
-        if (!IsFinalTx(wtx) || wtx.GetBlocksToMaturity() > 0 || wtx.GetNumberOfBlockConfirmations() < 0)
+        if (!IsFinalTx(wtx, chainActive) || wtx.GetBlocksToMaturity() > 0 || wtx.GetNumberOfBlockConfirmations() < 0)
             continue;
 
         CAmount nReceived, nSent, nFee;
@@ -1040,7 +1040,7 @@ Value getbalance(const Array& params, bool fHelp)
         for (std::vector<const CWalletTx*>::iterator it = walletTransactions.begin(); it != walletTransactions.end(); ++it)
         {
             const CWalletTx& wtx = *(*it);
-            if (!IsFinalTx(wtx) || wtx.GetBlocksToMaturity() > 0 || wtx.GetNumberOfBlockConfirmations() < 0)
+            if (!IsFinalTx(wtx, chainActive) || wtx.GetBlocksToMaturity() > 0 || wtx.GetNumberOfBlockConfirmations() < 0)
                 continue;
 
             CAmount allFee;
@@ -1325,7 +1325,7 @@ Value ListReceived(const Array& params, bool fByAccounts)
     {
         const CWalletTx& wtx = *(*it);
 
-        if (wtx.IsCoinBase() || !IsFinalTx(wtx))
+        if (wtx.IsCoinBase() || !IsFinalTx(wtx, chainActive))
             continue;
 
         int nDepth = wtx.GetNumberOfBlockConfirmations();

--- a/divi/src/test/FakeBlockIndexChain.cpp
+++ b/divi/src/test/FakeBlockIndexChain.cpp
@@ -86,12 +86,11 @@ FakeBlockIndexWithHashes::FakeBlockIndexWithHashes(
     unsigned blockStartTime,
     unsigned versionNumber
     ): randomBlockHashSeed_(uint256S("135bd924226929c2f4267f5e5c653d2a4ae0018187588dc1f016ceffe525fad2"))
-    , numberOfBlocks_(numberOfBlocks)
     , fakeBlockIndexChain_()
     , blockIndexByHash(new BlockMap())
     , activeChain(new CChain())
 {
-    addBlocks(numberOfBlocks_,versionNumber,blockStartTime);
+    addBlocks(numberOfBlocks, versionNumber, blockStartTime);
 }
 FakeBlockIndexWithHashes::~FakeBlockIndexWithHashes()
 {

--- a/divi/src/test/FakeBlockIndexChain.h
+++ b/divi/src/test/FakeBlockIndexChain.h
@@ -39,7 +39,6 @@ class FakeBlockIndexWithHashes
 {
 private:
     uint256 randomBlockHashSeed_;
-    unsigned numberOfBlocks_;
     FakeBlockIndexChain fakeBlockIndexChain_;
 public:
     std::unique_ptr<BlockMap> blockIndexByHash;

--- a/divi/src/test/FakeWallet.cpp
+++ b/divi/src/test/FakeWallet.cpp
@@ -37,7 +37,8 @@ const CHDChain& getHDWalletSeedForTesting()
 
   if (toBeConstructed)
   {
-    CWallet wallet("test_wallet.dat");
+    FakeBlockIndexWithHashes dummyChain(1, 1600000000, 1);
+    CWallet wallet("test_wallet.dat", *dummyChain.activeChain, *dummyChain.blockIndexByHash);
     wallet.defaultKeyPoolTopUp = 1;
     bool firstLoad = true;
     wallet.LoadWallet(firstLoad);
@@ -77,7 +78,7 @@ CMutableTransaction createDefaultTransaction(const CScript& defaultScript, unsig
 } // anonymous namespace
 
 FakeWallet::FakeWallet(FakeBlockIndexWithHashes& c)
-  : CWallet(GetWalletFilename()),
+  : CWallet(GetWalletFilename(), *c.activeChain, *c.blockIndexByHash),
     fakeChain(c)
 {
   defaultKeyPoolTopUp = (int64_t)3;

--- a/divi/src/test/FakeWallet.cpp
+++ b/divi/src/test/FakeWallet.cpp
@@ -1,0 +1,124 @@
+// Copyright (c) 2021 The Divi developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "test/FakeWallet.h"
+
+#include "chain.h"
+#include "merkletx.h"
+#include "primitives/transaction.h"
+#include "random.h"
+#include "script/script.h"
+#include "sync.h"
+#include "WalletTx.h"
+
+#include <sstream>
+#include <string>
+
+namespace
+{
+
+/** Returns a unique wallet filename.  */
+std::string GetWalletFilename()
+{
+  static int cnt = 0;
+  std::ostringstream res;
+  res << "currentWallet" << (++cnt) << ".dat";
+  return res.str();
+}
+
+/** Returns a HD seed for testing.  */
+const CHDChain& getHDWalletSeedForTesting()
+{
+  static CCriticalSection cs_testing;
+  static bool toBeConstructed = true;
+  static CHDChain hdchain;
+  LOCK(cs_testing);
+
+  if (toBeConstructed)
+  {
+    CWallet wallet("test_wallet.dat");
+    wallet.defaultKeyPoolTopUp = 1;
+    bool firstLoad = true;
+    wallet.LoadWallet(firstLoad);
+    wallet.GenerateNewHDChain();
+    wallet.GetHDChain(hdchain);
+    toBeConstructed = false;
+  }
+
+  return hdchain;
+}
+
+/** Creates a "normal" transaction paying to the given script.  */
+CMutableTransaction createDefaultTransaction(const CScript& defaultScript, unsigned& index,
+                                             const CAmount amount)
+{
+  static int nextLockTime = 0;
+  const int numberOfIndices = GetRand(10) + 1;
+  index = GetRand(numberOfIndices);
+
+  CMutableTransaction tx;
+  tx.nLockTime = nextLockTime++; // so all transactions get different hashes
+  tx.vout.resize(numberOfIndices);
+  for(CTxOut& output: tx.vout)
+  {
+    output.nValue = 1;
+    output.scriptPubKey = CScript() << OP_TRUE;
+  }
+  tx.vout[index].nValue = amount;
+  tx.vout[index].scriptPubKey = defaultScript;
+  tx.vin.resize(1);
+  // Avoid flagging as a coinbase tx
+  tx.vin[0].prevout = COutPoint(GetRandHash(),static_cast<uint32_t>(GetRand(100)) );
+
+  return tx;
+}
+
+} // anonymous namespace
+
+FakeWallet::FakeWallet(FakeBlockIndexWithHashes& c)
+  : CWallet(GetWalletFilename()),
+    fakeChain(c)
+{
+  defaultKeyPoolTopUp = (int64_t)3;
+  bool firstLoad = true;
+  CPubKey newDefaultKey;
+  LoadWallet(firstLoad);
+  //GenerateNewHDChain();
+  SetHDChain(getHDWalletSeedForTesting(),false);
+  SetMinVersion(FEATURE_HD);
+  GetKeyFromPool(newDefaultKey, false);
+  SetDefaultKey(newDefaultKey);
+}
+
+void FakeWallet::AddBlock()
+{
+  fakeChain.addBlocks(1, version);
+}
+
+const CWalletTx& FakeWallet::AddDefaultTx(const CScript& scriptToPayTo, unsigned& outputIndex,
+                                          const CAmount amount)
+{
+  const CMutableTransaction tx = createDefaultTransaction(scriptToPayTo, outputIndex, amount);
+  const CMerkleTx merkleTx(tx, *fakeChain.activeChain, *fakeChain.blockIndexByHash);
+  const CWalletTx wtx(merkleTx);
+  AddToWallet(wtx);
+  const CWalletTx* txPtr = GetWalletTx(wtx.GetHash());
+  assert(txPtr);
+  return *txPtr;
+}
+
+void FakeWallet::FakeAddToChain(const CWalletTx& tx)
+{
+  auto* txPtr = const_cast<CWalletTx*>(&tx);
+  txPtr->hashBlock = fakeChain.activeChain->Tip()->GetBlockHash();
+  txPtr->nIndex = 0;
+  txPtr->fMerkleVerified = true;
+}
+
+CPubKey FakeWallet::getNewKey()
+{
+  CPubKey nextKeyGenerated;
+  GetKeyFromPool(nextKeyGenerated, false);
+  return nextKeyGenerated;
+}

--- a/divi/src/test/FakeWallet.h
+++ b/divi/src/test/FakeWallet.h
@@ -1,0 +1,53 @@
+// Copyright (c) 2021 The Divi developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef FAKE_WALLET_H
+#define FAKE_WALLET_H
+
+#include "amount.h"
+#include "wallet.h"
+
+#include "test/FakeBlockIndexChain.h"
+
+#include <cstdint>
+
+class CScript;
+
+/** A wallet with (mostly) real seed and keys, which can be used in tests
+ *  that need to exercise wallet functions.  */
+class FakeWallet : public CWallet
+{
+
+private:
+  
+  /** Version for blocks to add.  */
+  static constexpr int32_t version = 1;
+
+  /** The fake chain that we use for the wallet.  */
+  FakeBlockIndexWithHashes& fakeChain;
+
+public:
+
+  /** Constructs the wallet with a given external fake chain.  */
+  explicit FakeWallet(FakeBlockIndexWithHashes& c);
+
+  /** Adds a new block to our fake chain.  */
+  void AddBlock();
+
+  /** Adds a new ordinary transaction to the wallet, paying a given amount
+   *  to a given script.  The transaction is returned, and the output index
+   *  with the output to the requested script is set.  */
+  const CWalletTx& AddDefaultTx(const CScript& scriptToPayTo, unsigned& outputIndex,
+                                CAmount amount = 100 * COIN);
+
+  /** Modifies the given wallet transaction to look like it was included in the
+   *  current top block.  */
+  void FakeAddToChain(const CWalletTx& tx);
+
+  /** Returns a new key from the wallet.  */
+  CPubKey getNewKey();
+
+};
+
+#endif // FAKE_WALLET_H

--- a/divi/src/test/MockBlockIncentivesPopulator.h
+++ b/divi/src/test/MockBlockIncentivesPopulator.h
@@ -1,0 +1,17 @@
+#ifndef MOCK_BLOCK_INCENTIVES_POPULATOR_H
+#define MOCK_BLOCK_INCENTIVES_POPULATOR_H
+
+#include "BlockRewards.h"
+#include "I_BlockIncentivesPopulator.h"
+
+#include <gmock/gmock.h>
+
+class MockBlockIncentivesPopulator : public I_BlockIncentivesPopulator
+{
+public:
+    MOCK_CONST_METHOD4(FillBlockPayee, void(CMutableTransaction&, const CBlockRewards&, const CBlockIndex*, bool fProofOfStake));
+    MOCK_CONST_METHOD3(IsBlockValueValid, bool(const CBlockRewards&, CAmount, int));
+    MOCK_CONST_METHOD2(HasValidPayees, bool(const CTransaction&, const CBlockIndex*));
+};
+
+#endif // MOCK_BLOCK_INCENTIVES_POPULATOR_H

--- a/divi/src/test/multi_wallet_tests.cpp
+++ b/divi/src/test/multi_wallet_tests.cpp
@@ -14,70 +14,18 @@
 #include <chain.h>
 #include <blockmap.h>
 #include <test/FakeBlockIndexChain.h>
+#include <test/FakeWallet.h>
 
 class MultiWalletTestFixture
 {
-public:
-    CMutableTransaction createDefaultTransaction(CScript defaultScript,unsigned& index, CAmount amount)
-    {
-        static int nextLockTime = 0;
-        int numberOfIndices = GetRand(10)+1;
-        index = GetRand(numberOfIndices);
-        CMutableTransaction tx;
-        tx.nLockTime = nextLockTime++;        // so all transactions get different hashes
-        tx.vout.resize(numberOfIndices);
-        for(CTxOut& output: tx.vout)
-        {
-            output.nValue = 1;
-            output.scriptPubKey = CScript() << OP_TRUE;
-        }
-        tx.vout[index].nValue = amount;
-        tx.vout[index].scriptPubKey = defaultScript;
-        tx.vin.resize(1);
-        {// Avoid flagging as a coinbase tx
-            tx.vin[0].prevout = COutPoint(GetRandHash(),static_cast<uint32_t>(GetRand(100)) );
-        }
-        return tx;
-    }
 private:
-    std::vector<std::unique_ptr<CWallet>> walletCache_;
-    const int32_t version;
-    int32_t timestamp;
-    CChain activeChain_;
-    BlockMap blockIndices_;
-    FakeBlockIndexChain fakeChain_;
+    std::vector<std::unique_ptr<FakeWallet>> walletCache_;
+    FakeBlockIndexWithHashes fakeChain_;
 public:
-    static void EnableSmallHDWallet(CWallet& wallet)
-    {
-        wallet.defaultKeyPoolTopUp = (int64_t)1;
-        bool firstLoad = true;
-        wallet.LoadWallet(firstLoad);
-        wallet.GenerateNewHDChain();
-        wallet.SetMinVersion(FEATURE_HD);
-        CPubKey newDefaultKey;
-        wallet.GetKeyFromPool(newDefaultKey, false);
-        wallet.SetDefaultKey(newDefaultKey);
-    }
-    uint256 extendFakeChainAndGetTipBlockHash()
-    {
-        uint256 hash;
-        fakeChain_.extendBy(1,timestamp++,version);
-        CBlockIndex* newTip = const_cast<CBlockIndex*>(fakeChain_.Tip());
-        hash = GetRandHash();
-        activeChain_.SetTip(newTip);
-        blockIndices_.insert(std::make_pair(hash, newTip));
-        return hash;
-    }
     MultiWalletTestFixture(
         ): walletCache_()
-        , version(0x01)
-        , timestamp(1600000000)
-        , activeChain_()
-        , blockIndices_()
-        , fakeChain_()
-    {
-        extendFakeChainAndGetTipBlockHash(); // Fake genesis block
-    }
+        , fakeChain_(1, 1600000000, 1)
+    {}
 
     void createWallets(const unsigned walletCount)
     {
@@ -85,47 +33,31 @@ public:
 
         walletCache_.resize(walletCount);
         for(unsigned walletID = 0; walletID < walletCount; ++ walletID)
-        {
-            auto& walletUniquePtr = walletCache_[walletID];
-            walletUniquePtr.reset(new CWallet("wallet"+std::to_string(walletID)+".dat"));
-            EnableSmallHDWallet(*walletUniquePtr);
-        }
+            walletCache_[walletID].reset(new FakeWallet(fakeChain_));
     }
     std::string deallocateWalletAndGetName(const unsigned walletID)
     {
         if(walletCache_.empty() || walletID >= walletCache_.size() || !walletCache_[walletID].get()) return "";
-        std::string walletName = walletCache_[walletID]->strWalletFile;
+        const std::string walletName = walletCache_[walletID]->strWalletFile;
         walletCache_[walletID].reset();
         return walletName;
     }
 
-    const CWalletTx& AddDefaultTxToWallet(CWallet& currentWallet, CAmount amount)
+    const CWalletTx& AddDefaultTxToWallet(FakeWallet& currentWallet, const CAmount amount)
     {
         assert(currentWallet.vchDefaultKey.IsValid());
         CScript scriptToPayTo = GetScriptForDestination(currentWallet.vchDefaultKey.GetID());
-        unsigned outputIndex =0;
-        CMutableTransaction tx = createDefaultTransaction(scriptToPayTo,outputIndex,amount);
-        CMerkleTx merkleTx(tx,activeChain_,blockIndices_);
-        CWalletTx wtx(merkleTx);
-        currentWallet.AddToWallet(wtx);
-        const CWalletTx* txPtr = currentWallet.GetWalletTx(wtx.GetHash());
-        assert(txPtr);
-        return *txPtr;
+        unsigned outputIndex;
+        return currentWallet.AddDefaultTx(scriptToPayTo, outputIndex, amount);
     }
-    CWallet& getWallet(const unsigned walletID) const
+
+    FakeWallet& getWallet(const unsigned walletID) const
     {
         if(walletID < walletCache_.size())
         {
             return *walletCache_[walletID];
         }
         assert(false);
-    }
-    void FakeAddTransactionToChain(CWallet& currentWallet,const uint256& txHash)
-    {
-        CWalletTx* txPtr = const_cast<CWalletTx*>( currentWallet.GetWalletTx(txHash) );
-        txPtr->hashBlock = extendFakeChainAndGetTipBlockHash();
-        txPtr->nIndex = 0;
-        txPtr->fMerkleVerified = true;
     }
 };
 
@@ -140,8 +72,9 @@ BOOST_AUTO_TEST_CASE(multipleWalletsCanCoexist)
     {
         for(unsigned txCount = 0; txCount < totalTxsPerWallet; ++txCount)
         {
-            const CWalletTx& tx = AddDefaultTxToWallet(getWallet(walletID),100*COIN);
-            FakeAddTransactionToChain(getWallet(walletID),tx.GetHash());
+            auto& wallet = getWallet(walletID);
+            const CWalletTx& tx = AddDefaultTxToWallet(wallet, 100 * COIN);
+            wallet.FakeAddToChain(tx);
         }
         BOOST_CHECK_EQUAL_MESSAGE(
             getWallet(walletID).GetBalance(),

--- a/divi/src/test/test_divi.cpp
+++ b/divi/src/test/test_divi.cpp
@@ -48,7 +48,7 @@ struct TestingSetup {
         InitBlockIndex();
 #ifdef ENABLE_WALLET
         bool fFirstRun;
-        pwalletMain = new CWallet("wallet.dat");
+        pwalletMain = new CWallet("wallet.dat", chainActive, mapBlockIndex);
         pwalletMain->LoadWallet(fFirstRun);
         RegisterValidationInterface(pwalletMain);
 #endif

--- a/divi/src/test/wallet_coinmanagement_tests.cpp
+++ b/divi/src/test/wallet_coinmanagement_tests.cpp
@@ -14,128 +14,24 @@
 #include <random.h>
 #include <chain.h>
 #include <blockmap.h>
-#include <test/FakeBlockIndexChain.h>
+#include <test/FakeWallet.h>
 
-static int walletCounter = 0;
 class WalletCoinManagementTestFixture
 {
 public:
-    static const CHDChain& getHDWalletSeedForTesting()
-    {
-        static CCriticalSection cs_testing;
-        static bool toBeConstructed = true;
-        static CHDChain hdchain;
-        LOCK(cs_testing);
+    FakeBlockIndexWithHashes fakeChain;
+    FakeWallet wallet;
 
-        if(toBeConstructed)
-        {
-            std::string walletName = "wallet_coinmanagement_tests.dat";
-            std::unique_ptr<CWallet> walletPtr(new CWallet(walletName));
-            walletPtr->defaultKeyPoolTopUp = (int64_t)1;
-            bool firstLoad = true;
-            walletPtr->LoadWallet(firstLoad);
-            walletPtr->GenerateNewHDChain();
-            walletPtr->GetHDChain(hdchain);
-
-            toBeConstructed = false;
-        }
-        return hdchain;
-    }
-
-    static CMutableTransaction createDefaultTransaction(CScript defaultScript,unsigned& index, CAmount amount)
-    {
-        static int nextLockTime = 0;
-        int numberOfIndices = GetRand(10)+1;
-        index = GetRand(numberOfIndices);
-        CMutableTransaction tx;
-        tx.nLockTime = nextLockTime++;        // so all transactions get different hashes
-        tx.vout.resize(numberOfIndices);
-        for(CTxOut& output: tx.vout)
-        {
-            output.nValue = 1;
-            output.scriptPubKey = CScript() << OP_TRUE;
-        }
-        tx.vout[index].nValue = amount;
-        tx.vout[index].scriptPubKey = defaultScript;
-        tx.vin.resize(1);
-        {// Avoid flagging as a coinbase tx
-            tx.vin[0].prevout = COutPoint(GetRandHash(),static_cast<uint32_t>(GetRand(100)) );
-        }
-        return tx;
-    }
-    std::unique_ptr<CWallet> populateWalletWithKeys(std::string walletName)
-    {
-        std::unique_ptr<CWallet> walletPtr(new CWallet(walletName));
-        walletPtr->defaultKeyPoolTopUp = (int64_t)3;
-        bool firstLoad = true;
-        CPubKey newDefaultKey;
-        walletPtr->LoadWallet(firstLoad);
-        //walletPtr->GenerateNewHDChain();
-        walletPtr->SetHDChain(getHDWalletSeedForTesting(),false);
-        walletPtr->SetMinVersion(FEATURE_HD);
-        walletPtr->GetKeyFromPool(newDefaultKey, false);
-        walletPtr->SetDefaultKey(newDefaultKey);
-        return std::move(walletPtr);
-    }
-public:
-    const std::string walletName;
-private:
-    std::unique_ptr<CWallet> walletManager_;
-    const int32_t version;
-    int32_t timestamp;
-    CChain activeChain_;
-    BlockMap blockIndices_;
-    FakeBlockIndexChain fakeChain_;
-public:
-    CWallet& currentWallet;
-
-    uint256 extendFakeChainAndGetTipBlockHash()
-    {
-        uint256 hash;
-        fakeChain_.extendBy(1,timestamp++,version);
-        CBlockIndex* newTip = const_cast<CBlockIndex*>(fakeChain_.Tip());
-        hash = GetRandHash();
-        activeChain_.SetTip(newTip);
-        blockIndices_.insert(std::make_pair(hash, newTip));
-        return hash;
-    }
-    WalletCoinManagementTestFixture(
-        ): walletName(std::string("currentWallet")+std::to_string(walletCounter++)+std::string(".dat") )
-        , walletManager_( populateWalletWithKeys(walletName) )
-        , version(0x01)
-        , timestamp(1600000000)
-        , activeChain_()
-        , blockIndices_()
-        , fakeChain_()
-        , currentWallet(*walletManager_)
-    {
-        extendFakeChainAndGetTipBlockHash(); // Fake genesis block
-    }
-
-    const CWalletTx& AddDefaultTxToWallet(CScript scriptToPayTo, unsigned& outputIndex,CAmount amount = 100*COIN)
-    {
-        CMutableTransaction tx = createDefaultTransaction(scriptToPayTo,outputIndex,amount);
-        CMerkleTx merkleTx(tx,activeChain_,blockIndices_);
-        CWalletTx wtx(merkleTx);
-        currentWallet.AddToWallet(wtx);
-        const CWalletTx* txPtr = currentWallet.GetWalletTx(wtx.GetHash());
-        assert(txPtr);
-        return *txPtr;
-    }
-    void FakeAddTransactionToChain(const uint256& txHash)
-    {
-        CWalletTx* txPtr = const_cast<CWalletTx*>( currentWallet.GetWalletTx(txHash) );
-        txPtr->hashBlock = extendFakeChainAndGetTipBlockHash();
-        txPtr->nIndex = 0;
-        txPtr->fMerkleVerified = true;
-    }
+    WalletCoinManagementTestFixture()
+      : fakeChain(1, 1600000000, 1), wallet(fakeChain)
+    {}
 
     CScript vaultScriptAsOwner() const
     {
         CKey managerKey;
         managerKey.MakeNewKey(true);
         return CreateStakingVaultScript(
-            ToByteVector(currentWallet.vchDefaultKey.GetID()),
+            ToByteVector(wallet.vchDefaultKey.GetID()),
             ToByteVector(managerKey.GetPubKey().GetID()));
     }
     CScript vaultScriptAsManager() const
@@ -144,14 +40,7 @@ public:
         ownerKey.MakeNewKey(true);
         return CreateStakingVaultScript(
             ToByteVector(ownerKey.GetPubKey().GetID()),
-            ToByteVector(currentWallet.vchDefaultKey.GetID()) );
-    }
-
-    CPubKey getNewKey()
-    {
-        CPubKey nextKeyGenerated;
-        currentWallet.GetKeyFromPool(nextKeyGenerated, false);
-        return nextKeyGenerated;
+            ToByteVector(wallet.vchDefaultKey.GetID()) );
     }
 };
 
@@ -159,25 +48,25 @@ BOOST_FIXTURE_TEST_SUITE(WalletCoinManagementTests,WalletCoinManagementTestFixtu
 
 BOOST_AUTO_TEST_CASE(willAllowSpendingUnlockedCoin)
 {
-    CScript defaultScript = GetScriptForDestination(getNewKey().GetID());
+    const CScript defaultScript = GetScriptForDestination(wallet.getNewKey().GetID());
     unsigned outputIndex=0;
-    const CWalletTx& wtx = AddDefaultTxToWallet(defaultScript,outputIndex);
+    const CWalletTx& wtx = wallet.AddDefaultTx(defaultScript,outputIndex);
 
     bool fIsSpendable = false;
-    BOOST_CHECK(currentWallet.IsAvailableForSpending(&wtx,outputIndex,nullptr,false,fIsSpendable));
+    BOOST_CHECK(wallet.IsAvailableForSpending(&wtx,outputIndex,nullptr,false,fIsSpendable));
     BOOST_CHECK(fIsSpendable);
 }
 
 BOOST_AUTO_TEST_CASE(willNotAllowSpendingLockedCoin)
 {
-    CScript defaultScript = GetScriptForDestination(getNewKey().GetID());
+    const CScript defaultScript = GetScriptForDestination(wallet.getNewKey().GetID());
 
     unsigned outputIndex=0;
-    const CWalletTx& wtx = AddDefaultTxToWallet(defaultScript,outputIndex);
-    currentWallet.LockCoin(COutPoint(wtx.GetHash(),outputIndex));
+    const CWalletTx& wtx = wallet.AddDefaultTx(defaultScript,outputIndex);
+    wallet.LockCoin(COutPoint(wtx.GetHash(),outputIndex));
 
     bool fIsSpendable = false;
-    BOOST_CHECK(!currentWallet.IsAvailableForSpending(&wtx,outputIndex,nullptr,false,fIsSpendable));
+    BOOST_CHECK(!wallet.IsAvailableForSpending(&wtx,outputIndex,nullptr,false,fIsSpendable));
     BOOST_CHECK(!fIsSpendable);/**/
 }
 
@@ -187,11 +76,11 @@ BOOST_AUTO_TEST_CASE(willNotAllowSpendingFromKeyOutsideWallet)
     CPubKey nonWalletPubKey = key.GetPubKey();
     CScript defaultScript = GetScriptForDestination(nonWalletPubKey.GetID());
 
-     unsigned outputIndex=0;
-    const CWalletTx& wtx = AddDefaultTxToWallet(defaultScript,outputIndex);
+    unsigned outputIndex=0;
+    const CWalletTx& wtx = wallet.AddDefaultTx(defaultScript,outputIndex);
 
     bool fIsSpendable = false;
-    BOOST_CHECK(!currentWallet.IsAvailableForSpending(&wtx,outputIndex,nullptr,false,fIsSpendable));
+    BOOST_CHECK(!wallet.IsAvailableForSpending(&wtx,outputIndex,nullptr,false,fIsSpendable));
     BOOST_CHECK(!fIsSpendable);/**/
 }
 BOOST_AUTO_TEST_CASE(willNotAllowSpendingFromWatchOnlyAddress)
@@ -202,51 +91,51 @@ BOOST_AUTO_TEST_CASE(willNotAllowSpendingFromWatchOnlyAddress)
 
 
     unsigned outputIndex=0;
-    const CWalletTx& wtx = AddDefaultTxToWallet(defaultScript,outputIndex);
-    currentWallet.AddWatchOnly(defaultScript);
+    const CWalletTx& wtx = wallet.AddDefaultTx(defaultScript,outputIndex);
+    wallet.AddWatchOnly(defaultScript);
 
     bool fIsSpendable = false;
-    BOOST_CHECK(!currentWallet.IsAvailableForSpending(&wtx,outputIndex,nullptr,false,fIsSpendable));
+    BOOST_CHECK(!wallet.IsAvailableForSpending(&wtx,outputIndex,nullptr,false,fIsSpendable));
     BOOST_CHECK(!fIsSpendable);/**/
 }
 
 BOOST_AUTO_TEST_CASE(willNotAllowSpendingFromWatchOnlyAddressEvenIfOwned)
 {
-    CScript defaultScript = GetScriptForDestination(getNewKey().GetID());
+    CScript defaultScript = GetScriptForDestination(wallet.getNewKey().GetID());
     unsigned outputIndex=0;
-    const CWalletTx& wtx = AddDefaultTxToWallet(defaultScript,outputIndex);
-    currentWallet.AddWatchOnly(defaultScript);
+    const CWalletTx& wtx = wallet.AddDefaultTx(defaultScript,outputIndex);
+    wallet.AddWatchOnly(defaultScript);
 
     bool fIsSpendable = false;
-    BOOST_CHECK(!currentWallet.IsAvailableForSpending(&wtx,outputIndex,nullptr,false,fIsSpendable));
+    BOOST_CHECK(!wallet.IsAvailableForSpending(&wtx,outputIndex,nullptr,false,fIsSpendable));
     BOOST_CHECK(!fIsSpendable);/**/
 }
 
 BOOST_AUTO_TEST_CASE(willAllowSpendingLockedCoinAfterUnlock)
 {
-    CScript defaultScript = GetScriptForDestination(getNewKey().GetID());
+    CScript defaultScript = GetScriptForDestination(wallet.getNewKey().GetID());
     unsigned outputIndex=0;
-    const CWalletTx& wtx = AddDefaultTxToWallet(defaultScript,outputIndex);
+    const CWalletTx& wtx = wallet.AddDefaultTx(defaultScript,outputIndex);
 
-    currentWallet.LockCoin(COutPoint(wtx.GetHash(),outputIndex));
-    currentWallet.UnlockCoin(COutPoint(wtx.GetHash(),outputIndex));
+    wallet.LockCoin(COutPoint(wtx.GetHash(),outputIndex));
+    wallet.UnlockCoin(COutPoint(wtx.GetHash(),outputIndex));
 
     bool fIsSpendable = false;
-    BOOST_CHECK(currentWallet.IsAvailableForSpending(&wtx,outputIndex,nullptr,false,fIsSpendable));
+    BOOST_CHECK(wallet.IsAvailableForSpending(&wtx,outputIndex,nullptr,false,fIsSpendable));
     BOOST_CHECK(fIsSpendable);
 }
 
 BOOST_AUTO_TEST_CASE(willMakeNoDistinctionBetweenAllCoinsAndStakableCoins)
 {
-    CScript defaultScript = GetScriptForDestination(getNewKey().GetID());
+    CScript defaultScript = GetScriptForDestination(wallet.getNewKey().GetID());
     unsigned outputIndex=0;
-    const CWalletTx& wtx = AddDefaultTxToWallet(defaultScript,outputIndex);
+    const CWalletTx& wtx = wallet.AddDefaultTx(defaultScript,outputIndex);
 
     bool fIsSpendable = false;
-    BOOST_CHECK(currentWallet.IsAvailableForSpending(&wtx,outputIndex,nullptr,false,fIsSpendable,ALL_SPENDABLE_COINS));
+    BOOST_CHECK(wallet.IsAvailableForSpending(&wtx,outputIndex,nullptr,false,fIsSpendable,ALL_SPENDABLE_COINS));
     BOOST_CHECK(fIsSpendable);
     fIsSpendable = false;
-    BOOST_CHECK(currentWallet.IsAvailableForSpending(&wtx,outputIndex,nullptr,false,fIsSpendable,STAKABLE_COINS));
+    BOOST_CHECK(wallet.IsAvailableForSpending(&wtx,outputIndex,nullptr,false,fIsSpendable,STAKABLE_COINS));
     BOOST_CHECK(fIsSpendable);
 }
 
@@ -254,168 +143,168 @@ BOOST_AUTO_TEST_CASE(willDisallowSelectingVaultFundsIfManagedAndSpendableCoinsSe
 {
     CScript defaultScript =  vaultScriptAsManager();
     unsigned outputIndex=0;
-    const CWalletTx& wtx = AddDefaultTxToWallet(defaultScript,outputIndex);
-    currentWallet.AddCScript(defaultScript);
+    const CWalletTx& wtx = wallet.AddDefaultTx(defaultScript,outputIndex);
+    wallet.AddCScript(defaultScript);
 
     bool fIsSpendable = false;
-    BOOST_CHECK(!currentWallet.IsAvailableForSpending(&wtx,outputIndex,nullptr,false,fIsSpendable,ALL_SPENDABLE_COINS));
+    BOOST_CHECK(!wallet.IsAvailableForSpending(&wtx,outputIndex,nullptr,false,fIsSpendable,ALL_SPENDABLE_COINS));
 }
 
 BOOST_AUTO_TEST_CASE(willDisallowSelectingVaultFundsIfOwnerAndSpendableCoinsSelected)
 {
     CScript defaultScript =  vaultScriptAsOwner();
     unsigned outputIndex=0;
-    const CWalletTx& wtx = AddDefaultTxToWallet(defaultScript,outputIndex);
+    const CWalletTx& wtx = wallet.AddDefaultTx(defaultScript,outputIndex);
 
     bool fIsSpendable = false;
-    BOOST_CHECK(!currentWallet.IsAvailableForSpending(&wtx,outputIndex,nullptr,false,fIsSpendable,ALL_SPENDABLE_COINS));
+    BOOST_CHECK(!wallet.IsAvailableForSpending(&wtx,outputIndex,nullptr,false,fIsSpendable,ALL_SPENDABLE_COINS));
 }
 
 BOOST_AUTO_TEST_CASE(willDisallowSelectingVaultFundsIfOwnedAndStakableCoinsSelected)
 {
     CScript defaultScript =  vaultScriptAsOwner();
     unsigned outputIndex=0;
-    const CWalletTx& wtx = AddDefaultTxToWallet(defaultScript,outputIndex);
+    const CWalletTx& wtx = wallet.AddDefaultTx(defaultScript,outputIndex);
 
     bool fIsSpendable = false;
-    BOOST_CHECK(!currentWallet.IsAvailableForSpending(&wtx,outputIndex,nullptr,false,fIsSpendable,STAKABLE_COINS));
+    BOOST_CHECK(!wallet.IsAvailableForSpending(&wtx,outputIndex,nullptr,false,fIsSpendable,STAKABLE_COINS));
 }
 BOOST_AUTO_TEST_CASE(willAllowSelectingVaultFundsIfManagedAndStakableCoinsSelected)
 {
     CScript defaultScript =  vaultScriptAsManager();
     unsigned outputIndex=0;
-    const CWalletTx& wtx = AddDefaultTxToWallet(defaultScript,outputIndex);
-    currentWallet.AddCScript(defaultScript);
+    const CWalletTx& wtx = wallet.AddDefaultTx(defaultScript,outputIndex);
+    wallet.AddCScript(defaultScript);
 
     bool fIsSpendable = false;
-    BOOST_CHECK(currentWallet.IsAvailableForSpending(&wtx,outputIndex,nullptr,false,fIsSpendable,STAKABLE_COINS));
+    BOOST_CHECK(wallet.IsAvailableForSpending(&wtx,outputIndex,nullptr,false,fIsSpendable,STAKABLE_COINS));
 }
 BOOST_AUTO_TEST_CASE(willDisallowSelectingVaultFundsIfManagedButScriptNotAdded)
 {
     CScript defaultScript =  vaultScriptAsManager();
     unsigned outputIndex=0;
-    const CWalletTx& wtx = AddDefaultTxToWallet(defaultScript,outputIndex);
+    const CWalletTx& wtx = wallet.AddDefaultTx(defaultScript,outputIndex);
 
     bool fIsSpendable = false;
-    BOOST_CHECK(!currentWallet.IsAvailableForSpending(&wtx,outputIndex,nullptr,false,fIsSpendable,STAKABLE_COINS));
-    BOOST_CHECK(!currentWallet.IsAvailableForSpending(&wtx,outputIndex,nullptr,false,fIsSpendable,ALL_SPENDABLE_COINS));
-    BOOST_CHECK(!currentWallet.IsAvailableForSpending(&wtx,outputIndex,nullptr,false,fIsSpendable,OWNED_VAULT_COINS));
+    BOOST_CHECK(!wallet.IsAvailableForSpending(&wtx,outputIndex,nullptr,false,fIsSpendable,STAKABLE_COINS));
+    BOOST_CHECK(!wallet.IsAvailableForSpending(&wtx,outputIndex,nullptr,false,fIsSpendable,ALL_SPENDABLE_COINS));
+    BOOST_CHECK(!wallet.IsAvailableForSpending(&wtx,outputIndex,nullptr,false,fIsSpendable,OWNED_VAULT_COINS));
 }
 
 BOOST_AUTO_TEST_CASE(willDisallowSelectingVaultFundsIfManagedAndOwnedVaultCoinsSelected)
 {
     CScript defaultScript =  vaultScriptAsManager();
     unsigned outputIndex=0;
-    const CWalletTx& wtx = AddDefaultTxToWallet(defaultScript,outputIndex);
-    currentWallet.AddCScript(defaultScript);
+    const CWalletTx& wtx = wallet.AddDefaultTx(defaultScript,outputIndex);
+    wallet.AddCScript(defaultScript);
 
     bool fIsSpendable = false;
-    BOOST_CHECK(!currentWallet.IsAvailableForSpending(&wtx,outputIndex,nullptr,false,fIsSpendable,OWNED_VAULT_COINS));
+    BOOST_CHECK(!wallet.IsAvailableForSpending(&wtx,outputIndex,nullptr,false,fIsSpendable,OWNED_VAULT_COINS));
 }
 
 BOOST_AUTO_TEST_CASE(willAllowSelectingVaultFundsIfOwnerAndOwnedVaultCoinsSelected)
 {
     CScript defaultScript =  vaultScriptAsOwner();
     unsigned outputIndex=0;
-    const CWalletTx& wtx = AddDefaultTxToWallet(defaultScript,outputIndex);
+    const CWalletTx& wtx = wallet.AddDefaultTx(defaultScript,outputIndex);
 
     bool fIsSpendable = false;
-    BOOST_CHECK(currentWallet.IsAvailableForSpending(&wtx,outputIndex,nullptr,false,fIsSpendable,OWNED_VAULT_COINS));
+    BOOST_CHECK(wallet.IsAvailableForSpending(&wtx,outputIndex,nullptr,false,fIsSpendable,OWNED_VAULT_COINS));
 }
 
 BOOST_AUTO_TEST_CASE(willDisallowSelectingNonVaultFundsIfOwnedVaultCoinsRequested)
 {
-    CScript defaultScript = GetScriptForDestination(getNewKey().GetID());
+    CScript defaultScript = GetScriptForDestination(wallet.getNewKey().GetID());
     unsigned outputIndex=0;
-    const CWalletTx& wtx = AddDefaultTxToWallet(defaultScript,outputIndex);
+    const CWalletTx& wtx = wallet.AddDefaultTx(defaultScript,outputIndex);
 
     bool fIsSpendable = false;
-    BOOST_CHECK(!currentWallet.IsAvailableForSpending(&wtx,outputIndex,nullptr,false,fIsSpendable,OWNED_VAULT_COINS));
+    BOOST_CHECK(!wallet.IsAvailableForSpending(&wtx,outputIndex,nullptr,false,fIsSpendable,OWNED_VAULT_COINS));
     BOOST_CHECK(!fIsSpendable);
     fIsSpendable = false;
-    BOOST_CHECK(currentWallet.IsAvailableForSpending(&wtx,outputIndex,nullptr,false,fIsSpendable,ALL_SPENDABLE_COINS));
+    BOOST_CHECK(wallet.IsAvailableForSpending(&wtx,outputIndex,nullptr,false,fIsSpendable,ALL_SPENDABLE_COINS));
     BOOST_CHECK(fIsSpendable);
 }
 
 BOOST_AUTO_TEST_CASE(willFindThatTransactionsByDefaultHaveNegativeDepth)
 {
-    CScript normalScript = GetScriptForDestination(currentWallet.vchDefaultKey.GetID());
+    CScript normalScript = GetScriptForDestination(wallet.vchDefaultKey.GetID());
     unsigned outputIndex=0;
-    auto normalTx = AddDefaultTxToWallet(normalScript,outputIndex,100*COIN);
+    auto normalTx = wallet.AddDefaultTx(normalScript,outputIndex,100*COIN);
     BOOST_CHECK_MESSAGE(normalTx.GetNumberOfBlockConfirmations()==-1,"Found wallet transaction has non-negative depth in empty chain!");
 }
 
 BOOST_AUTO_TEST_CASE(willFindThatTransactionsWillHaveDepthAccordingToLengthOfChain)
 {
-    CScript normalScript = GetScriptForDestination(currentWallet.vchDefaultKey.GetID());
+    CScript normalScript = GetScriptForDestination(wallet.vchDefaultKey.GetID());
     unsigned outputIndex=0;
-    const CWalletTx& normalTx = AddDefaultTxToWallet(normalScript,outputIndex,100*COIN);
-    FakeAddTransactionToChain(normalTx.GetHash());
+    const CWalletTx& normalTx = wallet.AddDefaultTx(normalScript,outputIndex,100*COIN);
+    wallet.FakeAddToChain(normalTx);
 
     int someNumberOfBlocksToAdd = GetRand(25)+1;
     int startingNumberOfConfirmations = 1;
     for(int numberOfAdditionalBlocks = 0; numberOfAdditionalBlocks < someNumberOfBlocksToAdd ; ++numberOfAdditionalBlocks )
     {
         BOOST_CHECK_EQUAL(normalTx.GetNumberOfBlockConfirmations(),startingNumberOfConfirmations+numberOfAdditionalBlocks);
-        extendFakeChainAndGetTipBlockHash();
+        wallet.AddBlock();
     }
 }
 
 BOOST_AUTO_TEST_CASE(willReturnZeroBalancesWhenTransactionsAreUnconfirmed)
 {
-    CScript normalScript = GetScriptForDestination(currentWallet.vchDefaultKey.GetID());
+    CScript normalScript = GetScriptForDestination(wallet.vchDefaultKey.GetID());
     CScript ownedVaultScript = vaultScriptAsOwner();
     CScript managedVaultScript = vaultScriptAsManager();
 
     unsigned outputIndex=0;
-    AddDefaultTxToWallet(normalScript,outputIndex,100*COIN);
-    AddDefaultTxToWallet(ownedVaultScript,outputIndex,1000*COIN);
-    AddDefaultTxToWallet(managedVaultScript,outputIndex,10000*COIN);
+    wallet.AddDefaultTx(normalScript,outputIndex,100*COIN);
+    wallet.AddDefaultTx(ownedVaultScript,outputIndex,1000*COIN);
+    wallet.AddDefaultTx(managedVaultScript,outputIndex,10000*COIN);
 
-    BOOST_CHECK_EQUAL_MESSAGE(currentWallet.GetBalance(), 0,"Total balance was not the expected amount");
-    BOOST_CHECK_EQUAL_MESSAGE(currentWallet.GetStakingBalance(), 0,"Staking balance was not the expected amount");
-    BOOST_CHECK_EQUAL_MESSAGE(currentWallet.GetSpendableBalance(), 0,"Spendable balance was not the expected amount");
+    BOOST_CHECK_EQUAL_MESSAGE(wallet.GetBalance(), 0,"Total balance was not the expected amount");
+    BOOST_CHECK_EQUAL_MESSAGE(wallet.GetStakingBalance(), 0,"Staking balance was not the expected amount");
+    BOOST_CHECK_EQUAL_MESSAGE(wallet.GetSpendableBalance(), 0,"Spendable balance was not the expected amount");
 }
 
 BOOST_AUTO_TEST_CASE(willReturnCorrectBalanceWhenTransactionIsConfirmed)
 {
-    CScript normalScript = GetScriptForDestination(currentWallet.vchDefaultKey.GetID());
+    CScript normalScript = GetScriptForDestination(wallet.vchDefaultKey.GetID());
     unsigned outputIndex=0;
-    const CWalletTx& normalTx = AddDefaultTxToWallet(normalScript,outputIndex,100*COIN);
-    FakeAddTransactionToChain(normalTx.GetHash());
+    const CWalletTx& normalTx = wallet.AddDefaultTx(normalScript,outputIndex,100*COIN);
+    wallet.FakeAddToChain(normalTx);
 
     BOOST_CHECK_MESSAGE(normalTx.GetNumberOfBlockConfirmations() >= 1,"Transaction is not at least one block deep!");
-    BOOST_CHECK_EQUAL_MESSAGE(currentWallet.GetBalance(), 100*COIN,"Total balance was not the expected amount");
+    BOOST_CHECK_EQUAL_MESSAGE(wallet.GetBalance(), 100*COIN,"Total balance was not the expected amount");
 }
 
 BOOST_AUTO_TEST_CASE(willFindStakingBalanceMatchesBalanceWhenOwnWalletFundsAreNotVaulted)
 {
-    CScript normalScript = GetScriptForDestination(currentWallet.vchDefaultKey.GetID());
+    CScript normalScript = GetScriptForDestination(wallet.vchDefaultKey.GetID());
     CScript managedVaultScript = vaultScriptAsManager();
-    currentWallet.AddCScript(managedVaultScript);
+    wallet.AddCScript(managedVaultScript);
 
     unsigned outputIndex=0;
-    const CWalletTx& normalTx = AddDefaultTxToWallet(normalScript,outputIndex,100*COIN);
-    const CWalletTx& managedVaultTx = AddDefaultTxToWallet(managedVaultScript,outputIndex,10000*COIN);
-    FakeAddTransactionToChain(normalTx.GetHash());
-    FakeAddTransactionToChain(managedVaultTx.GetHash());
+    const CWalletTx& normalTx = wallet.AddDefaultTx(normalScript,outputIndex,100*COIN);
+    const CWalletTx& managedVaultTx = wallet.AddDefaultTx(managedVaultScript,outputIndex,10000*COIN);
+    wallet.FakeAddToChain(normalTx);
+    wallet.FakeAddToChain(managedVaultTx);
 
-    BOOST_CHECK_EQUAL_MESSAGE(currentWallet.GetBalance(), 10100*COIN,"Total balance was not the expected amount");
-    BOOST_CHECK_EQUAL_MESSAGE(currentWallet.GetStakingBalance(), 10100*COIN,"Staking balance was not the expected amount");
+    BOOST_CHECK_EQUAL_MESSAGE(wallet.GetBalance(), 10100*COIN,"Total balance was not the expected amount");
+    BOOST_CHECK_EQUAL_MESSAGE(wallet.GetStakingBalance(), 10100*COIN,"Staking balance was not the expected amount");
 }
 
 BOOST_AUTO_TEST_CASE(willHaveAStakingBalanceFromAVaultThatIsntSpendable)
 {
     CScript managedVaultScript = vaultScriptAsManager();
-    currentWallet.AddCScript(managedVaultScript);
+    wallet.AddCScript(managedVaultScript);
 
     unsigned outputIndex=0;
-    const CWalletTx& managedVaultTx = AddDefaultTxToWallet(managedVaultScript,outputIndex,10000*COIN);
-    FakeAddTransactionToChain(managedVaultTx.GetHash());
+    const CWalletTx& managedVaultTx = wallet.AddDefaultTx(managedVaultScript,outputIndex,10000*COIN);
+    wallet.FakeAddToChain(managedVaultTx);
 
-    BOOST_CHECK_EQUAL_MESSAGE(currentWallet.GetBalance(), 10000*COIN,"Total balance was not the expected amount");
-    BOOST_CHECK_EQUAL_MESSAGE(currentWallet.GetStakingBalance(), 10000*COIN,"Staking balance was not the expected amount");
-    BOOST_CHECK_EQUAL_MESSAGE(currentWallet.GetSpendableBalance(), 0*COIN,"Spendable balance was not the expected amount");
+    BOOST_CHECK_EQUAL_MESSAGE(wallet.GetBalance(), 10000*COIN,"Total balance was not the expected amount");
+    BOOST_CHECK_EQUAL_MESSAGE(wallet.GetStakingBalance(), 10000*COIN,"Staking balance was not the expected amount");
+    BOOST_CHECK_EQUAL_MESSAGE(wallet.GetSpendableBalance(), 0*COIN,"Spendable balance was not the expected amount");
 }
 
 BOOST_AUTO_TEST_CASE(willTreatOwnedVaultAsUnspendableButWillRecordBalance)
@@ -423,20 +312,20 @@ BOOST_AUTO_TEST_CASE(willTreatOwnedVaultAsUnspendableButWillRecordBalance)
     CScript ownedVaultScript = vaultScriptAsOwner();
 
     unsigned outputIndex=0;
-    const CWalletTx& ownedVaultTx = AddDefaultTxToWallet(ownedVaultScript,outputIndex,10000*COIN);
-    FakeAddTransactionToChain(ownedVaultTx.GetHash());
+    const CWalletTx& ownedVaultTx = wallet.AddDefaultTx(ownedVaultScript,outputIndex,10000*COIN);
+    wallet.FakeAddToChain(ownedVaultTx);
 
-    BOOST_CHECK_EQUAL_MESSAGE(currentWallet.GetBalance(), 10000*COIN,"Total balance was not the expected amount");
-    BOOST_CHECK_EQUAL_MESSAGE(currentWallet.GetStakingBalance(), 0*COIN,"Staking balance was not the expected amount");
-    BOOST_CHECK_EQUAL_MESSAGE(currentWallet.GetSpendableBalance(), 0*COIN,"Spendable balance was not the expected amount");
+    BOOST_CHECK_EQUAL_MESSAGE(wallet.GetBalance(), 10000*COIN,"Total balance was not the expected amount");
+    BOOST_CHECK_EQUAL_MESSAGE(wallet.GetStakingBalance(), 0*COIN,"Staking balance was not the expected amount");
+    BOOST_CHECK_EQUAL_MESSAGE(wallet.GetSpendableBalance(), 0*COIN,"Spendable balance was not the expected amount");
 }
 
 BOOST_AUTO_TEST_CASE(willEnsureBalancesAreAsExpected)
 {
-    CScript normalScript = GetScriptForDestination(currentWallet.vchDefaultKey.GetID());
+    CScript normalScript = GetScriptForDestination(wallet.vchDefaultKey.GetID());
     CScript ownedVaultScript = vaultScriptAsOwner();
     CScript managedVaultScript = vaultScriptAsManager();
-    currentWallet.AddCScript(managedVaultScript);
+    wallet.AddCScript(managedVaultScript);
 
 
     CAmount normalTxValue = (GetRand(1000)+1)*COIN;
@@ -445,42 +334,42 @@ BOOST_AUTO_TEST_CASE(willEnsureBalancesAreAsExpected)
     CAmount totalBalance = normalTxValue + ownedVaultTxValue + managedVaultTxValue;
 
     unsigned outputIndex=0;
-    const CWalletTx& normalTx = AddDefaultTxToWallet(normalScript,outputIndex,normalTxValue);
-    const CWalletTx& ownedVaultTx = AddDefaultTxToWallet(ownedVaultScript,outputIndex,ownedVaultTxValue);
-    const CWalletTx& managedVaultTx = AddDefaultTxToWallet(managedVaultScript,outputIndex,managedVaultTxValue);
+    const CWalletTx& normalTx = wallet.AddDefaultTx(normalScript,outputIndex,normalTxValue);
+    const CWalletTx& ownedVaultTx = wallet.AddDefaultTx(ownedVaultScript,outputIndex,ownedVaultTxValue);
+    const CWalletTx& managedVaultTx = wallet.AddDefaultTx(managedVaultScript,outputIndex,managedVaultTxValue);
 
-    FakeAddTransactionToChain(normalTx.GetHash());
-    FakeAddTransactionToChain(ownedVaultTx.GetHash());
-    FakeAddTransactionToChain(managedVaultTx.GetHash());
+    wallet.FakeAddToChain(normalTx);
+    wallet.FakeAddToChain(ownedVaultTx);
+    wallet.FakeAddToChain(managedVaultTx);
 
-    BOOST_CHECK_EQUAL_MESSAGE(currentWallet.GetBalance(), totalBalance,"Total balance was not the expected amount");
-    BOOST_CHECK_EQUAL_MESSAGE(currentWallet.GetStakingBalance(), normalTxValue+managedVaultTxValue,"Staking balance was not the expected amount");
-    BOOST_CHECK_EQUAL_MESSAGE(currentWallet.GetSpendableBalance(), normalTxValue,"Spendable balance was not the expected amount");
-    BOOST_CHECK_EQUAL_MESSAGE(currentWallet.GetBalanceByCoinType(OWNED_VAULT_COINS), ownedVaultTxValue,"Owned vault balance was not the expected amount");
+    BOOST_CHECK_EQUAL_MESSAGE(wallet.GetBalance(), totalBalance,"Total balance was not the expected amount");
+    BOOST_CHECK_EQUAL_MESSAGE(wallet.GetStakingBalance(), normalTxValue+managedVaultTxValue,"Staking balance was not the expected amount");
+    BOOST_CHECK_EQUAL_MESSAGE(wallet.GetSpendableBalance(), normalTxValue,"Spendable balance was not the expected amount");
+    BOOST_CHECK_EQUAL_MESSAGE(wallet.GetBalanceByCoinType(OWNED_VAULT_COINS), ownedVaultTxValue,"Owned vault balance was not the expected amount");
 }
 
 BOOST_AUTO_TEST_CASE(willEnsureLockedCoinsDoNotCountTowardStakableBalance)
 {
-    CScript normalScript = GetScriptForDestination(currentWallet.vchDefaultKey.GetID());
+    CScript normalScript = GetScriptForDestination(wallet.vchDefaultKey.GetID());
     CScript ownedVaultScript = vaultScriptAsOwner();
     CScript managedVaultScript = vaultScriptAsManager();
-    currentWallet.AddCScript(managedVaultScript);
+    wallet.AddCScript(managedVaultScript);
 
 
     CAmount firstNormalTxValue = (GetRand(1000)+1)*COIN;
     CAmount secondNormalTxValue = (GetRand(1000)+1)*COIN;
 
     unsigned firstTxOutputIndex=0;
-    const CWalletTx& firstNormalTx = AddDefaultTxToWallet(normalScript,firstTxOutputIndex,firstNormalTxValue);
+    const CWalletTx& firstNormalTx = wallet.AddDefaultTx(normalScript,firstTxOutputIndex,firstNormalTxValue);
     unsigned secondTxOutputIndex=0;
-    const CWalletTx& secondNormalTx = AddDefaultTxToWallet(normalScript,secondTxOutputIndex,secondNormalTxValue);
-    FakeAddTransactionToChain(firstNormalTx.GetHash());
-    FakeAddTransactionToChain(secondNormalTx.GetHash());
+    const CWalletTx& secondNormalTx = wallet.AddDefaultTx(normalScript,secondTxOutputIndex,secondNormalTxValue);
+    wallet.FakeAddToChain(firstNormalTx);
+    wallet.FakeAddToChain(secondNormalTx);
 
-    currentWallet.LockCoin(COutPoint(firstNormalTx.GetHash(),firstTxOutputIndex));
+    wallet.LockCoin(COutPoint(firstNormalTx.GetHash(),firstTxOutputIndex));
 
-    BOOST_CHECK_EQUAL_MESSAGE(currentWallet.GetBalance(), firstNormalTxValue+secondNormalTxValue,"Total balance was not the expected amount");
-    BOOST_CHECK_EQUAL_MESSAGE(currentWallet.GetStakingBalance(), secondNormalTxValue,"Staking balance was not the expected amount");
+    BOOST_CHECK_EQUAL_MESSAGE(wallet.GetBalance(), firstNormalTxValue+secondNormalTxValue,"Total balance was not the expected amount");
+    BOOST_CHECK_EQUAL_MESSAGE(wallet.GetStakingBalance(), secondNormalTxValue,"Staking balance was not the expected amount");
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/divi/src/wallet.h
+++ b/divi/src/wallet.h
@@ -50,7 +50,9 @@ static const bool DEFAULT_USE_HD_WALLET = true;
 
 static const int ZQ_6666 = 6666;
 
+class BlockMap;
 class CAccountingEntry;
+class CChain;
 class CCoinControl;
 class COutput;
 class CReserveKey;
@@ -62,7 +64,7 @@ class CWalletDB;
 class COutPoint;
 class CTxIn;
 
-bool IsFinalTx(const CTransaction& tx, int nBlockHeight = 0 , int64_t nBlockTime = 0);
+bool IsFinalTx(const CTransaction& tx, const CChain& activeChain, int nBlockHeight = 0 , int64_t nBlockTime = 0);
 
 
 /** (client) version numbers for particular wallet features */
@@ -131,6 +133,8 @@ public:
 private:
     std::unique_ptr<WalletTransactionRecord> transactionRecord_;
     std::unique_ptr<SpentOutputTracker> outputTracker_;
+    const CChain& chainActive_;
+    const BlockMap& mapBlockIndex_;
     int64_t orderedTransactionIndex;
 public:
     int nWalletVersion;   //! the current wallet version: clients below this version are not able to load the wallet
@@ -193,8 +197,8 @@ public:
 
 
 
-    CWallet();
-    CWallet(std::string strWalletFileIn);
+    explicit CWallet(const CChain& chain, const BlockMap& blockMap);
+    explicit CWallet(const std::string& strWalletFileIn, const CChain& chain, const BlockMap& blockMap);
     ~CWallet();
 
     void SetNull();

--- a/divi/src/walletdb.cpp
+++ b/divi/src/walletdb.cpp
@@ -24,6 +24,8 @@
 #include <WalletTx.h>
 
 extern Settings& settings;
+extern CChain chainActive;
+extern BlockMap mapBlockIndex;
 using namespace boost;
 using namespace std;
 
@@ -901,7 +903,7 @@ bool CWalletDB::Recover(CDBEnv& dbenv, std::string filename, bool fOnlyKeys)
         LogPrintf("Cannot create database file %s\n", filename);
         return false;
     }
-    CWallet dummyWallet;
+    CWallet dummyWallet(chainActive, mapBlockIndex);
     CWalletScanState wss;
 
     DbTxn* ptxn = dbenv.TxnBegin();


### PR DESCRIPTION
This contains some cleanups / refactorings, in particular to the unit tests:

- A new `FakeWallet` class extracts the logic from `wallet_coinmanagement_tests` and `multi_wallet_tests` for setting up a "real" wallet in a unit test.
- `BlockIncentivesPopulator` gets a pure interface and a mock for use in unit tests.
- `CWallet` is changed to no longer rely on the global `chainActive` and `mapBlockIndex` variables, but instead keep references to those inside the instance.

All of these changes help with setting up unit tests with a real `PoSTransactionCreator` in the future, but they are useful cleanups in their own rights.