### PR TITLE
Return normal hash as bare txid for coinbase

### DIFF
--- a/divi/src/primitives/transaction.cpp
+++ b/divi/src/primitives/transaction.cpp
@@ -106,9 +106,23 @@ void CTransaction::UpdateHash() const
 
 uint256 CTransaction::GetBareTxid () const
 {
+    if (IsCoinBase())
+    {
+        /* For coinbase transactions, the bare txid equals the normal one.
+           They don't contain a real signature anyway, but the scriptSig
+           is needed to distinguish them and make sure we won't have two
+           transactions with the same bare txid.
+
+           In practice on mainnet, this has no influence, since no more
+           coinbases are created after the fork activation (since the network
+           is on PoS for a long time).  We still need this here to make sure
+           all works fine in tests and is just correct in general.  */
+        return GetHash();
+    }
+
     CMutableTransaction withoutSigs(*this);
     for (auto& in : withoutSigs.vin)
-      in.scriptSig.clear();
+        in.scriptSig.clear();
     return withoutSigs.GetHash();
 }
 

--- a/divi/src/test/BareTxid_tests.cpp
+++ b/divi/src/test/BareTxid_tests.cpp
@@ -110,6 +110,21 @@ BOOST_AUTO_TEST_CASE (doesNotCommitToInputSignature)
   BOOST_CHECK (GetMtxBareTxid () == tx.GetBareTxid ());
 }
 
+BOOST_AUTO_TEST_CASE (equalsTxidForCoinbase)
+{
+  mtx.vin.resize (1);
+  mtx.vin[0].prevout.SetNull ();
+
+  const CTransaction tx1(mtx);
+  BOOST_CHECK (tx1.IsCoinBase ());
+
+  mtx.vin[0].scriptSig.clear ();
+  const CTransaction tx2(mtx);
+
+  BOOST_CHECK (tx1.GetBareTxid () == tx1.GetHash ());
+  BOOST_CHECK (tx1.GetBareTxid () != tx2.GetBareTxid ());
+}
+
 BOOST_AUTO_TEST_SUITE_END ()
 
 } // anonymous namespace

--- a/divi/src/test/mempool_tests.cpp
+++ b/divi/src/test/mempool_tests.cpp
@@ -30,14 +30,18 @@ public:
   MempoolTestFixture()
     : testPool(CFeeRate(0))
   {
-    txParent.vin.resize(1);
+    txParent.vin.resize(2);
     txParent.vin[0].scriptSig = CScript() << OP_11;
+    /* Add a second input to make sure the transaction does not qualify as
+       coinbase and thus has a bare txid unequal to its normal hash.  */
+    txParent.vin[1].scriptSig = CScript() << OP_12;
     txParent.vout.resize(3);
     for (int i = 0; i < 3; i++)
     {
         txParent.vout[i].scriptPubKey = CScript() << OP_11 << OP_EQUAL;
         txParent.vout[i].nValue = 33000LL;
     }
+    assert(txParent.GetHash() != txParent.GetBareTxid());
 
     for (int i = 0; i < 3; i++)
     {


### PR DESCRIPTION
For coinbase transactions, we have to return the normal txid as the "bare" hash.  For them, there is not a real signature that could be malleated anyway, but instead the scriptSig is needed to make sure each coinbase transaction has a different hash from any others.

In practice, this has no relevance, since no new coinbase transactions from PoW are created anyway after the future mainnet fork activation of segwit light.  But for regtests it is needed (and in general required to make sure all is correct).