### PR TITLE
General cleanups for masternodes and main

### DIFF
--- a/divi/src/MasternodeBroadcastFactory.cpp
+++ b/divi/src/MasternodeBroadcastFactory.cpp
@@ -17,7 +17,10 @@ extern CChain chainActive;
 extern bool fReindex;
 extern bool fImporting;
 
-bool CMasternodeBroadcastFactory::checkBlockchainSync(std::string& strErrorRet, bool fOffline)
+namespace
+{
+
+bool checkBlockchainSync(std::string& strErrorRet, bool fOffline)
 {
      if (!fOffline && !IsBlockchainSynced()) {
         strErrorRet = "Sync in progress. Must wait until sync is complete to start Masternode";
@@ -26,7 +29,7 @@ bool CMasternodeBroadcastFactory::checkBlockchainSync(std::string& strErrorRet, 
     }
     return true;
 }
-bool CMasternodeBroadcastFactory::setMasternodeKeys(
+bool setMasternodeKeys(
     const std::string& strKeyMasternode,
     std::pair<CKey,CPubKey>& masternodeKeyPair,
     std::string& strErrorRet)
@@ -38,7 +41,7 @@ bool CMasternodeBroadcastFactory::setMasternodeKeys(
     }
     return true;
 }
-bool CMasternodeBroadcastFactory::setMasternodeCollateralKeys(
+bool setMasternodeCollateralKeys(
     const std::string& txHash,
     const std::string& outputIndex,
     const std::string& service,
@@ -63,7 +66,7 @@ bool CMasternodeBroadcastFactory::setMasternodeCollateralKeys(
     return true;
 }
 
-bool CMasternodeBroadcastFactory::checkMasternodeCollateral(
+bool checkMasternodeCollateral(
     const CTxIn& txin,
     const std::string& txHash,
     const std::string& outputIndex,
@@ -95,7 +98,7 @@ bool CMasternodeBroadcastFactory::checkMasternodeCollateral(
     return true;
 }
 
-bool CMasternodeBroadcastFactory::createArgumentsFromConfig(
+bool createArgumentsFromConfig(
     const CMasternodeConfig::CMasternodeEntry configEntry,
     std::string& strErrorRet,
     bool fOffline,
@@ -120,6 +123,8 @@ bool CMasternodeBroadcastFactory::createArgumentsFromConfig(
     }
     return true;
 }
+
+} // anonymous namespace
 
 bool CMasternodeBroadcastFactory::Create(
     const CMasternodeConfig::CMasternodeEntry configEntry,
@@ -278,10 +283,10 @@ CMasternodePing createDelayedMasternodePing(const CMasternodeBroadcast& mnb)
 } // anonymous namespace
 
 void CMasternodeBroadcastFactory::createWithoutSignatures(
-    CTxIn txin,
-    CService service,
-    CPubKey pubKeyCollateralAddressNew,
-    CPubKey pubKeyMasternodeNew,
+    const CTxIn& txin,
+    const CService& service,
+    const CPubKey& pubKeyCollateralAddressNew,
+    const CPubKey& pubKeyMasternodeNew,
     const MasternodeTier nMasternodeTier,
     bool deferRelay,
     CMasternodeBroadcast& mnbRet)
@@ -299,12 +304,12 @@ void CMasternodeBroadcastFactory::createWithoutSignatures(
 }
 
 bool CMasternodeBroadcastFactory::Create(
-    CTxIn txin,
-    CService service,
-    CKey keyCollateralAddressNew,
-    CPubKey pubKeyCollateralAddressNew,
-    CKey keyMasternodeNew,
-    CPubKey pubKeyMasternodeNew,
+    const CTxIn& txin,
+    const CService& service,
+    const CKey& keyCollateralAddressNew,
+    const CPubKey& pubKeyCollateralAddressNew,
+    const CKey& keyMasternodeNew,
+    const CPubKey& pubKeyMasternodeNew,
     const MasternodeTier nMasternodeTier,
     std::string& strErrorRet,
     CMasternodeBroadcast& mnbRet,

--- a/divi/src/MasternodeBroadcastFactory.h
+++ b/divi/src/MasternodeBroadcastFactory.h
@@ -37,10 +37,10 @@ public:
         std::string& strErrorRet);
 private:
     static void createWithoutSignatures(
-        CTxIn txin,
-        CService service,
-        CPubKey pubKeyCollateralAddressNew,
-        CPubKey pubKeyMasternodeNew,
+        const CTxIn& txin,
+        const CService& service,
+        const CPubKey& pubKeyCollateralAddressNew,
+        const CPubKey& pubKeyMasternodeNew,
         MasternodeTier nMasternodeTier,
         bool deferRelay,
         CMasternodeBroadcast& mnbRet);
@@ -57,45 +57,15 @@ private:
         CMasternodeBroadcast& mnb,
         std::string& strErrorRet);
 
-    static bool Create(CTxIn vin,
-                        CService service,
-                        CKey keyCollateralAddressNew,
-                        CPubKey pubKeyCollateralAddressNew,
-                        CKey keyMasternodeNew,
-                        CPubKey pubKeyMasternodeNew,
-                        MasternodeTier nMasternodeTier,
-                        std::string& strErrorRet,
-                        CMasternodeBroadcast& mnbRet,
-                        bool deferRelay);
-    static bool checkBlockchainSync(
-        std::string& strErrorRet, bool fOffline);
-    static bool setMasternodeKeys(
-        const std::string& strKeyMasternode,
-        std::pair<CKey,CPubKey>& masternodeKeyPair,
-        std::string& strErrorRet);
-    static bool setMasternodeCollateralKeys(
-        const std::string& txHash,
-        const std::string& outputIndex,
-        const std::string& service,
-        bool collateralPrivKeyIsRemote,
-        CTxIn& txin,
-        std::pair<CKey,CPubKey>& masternodeCollateralKeyPair,
-        std::string& error);
-    static bool checkMasternodeCollateral(
-        const CTxIn& txin,
-        const std::string& txHash,
-        const std::string& outputIndex,
-        const std::string& service,
-        MasternodeTier& nMasternodeTier,
-        std::string& strErrorRet);
-    static bool createArgumentsFromConfig(
-        const CMasternodeConfig::CMasternodeEntry configEntry,
-        std::string& strErrorRet,
-        bool fOffline,
-        bool collateralPrivKeyIsRemote,
-        CTxIn& txin,
-        std::pair<CKey,CPubKey>& masternodeKeyPair,
-        std::pair<CKey,CPubKey>& masternodeCollateralKeyPair,
-        MasternodeTier& nMasternodeTier);
+    static bool Create(const CTxIn& vin,
+                       const CService& service,
+                       const CKey& keyCollateralAddressNew,
+                       const CPubKey& pubKeyCollateralAddressNew,
+                       const CKey& keyMasternodeNew,
+                       const CPubKey& pubKeyMasternodeNew,
+                       MasternodeTier nMasternodeTier,
+                       std::string& strErrorRet,
+                       CMasternodeBroadcast& mnbRet,
+                       bool deferRelay);
 };
 #endif //MASTERNODE_BROADCAST_FACTORY_H

--- a/divi/src/masternode-sync.h
+++ b/divi/src/masternode-sync.h
@@ -85,7 +85,7 @@ public:
     bool MasternodeWinnersListIsSync(CNode* pnode, const int64_t now);
     void Process(bool networkIsRegtest);
     bool IsSynced() const;
-    bool IsMasternodeListSynced() { return RequestedMasternodeAssets > MASTERNODE_SYNC_LIST; }
+    bool IsMasternodeListSynced() const { return RequestedMasternodeAssets > MASTERNODE_SYNC_LIST; }
     void AskForMN(CNode* pnode, const CTxIn& vin) const;
 };
 

--- a/divi/src/masternode.cpp
+++ b/divi/src/masternode.cpp
@@ -258,7 +258,10 @@ bool CMasternode::IsValidNetAddr() const
             (IsReachable(addr) && addr.IsRoutable());
 }
 
-CMasternodeBroadcast::CMasternodeBroadcast(CService newAddr, CTxIn newVin, CPubKey pubKeyCollateralAddressNew, CPubKey pubKeyMasternodeNew, const MasternodeTier nMasternodeTier, int protocolVersionIn)
+CMasternodeBroadcast::CMasternodeBroadcast(
+    const CService& newAddr, const CTxIn& newVin,
+    const CPubKey& pubKeyCollateralAddressNew, const CPubKey& pubKeyMasternodeNew,
+    const MasternodeTier nMasternodeTier, const int protocolVersionIn)
 {
     vin = newVin;
     addr = newAddr;

--- a/divi/src/masternode.h
+++ b/divi/src/masternode.h
@@ -146,15 +146,19 @@ public:
 
 class CMasternodeBroadcast : public CMasternode
 {
-public:
-    CMasternodeBroadcast() = default;
+private:
     CMasternodeBroadcast(
-        CService newAddr,
-        CTxIn newVin,
-        CPubKey pubKeyCollateralAddress,
-        CPubKey pubKeyMasternode,
+        const CService& newAddr,
+        const CTxIn& newVin,
+        const CPubKey& pubKeyCollateralAddress,
+        const CPubKey& pubKeyMasternode,
         MasternodeTier nMasternodeTier,
         int protocolVersionIn);
+
+    friend class CMasternodeBroadcastFactory;
+
+public:
+    CMasternodeBroadcast() = default;
     CMasternodeBroadcast(const CMasternode& mn);
 
     void Relay() const;

--- a/divi/src/masternodeconfig.cpp
+++ b/divi/src/masternodeconfig.cpp
@@ -23,10 +23,11 @@ boost::filesystem::path GetMasternodeConfigFile()
     if (!pathConfigFile.is_complete()) pathConfigFile = GetDataDir() / pathConfigFile;
     return pathConfigFile;
 }
-void CMasternodeConfig::add(std::string alias, std::string ip, std::string privKey, std::string txHash, std::string outputIndex)
+
+void CMasternodeConfig::add(const std::string& alias, const std::string& ip, const std::string& privKey,
+                            const std::string& txHash, const std::string& outputIndex)
 {
-    CMasternodeEntry cme(alias, ip, privKey, txHash, outputIndex);
-    entries.push_back(cme);
+    entries.emplace_back(alias, ip, privKey, txHash, outputIndex);
 }
 
 bool CMasternodeConfig::read(std::string& strErr)
@@ -94,15 +95,16 @@ CMasternodeConfig::CMasternodeConfig()
 {
     entries = std::vector<CMasternodeEntry>();
 }
+
 const std::vector<CMasternodeConfig::CMasternodeEntry>& CMasternodeConfig::getEntries() const
 {
     return entries;
 }
 
-int CMasternodeConfig::getCount()
+int CMasternodeConfig::getCount() const
 {
     int c = -1;
-    BOOST_FOREACH (CMasternodeEntry e, entries) {
+    for (const auto& e : entries) {
         if (e.getAlias() != "") c++;
     }
     return c;

--- a/divi/src/masternodeconfig.h
+++ b/divi/src/masternodeconfig.h
@@ -25,7 +25,9 @@ public:
         std::string outputIndex;
 
     public:
-        CMasternodeEntry(std::string alias, std::string ip, std::string privKey, std::string txHash, std::string outputIndex)
+        CMasternodeEntry(const std::string& alias, const std::string& ip,
+                         const std::string& privKey,
+                         const std::string& txHash, const std::string& outputIndex)
         {
             this->alias = alias;
             this->ip = ip;
@@ -91,9 +93,10 @@ public:
 
     void clear();
     bool read(std::string& strErr);
-    void add(std::string alias, std::string ip, std::string privKey, std::string txHash, std::string outputIndex);
+    void add(const std::string& alias, const std::string& ip, const std::string& privKey,
+             const std::string& txHash, const std::string& outputIndex);
     const std::vector<CMasternodeEntry>& getEntries() const;
-    int getCount();
+    int getCount() const;
 
 private:
     std::vector<CMasternodeEntry> entries;


### PR DESCRIPTION
This contains two commits with general cleanups and refactorings to `main` and the masternode config logic, which have been split out of the other PRs like #65 and #44.  This contains just very basic stuff, like marking methods as `const` where possible, using `const&` to pass arguments and moving helper functions into anonymous namespaces inside the source file instead of declaring them in the header.