### PR TITLE
Fix some bugs with locks

### DIFF
--- a/divi/src/VaultManager.cpp
+++ b/divi/src/VaultManager.cpp
@@ -26,6 +26,7 @@ VaultManager::VaultManager(
     I_VaultManagerDatabase& vaultManagerDB
     ): VaultManager(activeChain,blockIndicesByHash)
 {
+    LOCK(cs_vaultManager_);
     vaultManagerDB.ReadManagedScripts(managedScriptsLimits_);
     bool continueLoadingTransactions = true;
     while(continueLoadingTransactions)
@@ -100,15 +101,14 @@ UnspentOutputs VaultManager::getUTXOs() const
 const CWalletTx& VaultManager::GetTransaction(const uint256& hash) const
 {
     static CWalletTx dummyValue;
+
+    LOCK(cs_vaultManager_);
     const CWalletTx* tx = walletTxRecord_->GetWalletTx(hash);
+
     if(!tx)
-    {
         return dummyValue;
-    }
-    else
-    {
-        return *tx;
-    }
+
+    return *tx;
 }
 
 const ManagedScripts& VaultManager::GetManagedScriptLimits() const

--- a/divi/src/masternode-sync.cpp
+++ b/divi/src/masternode-sync.cpp
@@ -313,14 +313,15 @@ void CMasternodeSync::Process(bool networkIsRegtest)
     // sporks synced but blockchain is not, wait until we're almost at a recent block to continue
     if (!networkIsRegtest && !IsBlockchainSynced() && RequestedMasternodeAssets > MASTERNODE_SYNC_SPORKS) return;
 
+    std::vector<CNode*> vSporkSyncedNodes;
+    {
     TRY_LOCK(cs_vNodes, lockRecv);
     if (!lockRecv) return;
-
-    std::vector<CNode*> vSporkSyncedNodes;
 
     std::copy_if(std::begin(vNodes), std::end(vNodes), std::back_inserter(vSporkSyncedNodes), [](const CNode *node) {
         return node->fInbound || node->AreSporksSynced();
     });
+    }
 
     // don't event attemp to sync if we don't have 3 synced nodes
     if(vSporkSyncedNodes.size() < 3) {

--- a/divi/src/net.h
+++ b/divi/src/net.h
@@ -593,6 +593,14 @@ public:
     void CloseSocketDisconnect();
     bool DisconnectOldProtocol(int nVersionRequired, std::string strLastCommand = "");
 
+    /** Checks whether we want to send messages to this peer.  We do not
+     *  send messages until we receive their version and get sporks.  */
+    bool CanSendMessagesToPeer() const;
+
+    /** Checks if we should send a ping message to this peer, and does it
+     *  if we should.  */
+    void MaybeSendPing();
+
     // Denial-of-service detection/prevention
     // The idea is to detect peers that are behaving
     // badly and disconnect/ban them, but do it in a

--- a/divi/src/rpcwallet.cpp
+++ b/divi/src/rpcwallet.cpp
@@ -2328,7 +2328,9 @@ Value lockunspent(const Array& params, bool fHelp)
     else
         RPCTypeCheck(params, list_of(bool_type)(array_type));
 
-    bool fUnlock = params[0].get_bool();
+    const bool fUnlock = params[0].get_bool();
+
+    LOCK(pwalletMain->cs_wallet);
 
     if (params.size() == 1) {
         if (fUnlock)

--- a/divi/src/sync.cpp
+++ b/divi/src/sync.cpp
@@ -79,6 +79,9 @@ static void potential_deadlock_detected(const std::pair<void*, void*>& mismatch,
             LogPrintf(" (2)");
         LogPrintf(" %s\n", i.second.ToString());
     }
+
+    tfm::format(std::cerr, "Assertion failed: detected inconsistent lock order for %s, details in debug log.\n", s2.back().second.ToString());
+    abort();
 }
 
 static void push_lock(void* c, const CLockLocation& locklocation, bool fTry)

--- a/divi/src/test/FakeWallet.cpp
+++ b/divi/src/test/FakeWallet.cpp
@@ -90,6 +90,13 @@ FakeWallet::FakeWallet(FakeBlockIndexWithHashes& c)
   SetMinVersion(FEATURE_HD);
   GetKeyFromPool(newDefaultKey, false);
   SetDefaultKey(newDefaultKey);
+
+  ENTER_CRITICAL_SECTION(cs_wallet);
+}
+
+FakeWallet::~FakeWallet()
+{
+  LEAVE_CRITICAL_SECTION(cs_wallet);
 }
 
 void FakeWallet::AddBlock()

--- a/divi/src/test/FakeWallet.h
+++ b/divi/src/test/FakeWallet.h
@@ -15,7 +15,9 @@
 class CScript;
 
 /** A wallet with (mostly) real seed and keys, which can be used in tests
- *  that need to exercise wallet functions.  */
+ *  that need to exercise wallet functions.
+ *
+ *  The FakeWallet will hold cs_wallet automatically.  */
 class FakeWallet : public CWallet
 {
 
@@ -31,6 +33,7 @@ public:
 
   /** Constructs the wallet with a given external fake chain.  */
   explicit FakeWallet(FakeBlockIndexWithHashes& c);
+  ~FakeWallet ();
 
   /** Adds a new block to our fake chain.  */
   void AddBlock();

--- a/divi/src/wallet.cpp
+++ b/divi/src/wallet.cpp
@@ -1521,17 +1521,21 @@ void CWallet::ResendWalletTransactions()
     // Rebroadcast any of our txes that aren't in a block yet
     LogPrintf("ResendWalletTransactions()\n");
     {
-        LOCK(cs_wallet);
         // Sort them in chronological order
         multimap<unsigned int, CWalletTx*> mapSorted;
-        BOOST_FOREACH (PAIRTYPE(const uint256, CWalletTx) & item, transactionRecord_->mapWallet) {
+
+        {
+        LOCK(cs_wallet);
+        for (auto& item : transactionRecord_->mapWallet) {
             CWalletTx& wtx = item.second;
             // Don't rebroadcast until it's had plenty of time that
             // it should have gotten in already by now.
             if (nTimeBestReceived - (int64_t)wtx.nTimeReceived > 5 * 60)
                 mapSorted.insert(std::make_pair(wtx.nTimeReceived, &wtx));
         }
-        BOOST_FOREACH (PAIRTYPE(const unsigned int, CWalletTx*) & item, mapSorted) {
+        }
+
+        for (auto& item : mapSorted) {
             CWalletTx& wtx = *item.second;
             wtx.RelayWalletTransaction();
         }

--- a/divi/src/wallet.cpp
+++ b/divi/src/wallet.cpp
@@ -2870,7 +2870,7 @@ bool CWallet::UpdatedTransaction(const uint256& hashTx)
 
 unsigned int CWallet::GetKeyPoolSize() const
 {
-    AssertLockHeld(cs_wallet); // set{Ex,In}ternalKeyPool
+    LOCK(cs_wallet);
     return setInternalKeyPool.size() + setExternalKeyPool.size();
 }
 


### PR DESCRIPTION
This set of changes fixes some bugs with locks in the code:

- Some places use `AssertLockHeld` even though the lock was not held
- Pairs of locks should always be acquired in the same order to avoid deadlocks

In particular, we add some missing locks, and reduce others (mainly `cs_main`) where possible to avoid violating these conditions.