### PR TITLE
Fix global destruction undefined behaviour

### DIFF
--- a/divi/qa/rpc-tests/util.py
+++ b/divi/qa/rpc-tests/util.py
@@ -124,7 +124,11 @@ def start_node(i, dirname, extra_args=None, mn_config_lines=[], rpchost=None):
     datadir = os.path.join(dirname, "node"+str(i))
     with open(os.path.join(datadir, "regtest", "masternode.conf"), "w") as f:
       f.write("\n".join(mn_config_lines))
-    args = [ os.getenv("BITCOIND", "divid"), "-datadir="+datadir, "-keypool=1", "-discover=0", "-rest" ]
+    binary = []
+    if os.getenv("RUNNER") is not None:
+      binary.append(os.getenv("RUNNER"))
+    binary.append(os.getenv("BITCOIND", "divid"))
+    args = binary + ["-datadir="+datadir, "-keypool=1", "-discover=0", "-rest"]
     if extra_args is not None: args.extend(extra_args)
     bitcoind_processes[i] = subprocess.Popen(args)
     devnull = open("/dev/null", "w+")

--- a/divi/src/OrphanTransactions.cpp
+++ b/divi/src/OrphanTransactions.cpp
@@ -24,11 +24,6 @@ std::map<uint256, std::set<uint256> > mapOrphanTransactionsByPrev;
 //
 // mapOrphanTransactions
 //
-void CleanupOrphanTransactionCaches()
-{
-    mapOrphanTransactions.clear();
-    mapOrphanTransactionsByPrev.clear();
-}
 const std::set<uint256>& GetOrphanSpendingTransactionIds(const uint256& txHash)
 {
     static std::set<uint256> emptySet;

--- a/divi/src/OrphanTransactions.h
+++ b/divi/src/OrphanTransactions.h
@@ -3,7 +3,6 @@
 #include <net.h>
 #include <uint256.h>
 #include <set>
-void CleanupOrphanTransactionCaches();
 const std::set<uint256>& GetOrphanSpendingTransactionIds(const uint256& txHash);
 const CTransaction& GetOrphanTransaction(const uint256& txHash, NodeId& peer);
 bool OrphanTransactionIsKnown(const uint256& hash);

--- a/divi/src/main.cpp
+++ b/divi/src/main.cpp
@@ -4880,19 +4880,3 @@ bool SendMessages(CNode* pto, bool fSendTrickle)
     }
     return true;
 }
-class CMainCleanup
-{
-public:
-    CMainCleanup() {}
-    ~CMainCleanup()
-    {
-        // block headers
-        BlockMap::iterator it1 = mapBlockIndex.begin();
-        for (; it1 != mapBlockIndex.end(); it1++)
-            delete (*it1).second;
-        mapBlockIndex.clear();
-
-        // orphan transactions
-        CleanupOrphanTransactionCaches();
-    }
-} instance_of_cmaincleanup;


### PR DESCRIPTION
This removes the `CMainCleanup` logic, which just released some memory on process exit; that is unnecessary, as the OS reclaims the memory anyway, and there aren't any other side-effects of the destructors.  By doing that, we also fix undefined behaviour / potential memory violations with the destruction order between globals, e.g. `mapOrphanTransactions` and the `CMainCleanup` instance.

Also includes a commit that allows running regtests through a tool like valgrind, by setting the environment variable `RUNNER="valgrind"`.  This can help debug issues like this (and memory bugs in general) in the future.