### PR TITLE
Remove staking-vault activation in tests

### DIFF
--- a/divi/qa/rpc-tests/StakingVaultDeactivation.py
+++ b/divi/qa/rpc-tests/StakingVaultDeactivation.py
@@ -66,8 +66,6 @@ class StakingVaultDeactivationTest(BitcoinTestFramework):
         self.nodes.append(start_node(1, self.options.tmpdir,["-debug","-autocombine=0"]))
         self.nodes.append(start_node(2, self.options.tmpdir,["-debug","-autocombine=0"]))
 
-        stakingVaultForkActivationTime = 2000000000
-        set_node_times(self.nodes,stakingVaultForkActivationTime)
         connect_nodes_bi(self.nodes, 0, 1)
         connect_nodes_bi(self.nodes, 0, 2)
         connect_nodes_bi(self.nodes, 2, 1)

--- a/divi/qa/rpc-tests/StakingVaultSpam.py
+++ b/divi/qa/rpc-tests/StakingVaultSpam.py
@@ -64,8 +64,6 @@ class StakingVaultSpamTest(BitcoinTestFramework):
         self.nodes.append(start_node(1, self.options.tmpdir,["-debug","-autocombine=0"]))
         self.nodes.append(start_node(2, self.options.tmpdir,["-debug","-autocombine=0","-vault_min=2000"]))
 
-        stakingVaultForkActivationTime = 2000000000
-        set_node_times(self.nodes,stakingVaultForkActivationTime)
         connect_nodes_bi(self.nodes, 0, 1)
         connect_nodes_bi(self.nodes, 0, 2)
         connect_nodes_bi(self.nodes, 2, 1)

--- a/divi/qa/rpc-tests/StakingVaultStaking.py
+++ b/divi/qa/rpc-tests/StakingVaultStaking.py
@@ -64,8 +64,6 @@ class StakingVaultStakingTest(BitcoinTestFramework):
         self.nodes.append(start_node(1, self.options.tmpdir,["-debug","-autocombine=0"]))
         self.nodes.append(start_node(2, self.options.tmpdir,["-debug","-autocombine=0"]))
 
-        stakingVaultForkActivationTime = 2000000000
-        set_node_times(self.nodes,stakingVaultForkActivationTime)
         connect_nodes_bi(self.nodes, 0, 1)
         connect_nodes_bi(self.nodes, 0, 2)
         connect_nodes_bi(self.nodes, 2, 1)


### PR DESCRIPTION
Staking vaults have been activated already in normal operations (i.e. with a cut-off time in the past).  Thus there is no need to explicitly modify nodes times anymore in regtests, as the fork will be active by default.

Still having an explicit "activation time" in the tests is unnecessary, confusing and may even lead to weird behaviour with future forks that will be temp-scheduled at the same future fake timestamp.