### PR TITLE
Fix network versioning for mnb/mnp messages

### DIFF
--- a/divi/src/Makefile.am
+++ b/divi/src/Makefile.am
@@ -582,6 +582,7 @@ libbitcoin_util_a_SOURCES = \
   utilstrencodings.cpp \
   utilmoneystr.cpp \
   utiltime.cpp \
+  version-util.cpp \
   $(BITCOIN_CORE_H)
 
 if GLIBC_BACK_COMPAT

--- a/divi/src/MasternodeModule.cpp
+++ b/divi/src/MasternodeModule.cpp
@@ -306,10 +306,7 @@ void ForceMasternodeResync()
 bool ShareMasternodePingWithPeer(CNode* peer,const uint256& inventoryHash)
 {
     if (networkMessageManager.pingIsKnown(inventoryHash)) {
-        CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
-        ss.reserve(1000);
-        ss << networkMessageManager.getKnownPing(inventoryHash);
-        peer->PushMessage("mnp", ss);
+        peer->PushMessage("mnp", networkMessageManager.getKnownPing(inventoryHash));
         return true;
     }
     return false;
@@ -319,10 +316,7 @@ bool ShareMasternodeBroadcastWithPeer(CNode* peer,const uint256& inventoryHash)
 {
     if (networkMessageManager.broadcastIsKnown(inventoryHash))
     {
-        CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
-        ss.reserve(1000);
-        ss << networkMessageManager.getKnownBroadcast(inventoryHash);
-        peer->PushMessage("mnb", ss);
+        peer->PushMessage("mnb", networkMessageManager.getKnownBroadcast(inventoryHash));
         return true;
     }
     return false;

--- a/divi/src/init.cpp
+++ b/divi/src/init.cpp
@@ -493,6 +493,8 @@ std::string HelpMessage(HelpMessageMode mode)
         strUsage += HelpMessageOpt("-fuzzmessagestest=<n>", translate("Randomly fuzz 1 of every <n> network messages"));
         strUsage += HelpMessageOpt("-flushwallet", strprintf(translate("Run a thread to flush wallet periodically (default: %u)"), 1));
         strUsage += HelpMessageOpt("-maxreorg", strprintf(translate("Use a custom max chain reorganization depth (default: %u)"), 100));
+        strUsage += HelpMessageOpt("-protocolversion", strprintf(translate("Use a custom protocol version (default: use latest version %d)"), PROTOCOL_VERSION));
+        strUsage += HelpMessageOpt("-activeversion", translate("Use a custom active version"));
         strUsage += HelpMessageOpt("-stopafterblockimport", strprintf(translate("Stop running after importing blocks from disk (default: %u)"), 0));
         strUsage += HelpMessageOpt("-sporkkey=<privkey>", translate("Enable spork administration functionality with the appropriate private key."));
     }
@@ -1523,6 +1525,11 @@ bool InitializeDivi(boost::thread_group& threadGroup)
     {
         return false;
     }
+
+    if (settings.ParameterIsSet("-protocolversion")) {
+        SetProtocolVersion(settings.GetArg("-protocolversion", PROTOCOL_VERSION));
+    }
+
     // ********************************************************* Step 4: application initialization: dir lock, daemonize, pidfile, debug log
     // Sanity check
     if (!VerifyCriticalDependenciesAreAvailable())

--- a/divi/src/version-util.cpp
+++ b/divi/src/version-util.cpp
@@ -1,0 +1,12 @@
+#include <version.h>
+
+#include <Logging.h>
+
+static int version = MIN_PEER_PROTO_VERSION_AFTER_ENFORCEMENT;
+const int& PROTOCOL_VERSION(version);
+
+void SetProtocolVersion(const int newVersion)
+{
+    LogPrintf("Setting protocol version to %d from %d\n", newVersion, PROTOCOL_VERSION);
+    version = newVersion;
+}

--- a/divi/src/version.cpp
+++ b/divi/src/version.cpp
@@ -1,10 +1,17 @@
 #include <version.h>
 
+#include <Settings.h>
+
+extern Settings& settings;
+
 // Note: whenever a protocol update is needed toggle between both implementations (comment out the formerly active one)
 //       so we can leave the existing clients untouched (old SPORK will stay on so they don't see even older clients).
 //       Those old clients won't react to the changes of the other (new) SPORK because at the time of their implementation
 //       it was the one which was commented out
 int ActiveProtocol()
 {
+    if (settings.ParameterIsSet("-activeversion"))
+        return settings.GetArg("-activeversion", 0);
+
     return MIN_PEER_PROTO_VERSION_AFTER_ENFORCEMENT;
 }

--- a/divi/src/version.h
+++ b/divi/src/version.h
@@ -11,30 +11,38 @@
  * network protocol versioning
  */
 
-static const int PROTOCOL_VERSION = 70915;
-
 //! initial proto version, to be increased after version/verack negotiation
-static const int INIT_PROTO_VERSION = 209;
+static constexpr int INIT_PROTO_VERSION = 209;
 
 //! In this version, 'getheaders' was introduced.
-static const int GETHEADERS_VERSION = 70077;
+static constexpr int GETHEADERS_VERSION = 70077;
 
 //! disconnect from peers older than this proto version
-static const int MIN_PEER_PROTO_VERSION_AFTER_ENFORCEMENT = 70915;
+static constexpr int MIN_PEER_PROTO_VERSION_AFTER_ENFORCEMENT = 70915;
 
 //! nTime field added to CAddress, starting with this version;
 //! if possible, avoid requesting addresses nodes older than this
-static const int CADDR_TIME_VERSION = 31402;
+static constexpr int CADDR_TIME_VERSION = 31402;
 
 //! BIP 0031, pong message, is enabled for all versions AFTER this one
-static const int BIP0031_VERSION = 60000;
+static constexpr int BIP0031_VERSION = 60000;
 
 //! "mempool" command, enhanced "getdata" behavior starts with this version
-static const int MEMPOOL_GD_VERSION = 60002;
+static constexpr int MEMPOOL_GD_VERSION = 60002;
 
 //! "filter*" commands are disabled without NODE_BLOOM after and including this version
-static const int NO_BLOOM_VERSION = 70005;
+static constexpr int NO_BLOOM_VERSION = 70005;
+
+/** The current protocol version.   Since it can be changed through -protocolversion
+ *  for testing, it is not a constexpr but a real variable.  */
+extern const int& PROTOCOL_VERSION;
+
+/** Changes the current protocol version (PROTOCOL_VERSION).  This is used for
+ *  testing with -protocolversion.  It should not be applied during normal
+ *  production use, in which case the default value of PROTOCOL_VERSION is good.  */
+void SetProtocolVersion(int newVersion);
 
 /** See whether the protocol update is enforced for connected nodes */
 int ActiveProtocol();
+
 #endif // BITCOIN_VERSION_H


### PR DESCRIPTION
This adds a fix for network versioning of `mnb` and `mnp` messages; they used custom serialisation code, bypassing the per-peer protocol version.

Also includes a change that adds two new command-line arguments, `-activeversion` and `-protocolversion`, which can be used to override the `PROTOCOL_VERSION` and `ActiveVersion()` in the daemon.  This is useful for testing compatibility between "old" and "new" nodes with changes to the protocol version.