### PR TITLE
Simplify logging code

### DIFF
--- a/divi/src/ActiveChainManager.cpp
+++ b/divi/src/ActiveChainManager.cpp
@@ -71,7 +71,7 @@ bool ActiveChainManager::DisconnectBlock(
     bool* pfClean) const
 {
     if (pindex->GetBlockHash() != view.GetBestBlock())
-        LogPrintf("%s : pindex=%s view=%s\n", __func__, pindex->GetBlockHash().GetHex(), view.GetBestBlock().GetHex());
+        LogPrintf("%s : pindex=%s view=%s\n", __func__, pindex->GetBlockHash(), view.GetBestBlock());
     assert(pindex->GetBlockHash() == view.GetBestBlock());
 
     if (pfClean)

--- a/divi/src/BlockDiskAccessor.cpp
+++ b/divi/src/BlockDiskAccessor.cpp
@@ -59,7 +59,7 @@ bool ReadBlockFromDisk(CBlock& block, const CBlockIndex* pindex)
     if (!ReadBlockFromDisk(block, pindex->GetBlockPos()))
         return false;
     if (block.GetHash() != pindex->GetBlockHash()) {
-        LogPrintf("%s : block=%s index=%s\n", __func__, block.GetHash().ToString().c_str(), pindex->GetBlockHash().ToString().c_str());
+        LogPrintf("%s : block=%s index=%s\n", __func__, block.GetHash(), pindex->GetBlockHash());
         return error("ReadBlockFromDisk(CBlock&, CBlockIndex*) : GetHash() doesn't match index");
     }
     return true;

--- a/divi/src/BlockIncentivesPopulator.cpp
+++ b/divi/src/BlockIncentivesPopulator.cpp
@@ -222,7 +222,7 @@ bool BlockIncentivesPopulator::HasValidMasternodePayee(const CTransaction &txNew
     }
     if (masternodePayments_.IsTransactionValid(blockSubsidies_,txNew, seedHash) || settings.GetBoolArg("-override_mnpayee",false))
         return true;
-    LogPrintf("%s : Invalid mn payment detected %s\n", __func__, txNew.ToString().c_str());
+    LogPrintf("%s : Invalid mn payment detected %s\n", __func__, txNew);
 
     if (sporkManager_.IsSporkActive(SPORK_8_MASTERNODE_PAYMENT_ENFORCEMENT))
         return false;

--- a/divi/src/BlockIncentivesPopulator.cpp
+++ b/divi/src/BlockIncentivesPopulator.cpp
@@ -58,7 +58,7 @@ bool IsValidLotteryPayment(const CBlockRewards& rewards, const CTransaction &tx,
         CScript scriptPayment = vRequiredWinnersCoinstake[i].second;
         CAmount reward = i == 0 ? nBigReward : nSmallReward;
         if(!verifyPayment(scriptPayment, reward)) {
-            LogPrintf("%s: No payment for winner: %s\n", __func__, vRequiredWinnersCoinstake[i].first.ToString());
+            LogPrintf("%s: No payment for winner: %s\n", __func__, vRequiredWinnersCoinstake[i].first);
             return false;
         }
     }
@@ -137,7 +137,7 @@ void BlockIncentivesPopulator::FillLotteryPayment(CMutableTransaction &tx, const
     for(size_t i = 0; i < lotteryWinners.size(); ++i) {
         CAmount reward = i == 0 ? nBigReward : nSmallReward;
         const auto &winner = lotteryWinners[i];
-        LogPrintf("%s: Winner: %s\n", __func__, winner.first.ToString());
+        LogPrintf("%s: Winner: %s\n", __func__, winner.first);
         auto scriptLotteryWinner = winner.second;
         tx.vout.emplace_back(reward, scriptLotteryWinner); // pay winners
     }

--- a/divi/src/BlockMemoryPoolTransactionCollector.cpp
+++ b/divi/src/BlockMemoryPoolTransactionCollector.cpp
@@ -342,7 +342,7 @@ std::vector<PrioritizedTransactionData> BlockMemoryPoolTransactionCollector::Pri
 
         if (fPrintPriority) {
             LogPrintf("priority %.1f fee %s txid %s\n",
-                    dPriority, feeRate.ToString(), tx.GetHash());
+                    dPriority, feeRate, tx.GetHash());
         }
 
         // Add transactions that depend on this one to the priority queue
@@ -393,6 +393,6 @@ bool BlockMemoryPoolTransactionCollector::CollectTransactionsIntoBlock (
         view,
         pblocktemplate);
 
-    LogPrintf("CreateNewBlock(): block tostring %s\n", block.ToString());
+    LogPrintf("CreateNewBlock(): block tostring %s\n", block);
     return true;
 }

--- a/divi/src/BlockMemoryPoolTransactionCollector.cpp
+++ b/divi/src/BlockMemoryPoolTransactionCollector.cpp
@@ -342,7 +342,7 @@ std::vector<PrioritizedTransactionData> BlockMemoryPoolTransactionCollector::Pri
 
         if (fPrintPriority) {
             LogPrintf("priority %.1f fee %s txid %s\n",
-                    dPriority, feeRate.ToString(), tx.GetHash().ToString());
+                    dPriority, feeRate.ToString(), tx.GetHash());
         }
 
         // Add transactions that depend on this one to the priority queue

--- a/divi/src/CoinMinter.cpp
+++ b/divi/src/CoinMinter.cpp
@@ -139,7 +139,7 @@ void CoinMinter::UpdateTime(CBlockHeader* block, const CBlockIndex* pindexPrev) 
 
 bool CoinMinter::ProcessBlockFound(CBlock* block, CReserveKey& reservekey) const
 {
-    LogPrintf("%s\n", block->ToString());
+    LogPrintf("%s\n", *block);
     LogPrintf("generated %s\n", FormatMoney(block->vtx[0].vout[0].nValue));
 
     // Found a solution

--- a/divi/src/CoinMinter.cpp
+++ b/divi/src/CoinMinter.cpp
@@ -230,14 +230,14 @@ bool CoinMinter::createProofOfStakeBlock(
     IncrementExtraNonce(block, pindexPrev, nExtraNonce);
 
     //Stake miner main
-    LogPrintf("%s: proof-of-stake block found %s \n",__func__, block->GetHash().ToString().c_str());
+    LogPrintf("%s: proof-of-stake block found %s \n",__func__, block->GetHash());
 
     if (!SignBlock(*pwallet_, *block)) {
         LogPrintf("%s: Signing new block failed \n",__func__);
         return false;
     }
 
-    LogPrintf("%s: proof-of-stake block was signed %s \n", __func__, block->GetHash().ToString().c_str());
+    LogPrintf("%s: proof-of-stake block was signed %s \n", __func__, block->GetHash());
     SetThreadPriority(THREAD_PRIORITY_NORMAL);
     blockSuccessfullyCreated = ProcessBlockFound(block, reserveKey);
     SetThreadPriority(THREAD_PRIORITY_LOWEST);
@@ -282,7 +282,7 @@ bool CoinMinter::createProofOfWorkBlock(
                 // Found a solution
                 SetThreadPriority(THREAD_PRIORITY_NORMAL);
                 LogPrintf("%s:\n",__func__);
-                LogPrintf("proof-of-work found  \n  hash: %s  \ntarget: %s\n", hash.GetHex(), hashTarget.GetHex());
+                LogPrintf("proof-of-work found  \n  hash: %s  \ntarget: %s\n", hash, hashTarget);
                 blockSuccessfullyCreated = ProcessBlockFound(block, reserveKey);
                 SetThreadPriority(THREAD_PRIORITY_LOWEST);
 

--- a/divi/src/Logging-common.cpp
+++ b/divi/src/Logging-common.cpp
@@ -1,0 +1,26 @@
+#include <Logging.h>
+
+#include "base58address.h"
+#include "FeeRate.h"
+#include "net.h"
+#include "netbase.h"
+#include "primitives/block.h"
+#include "primitives/transaction.h"
+#include "pubkey.h"
+#include "script/script.h"
+
+LOG_FORMAT_WITH_TOSTRING(CAddress)
+LOG_FORMAT_WITH_TOSTRING(CInv)
+LOG_FORMAT_WITH_TOSTRING(CNetAddr)
+LOG_FORMAT_WITH_TOSTRING(CService)
+
+LOG_FORMAT_WITH_TOSTRING(CBitcoinAddress)
+LOG_FORMAT_WITH_TOSTRING(CFeeRate)
+LOG_FORMAT_WITH_TOSTRING(CKeyID)
+
+LOG_FORMAT_WITH_TOSTRING(CBlock)
+LOG_FORMAT_WITH_TOSTRING(CTxIn)
+LOG_FORMAT_WITH_TOSTRING(CTxOut)
+LOG_FORMAT_WITH_TOSTRING(CTransaction)
+
+LOG_FORMAT_WITH_TOSTRING(CScript)

--- a/divi/src/Logging-server.cpp
+++ b/divi/src/Logging-server.cpp
@@ -1,0 +1,9 @@
+#include <Logging.h>
+
+#include "blockFileInfo.h"
+#include "BlockRewards.h"
+#include "chain.h"
+
+LOG_FORMAT_WITH_TOSTRING(CBlockFileInfo)
+LOG_FORMAT_WITH_TOSTRING(CBlockIndex)
+LOG_FORMAT_WITH_TOSTRING(CBlockRewards)

--- a/divi/src/Logging-wallet.cpp
+++ b/divi/src/Logging-wallet.cpp
@@ -1,0 +1,5 @@
+#include <Logging.h>
+
+#include "WalletTx.h"
+
+LOG_FORMAT_WITH_TOSTRING(CWalletTx)

--- a/divi/src/Logging.cpp
+++ b/divi/src/Logging.cpp
@@ -9,12 +9,15 @@
 
 #include <DataDirectory.h>
 #include <chainparamsbase.h>
+#include <uint256.h>
 
 bool fDebug = false;
 bool fPrintToConsole = false;
 bool fPrintToDebugLog = true;
 volatile bool fReopenDebugLog = false;
 bool fLogTimestamps = false;
+
+LOG_FORMAT_WITH_TOSTRING(uint256)
 
 namespace
 {

--- a/divi/src/Logging.h
+++ b/divi/src/Logging.h
@@ -49,7 +49,30 @@ template <typename T>
             return LogFormatConvert(v); \
         } \
     };
+LOG_WITH_CONVERSION(CLockLocation)
 LOG_WITH_CONVERSION(uint256)
+
+/* Defined in Logging-common.cpp.  */
+LOG_WITH_CONVERSION(CAddress)
+LOG_WITH_CONVERSION(CBitcoinAddress)
+LOG_WITH_CONVERSION(CBlock)
+LOG_WITH_CONVERSION(CNetAddr)
+LOG_WITH_CONVERSION(CFeeRate)
+LOG_WITH_CONVERSION(CInv)
+LOG_WITH_CONVERSION(CKeyID)
+LOG_WITH_CONVERSION(CScript)
+LOG_WITH_CONVERSION(CService)
+LOG_WITH_CONVERSION(CTxIn)
+LOG_WITH_CONVERSION(CTxOut)
+LOG_WITH_CONVERSION(CTransaction)
+
+/* Defined in Logging-server.cpp.  */
+LOG_WITH_CONVERSION(CBlockFileInfo)
+LOG_WITH_CONVERSION(CBlockIndex)
+LOG_WITH_CONVERSION(CBlockRewards)
+
+/* Defined in Logging-wallet.cpp.  */
+LOG_WITH_CONVERSION(CWalletTx)
 
 /** This macro defines a custom implementation of LogFormatConvert for
  *  a type that then just calls through to the instance's ToString

--- a/divi/src/Logging.h
+++ b/divi/src/Logging.h
@@ -20,13 +20,57 @@ bool LogAcceptCategory(const char* category);
 /** Send a string to the log output */
 int LogPrintStr(const std::string& str);
 
+/** Explicitly converts a particular value to a string for logging.  This is
+ *  used for some types (e.g. uint256) that are not literally passed on to
+ *  the format engine.  Template specialisations are defined in source files
+ *  that are linked into the respective libraries.  */
+template <typename T>
+  std::string LogFormatConvert(const T& v);
+
+/** Helper type for converting some types with LogFormatConvert, while keeping
+ *  others literal at whatever they are.  */
+template <typename T>
+  struct LogFormatConvertWorker
+{
+    static const T& apply(const T& v)
+    {
+        return v;
+    }
+};
+#define LOG_WITH_CONVERSION(type) \
+    class type; \
+    template <> \
+      std::string LogFormatConvert<type>(const type& v); \
+    template <> \
+      struct LogFormatConvertWorker<const type&> \
+    { \
+        static std::string apply(const type& v) \
+        { \
+            return LogFormatConvert(v); \
+        } \
+    };
+LOG_WITH_CONVERSION(uint256)
+
+/** This macro defines a custom implementation of LogFormatConvert for
+ *  a type that then just calls through to the instance's ToString
+ *  method.  The actual definition has to be done in a source file
+ *  linked in with the correct library, since it needs the definition of
+ *  the type in question.  */
+#define LOG_FORMAT_WITH_TOSTRING(type) \
+    template <> \
+      std::string LogFormatConvert<type>(const type& v) \
+    { \
+        return v.ToString(); \
+    }
+
 /** Formats a string (consisting of a format template and zero or more
  *  arguments) for logging.  This mostly invokes tinyformat, but has some
- *  extra tweaks like supporting zero arguments.  */
+ *  extra tweaks like supporting zero arguments and applying conversion
+ *  for some types.  */
 template <typename... Args>
   std::string LogFormat(const char* format, const Args&... args)
 {
-    return tfm::format(format, args...);
+    return tfm::format(format, LogFormatConvertWorker<decltype(args)>::apply(args)...);
 }
 /* This is an explicit specialisation, so we have to declare it "inline"
    to prevent ODR violations.  */

--- a/divi/src/Makefile.am
+++ b/divi/src/Makefile.am
@@ -382,6 +382,7 @@ libbitcoin_server_a_SOURCES = \
   ProofOfStakeModule.cpp \
   ProofOfStakeCalculator.cpp \
   LegacyPoSStakeModifierService.cpp \
+  Logging-server.cpp \
   PoSStakeModifierService.cpp \
   PeerNotificationOfMintService.cpp \
   miner.cpp \
@@ -446,6 +447,7 @@ libbitcoin_wallet_a_SOURCES = \
   keypool.cpp \
   swifttx.cpp \
   LegacyBlockSubsidies.cpp \
+  Logging-wallet.cpp \
   masternode.cpp \
   MasternodePing.cpp \
   MasternodePaymentData.cpp \
@@ -555,6 +557,7 @@ libbitcoin_common_a_SOURCES = \
   hdchain.cpp \
   key.cpp \
   keystore.cpp \
+  Logging-common.cpp \
   netbase.cpp \
   protocol.cpp \
   pubkey.cpp \

--- a/divi/src/MasternodeModule.cpp
+++ b/divi/src/MasternodeModule.cpp
@@ -304,7 +304,7 @@ MasternodeStartResult StartMasternode(std::string alias, bool deferRelay)
 
         if(!mnodeman.ProcessBroadcast(activeMasternode, masternodeSync,nullptr, mnb))
         {
-            LogPrintf("%s - Relaying broadcast vin = %s\n",__func__, mnb.vin.ToString());
+            LogPrintf("%s - Relaying broadcast vin = %s\n",__func__, mnb.vin);
             result.status = false;
             result.errorMessage = "Error processing broadcast";
             return result;
@@ -453,7 +453,7 @@ bool VoteForMasternodePayee(const CBlockIndex* pindex)
         LogPrint("masternode","CMasternodePayments::ProcessBlock() Found by FindOldestNotInVec \n");
 
         newWinner.AddPayee(payee);
-        LogPrint("masternode","CMasternodePayments::ProcessBlock() WinnerPayee %s nHeight %d. \n", payee.ToString(), newWinner.GetHeight());
+        LogPrint("masternode","CMasternodePayments::ProcessBlock() WinnerPayee %s nHeight %d. \n", payee, newWinner.GetHeight());
     } else {
         LogPrint("masternode","CMasternodePayments::ProcessBlock() Failed to find masternode to pay\n");
     }
@@ -510,7 +510,7 @@ bool SetupActiveMasternode(const Settings& settings, std::string& errorMessage)
         errorMessage = "Invalid -masternodeaddr address: " + settings.GetArg("-masternodeaddr", "");
         return false;
     }
-    LogPrintf("Masternode address: %s\n", activeMasternode.service.ToString());
+    LogPrintf("Masternode address: %s\n", activeMasternode.service);
 
     if(settings.ParameterIsSet("-masternodeprivkey"))
     {

--- a/divi/src/MasternodeModule.cpp
+++ b/divi/src/MasternodeModule.cpp
@@ -444,7 +444,7 @@ bool VoteForMasternodePayee(const CBlockIndex* pindex)
 
     CMasternodePaymentWinner newWinner(activeMasternode.vin, nBlockHeight, seedHash);
 
-    LogPrint("masternode","CMasternodePayments::ProcessBlock() Start nHeight %d - vin %s. \n", nBlockHeight, activeMasternode.vin.prevout.hash.ToString());
+    LogPrint("masternode","CMasternodePayments::ProcessBlock() Start nHeight %d - vin %s. \n", nBlockHeight, activeMasternode.vin.prevout.hash);
 
     // pay to the oldest MN that still had no payment but its input is old enough and it was active long enough
     CScript payee = masternodePayments.GetNextMasternodePayeeInQueueForPayment(pindex, numberOfBlocksIntoTheFutureToVoteOn);

--- a/divi/src/MasternodeNetworkMessageManager.cpp
+++ b/divi/src/MasternodeNetworkMessageManager.cpp
@@ -135,7 +135,7 @@ bool MasternodeNetworkMessageManager::recordDsegUpdateAttempt(const CAddress& pe
         std::map<CNetAddr, int64_t>::iterator it = mWeAskedForMasternodeList.find(peerAddress);
         if (it != mWeAskedForMasternodeList.end()) {
             if (GetTime() < (*it).second) {
-                LogPrint("masternode", "dseg - we already asked peer %s for the list; skipping...\n", peerAddress.ToString());
+                LogPrint("masternode", "dseg - we already asked peer %s for the list; skipping...\n", peerAddress);
                 return false;
             }
         }

--- a/divi/src/MasternodeNetworkMessageManager.cpp
+++ b/divi/src/MasternodeNetworkMessageManager.cpp
@@ -156,7 +156,7 @@ bool MasternodeNetworkMessageManager::recordMasternodeEntryRequestAttempt(const 
 
     // ask for the mnb info once from the node that sent mnp
 
-    LogPrint("masternode", "%s - Asking node for missing entry, vin: %s\n", __func__, masternodeCollateral.hash.ToString());
+    LogPrint("masternode", "%s - Asking node for missing entry, vin: %s\n", __func__, masternodeCollateral.hash);
     int64_t askAgain = GetTime() + MASTERNODE_MIN_MNP_SECONDS;
     mWeAskedForMasternodeListEntry[masternodeCollateral] = askAgain;
 

--- a/divi/src/OrphanTransactions.cpp
+++ b/divi/src/OrphanTransactions.cpp
@@ -56,7 +56,7 @@ bool AddOrphanTx(const CTransaction& tx, NodeId peer)
     // at most 500 megabytes of orphans:
     unsigned int sz = tx.GetSerializeSize(SER_NETWORK, CTransaction::CURRENT_VERSION);
     if (sz > 5000) {
-        LogPrint("mempool", "ignoring large orphan tx (size: %u, hash: %s)\n", sz, hash.ToString());
+        LogPrint("mempool", "ignoring large orphan tx (size: %u, hash: %s)\n", sz, hash);
         return false;
     }
 
@@ -65,7 +65,7 @@ bool AddOrphanTx(const CTransaction& tx, NodeId peer)
     BOOST_FOREACH (const CTxIn& txin, tx.vin)
             mapOrphanTransactionsByPrev[txin.prevout.hash].insert(hash);
 
-    LogPrint("mempool", "stored orphan tx %s (mapsz %u prevsz %u)\n", hash.ToString(),
+    LogPrint("mempool", "stored orphan tx %s (mapsz %u prevsz %u)\n", hash,
              mapOrphanTransactions.size(), mapOrphanTransactionsByPrev.size());
     return true;
 }

--- a/divi/src/PoSTransactionCreator.cpp
+++ b/divi/src/PoSTransactionCreator.cpp
@@ -182,7 +182,7 @@ bool PoSTransactionCreator::FindHashproof(
     BlockMap::const_iterator it = mapBlockIndex_.find(stakeData.blockHashOfFirstConfirmation);
     if (it == mapBlockIndex_.end())
     {
-        LogPrint("staking","%s failed to find block index for %s\n",__func__,stakeData.blockHashOfFirstConfirmation.ToString());
+        LogPrint("staking","%s failed to find block index for %s\n",__func__,stakeData.blockHashOfFirstConfirmation);
         return false;
     }
 
@@ -206,7 +206,7 @@ bool PoSTransactionCreator::FindHashproof(
             LogPrintf("%s : kernel found, but it is too far in the past \n",__func__);
             return false;
         }
-        LogPrint("staking","%s : kernel found for %s\n",__func__, stakeData.tx->GetHash().ToString());
+        LogPrint("staking","%s : kernel found for %s\n",__func__, stakeData.tx->GetHash());
 
         SetSuportedStakingScript(stakeData,txNew);
         nTxNewTime = hashproofResult.timestamp();

--- a/divi/src/UtxoCheckingAndUpdating.cpp
+++ b/divi/src/UtxoCheckingAndUpdating.cpp
@@ -151,7 +151,7 @@ bool CheckInputs(
                                  REJECT_INVALID, "bad-txns-inputs-missingorspent");
             }
             return state.Invalid(
-                error("CheckInputs() : %s inputs unavailable", tx.GetHash().ToString()) );
+                error("CheckInputs() : %s inputs unavailable", tx.GetHash()) );
         }
 
 
@@ -184,13 +184,13 @@ bool CheckInputs(
         if (!tx.IsCoinStake()) {
             if (nValueIn < tx.GetValueOut())
                 return state.DoS(100, error("CheckInputs() : %s value in (%s) < value out (%s)",
-                                            tx.GetHash().ToString(), FormatMoney(nValueIn), FormatMoney(tx.GetValueOut())),
+                                            tx.GetHash(), FormatMoney(nValueIn), FormatMoney(tx.GetValueOut())),
                                  REJECT_INVALID, "bad-txns-in-belowout");
 
             // Tally transaction fees
             CAmount nTxFee = nValueIn - tx.GetValueOut();
             if (nTxFee < 0)
-                return state.DoS(100, error("CheckInputs() : %s nTxFee < 0", tx.GetHash().ToString()),
+                return state.DoS(100, error("CheckInputs() : %s nTxFee < 0", tx.GetHash()),
                                  REJECT_INVALID, "bad-txns-fee-negative");
             nFees += nTxFee;
             if (!MoneyRange(nFees))

--- a/divi/src/WalletTx.cpp
+++ b/divi/src/WalletTx.cpp
@@ -99,7 +99,7 @@ void CWalletTx::RelayWalletTransaction(std::string strCommand)
     if (!IsCoinBase()) {
         if (GetNumberOfBlockConfirmations() == 0) {
             uint256 hash = GetHash();
-            LogPrintf("Relaying wtx %s\n", hash.ToString());
+            LogPrintf("Relaying wtx %s\n", hash);
 
             if (strCommand == "ix") {
                 mapTxLockReq.insert(std::make_pair(hash, (CTransaction) * this));

--- a/divi/src/activemasternode.cpp
+++ b/divi/src/activemasternode.cpp
@@ -230,7 +230,7 @@ bool CActiveMasternode::SignMasternodeWinner(CMasternodePaymentWinner& winner) c
 
     if(!CObfuScationSigner::SignAndVerify<CMasternodePaymentWinner>(winner,masternodeKey_,pubKeyMasternode,errorMessage))
     {
-        LogPrint("masternode","%s - Error: %s\n",__func__,errorMessage.c_str());
+        LogPrint("masternode", "%s - Error: %s\n", __func__, errorMessage);
     }
     return true;
 }

--- a/divi/src/activemasternode.cpp
+++ b/divi/src/activemasternode.cpp
@@ -101,7 +101,7 @@ void CActiveMasternode::ManageStatus(CMasternodeMan& masternodeManager)
             return;
         }
 
-        LogPrintf("CActiveMasternode::ManageStatus() - Checking inbound connection to '%s'\n", service.ToString());
+        LogPrintf("CActiveMasternode::ManageStatus() - Checking inbound connection to '%s'\n", service);
         CNode* pnode = ConnectNode(masternodeIPAddress, NULL, false);
         if (!pnode)
         {
@@ -148,7 +148,7 @@ bool CActiveMasternode::SendMasternodePing(CMasternodeMan& masternodeManager, st
         return false;
     }
 
-    LogPrintf("CActiveMasternode::SendMasternodePing() - Relay Masternode Ping vin = %s\n", vin.ToString());
+    LogPrintf("CActiveMasternode::SendMasternodePing() - Relay Masternode Ping vin = %s\n", vin);
 
     CMasternodePing mnp = createCurrentPing(vin);
     if(!CObfuScationSigner::SignAndVerify<CMasternodePing>(mnp,masternodeKey_,pubKeyMasternode,errorMessage))

--- a/divi/src/addrman.cpp
+++ b/divi/src/addrman.cpp
@@ -238,7 +238,7 @@ void CAddrMan::Good_(const CService& addr, int64_t nTime)
     if (nUBucket == -1)
         return;
 
-    LogPrint("addrman", "Moving %s to tried\n", addr.ToString());
+    LogPrint("addrman", "Moving %s to tried\n", addr);
 
     // move nId to the tried tables
     MakeTried(info, nId);

--- a/divi/src/addrman.h
+++ b/divi/src/addrman.h
@@ -485,7 +485,7 @@ public:
             Check();
         }
         if (fRet)
-            LogPrint("addrman", "Added %s from %s: %i tried, %i new\n", addr.ToStringIPPort(), source.ToString(), nTried, nNew);
+            LogPrint("addrman", "Added %s from %s: %i tried, %i new\n", addr.ToStringIPPort(), source, nTried, nNew);
         return fRet;
     }
 
@@ -501,7 +501,7 @@ public:
             Check();
         }
         if (nAdd)
-            LogPrint("addrman", "Added %i addresses from %s: %i tried, %i new\n", nAdd, source.ToString(), nTried, nNew);
+            LogPrint("addrman", "Added %i addresses from %s: %i tried, %i new\n", nAdd, source, nTried, nNew);
         return nAdd > 0;
     }
 

--- a/divi/src/init.cpp
+++ b/divi/src/init.cpp
@@ -977,17 +977,17 @@ void ClearFoldersForResync()
     try {
         if (boost::filesystem::exists(blocksDir)){
             boost::filesystem::remove_all(blocksDir);
-            LogPrintf("-resync: folder deleted: %s\n", blocksDir.string().c_str());
+            LogPrintf("-resync: folder deleted: %s\n", blocksDir.string());
         }
 
         if (boost::filesystem::exists(chainstateDir)){
             boost::filesystem::remove_all(chainstateDir);
-            LogPrintf("-resync: folder deleted: %s\n", chainstateDir.string().c_str());
+            LogPrintf("-resync: folder deleted: %s\n", chainstateDir.string());
         }
 
         if (boost::filesystem::exists(sporksDir)){
             boost::filesystem::remove_all(sporksDir);
-            LogPrintf("-resync: folder deleted: %s\n", sporksDir.string().c_str());
+            LogPrintf("-resync: folder deleted: %s\n", sporksDir.string());
         }
 
     } catch (boost::filesystem::filesystem_error& error) {

--- a/divi/src/kernel.cpp
+++ b/divi/src/kernel.cpp
@@ -70,7 +70,7 @@ static bool SelectBlockFromCandidates(
     for (const std::pair<int64_t, uint256>& item: vSortedByTimestamp)
     {
         if (!mapBlockIndex.count(item.second))
-            return error("SelectBlockFromCandidates: failed to find block index for candidate block %s", item.second.ToString().c_str());
+            return error("SelectBlockFromCandidates: failed to find block index for candidate block %s", item.second);
 
         const CBlockIndex* pindex = mapBlockIndex[item.second];
         if (fSelected && pindex->GetBlockTime() > nSelectionIntervalStop)
@@ -102,7 +102,7 @@ static bool SelectBlockFromCandidates(
         }
     }
     if (settings.GetBoolArg("-printstakemodifier", false))
-        LogPrintf("SelectBlockFromCandidates: selection hash=%s\n", hashBest.ToString().c_str());
+        LogPrintf("SelectBlockFromCandidates: selection hash=%s\n", hashBest);
     return fSelected;
 }
 
@@ -160,7 +160,7 @@ bool ComputeNextStakeModifier(const CBlockIndex* pindexPrev, uint64_t& nStakeMod
     // if it's not old enough, return the same stake modifier
     const CBlockIndex* indexWhereLastStakeModifierWasSet = GetLastBlockIndexWithGeneratedStakeModifier(pindexPrev);
     if (!indexWhereLastStakeModifierWasSet || !indexWhereLastStakeModifierWasSet->GeneratedStakeModifier())
-        return error("ComputeNextStakeModifier: unable to get last modifier prior to blockhash %s\n",pindexPrev->GetBlockHash().ToString());
+        return error("ComputeNextStakeModifier: unable to get last modifier prior to blockhash %s\n",pindexPrev->GetBlockHash());
 
     int64_t nModifierTime = indexWhereLastStakeModifierWasSet->GetBlockTime();
     nStakeModifier = indexWhereLastStakeModifierWasSet->nStakeModifier;
@@ -241,7 +241,7 @@ bool CheckProofOfStakeContextAndRecoverStakingData(
     static const unsigned maxInputs = settings.MaxNumberOfPoSCombinableInputs();
     const CTransaction tx = block.vtx[1];
     if (!tx.IsCoinStake())
-        return error("CheckProofOfStake() : called on non-coinstake %s", tx.GetHash().ToString().c_str());
+        return error("CheckProofOfStake() : called on non-coinstake %s", tx.GetHash());
 
     if(tx.vin.size() > maxInputs) {
         return error("CheckProofOfStake() : invalid amount of stake inputs, current: %d, max: %d", tx.vin.size(), maxInputs);
@@ -270,7 +270,7 @@ bool CheckProofOfStakeContextAndRecoverStakingData(
 
     //verify signature and script
     if (!VerifyScript(txin.scriptSig, txPrev.vout[txin.prevout.n].scriptPubKey, POS_SCRIPT_VERIFY_FLAGS, TransactionSignatureChecker(&tx, 0)))
-        return error("CheckProofOfStake() : VerifySignature failed on coinstake %s", tx.GetHash().ToString().c_str());
+        return error("CheckProofOfStake() : VerifySignature failed on coinstake %s", tx.GetHash());
 
     CBlockIndex* pindex = NULL;
     BlockMap::iterator it = mapBlockIndex.find(hashBlock);
@@ -303,7 +303,7 @@ bool CheckProofOfStake(CChain& activeChain, const CBlock& block, CBlockIndex* pi
         return false;
     if (!posGenerator.ComputeAndVerifyProofOfStake(stakingData, block.nTime, hashProofOfStake))
         return error("CheckProofOfStake() : INFO: check kernel failed on coinstake %s, hashProof=%s \n",
-            block.vtx[1].GetHash().ToString().c_str(), hashProofOfStake.ToString().c_str()); // may occur during initial download or if behind on block chain sync
+            block.vtx[1].GetHash(), hashProofOfStake); // may occur during initial download or if behind on block chain sync
 
     return true;
 }

--- a/divi/src/main.cpp
+++ b/divi/src/main.cpp
@@ -1382,7 +1382,7 @@ bool CheckMintTotalsAndBlockPayees(
         return state.DoS(100,
                          error("%s : reward pays too much (actual=%s vs limit=%s)",
                             __func__,
-                            FormatMoney(pindex->nMint), nExpectedMint.ToString()),
+                            FormatMoney(pindex->nMint), nExpectedMint),
                          REJECT_INVALID, "bad-cb-amount");
     }
 
@@ -2132,7 +2132,7 @@ bool FindBlockPos(CValidationState& state, CDiskBlockPos& pos, unsigned int nAdd
 
     if (!fKnown) {
         while (vinfoBlockFile[nFile].nSize + nAddSize >= MAX_BLOCKFILE_SIZE) {
-            LogPrintf("Leaving block file %i: %s\n", nFile, vinfoBlockFile[nFile].ToString());
+            LogPrintf("Leaving block file %i: %s\n", nFile, vinfoBlockFile[nFile]);
             FlushBlockFile(true);
             nFile++;
             if (vinfoBlockFile.size() <= nFile) {
@@ -2669,7 +2669,7 @@ bool static LoadBlockIndexDB(string& strError)
     for (int nFile = 0; nFile <= nLastBlockFile; nFile++) {
         pblocktree->ReadBlockFileInfo(nFile, vinfoBlockFile[nFile]);
     }
-    LogPrintf("%s: last block file info: %s\n", __func__, vinfoBlockFile[nLastBlockFile].ToString());
+    LogPrintf("%s: last block file info: %s\n", __func__, vinfoBlockFile[nLastBlockFile]);
     for (int nFile = nLastBlockFile + 1; true; nFile++) {
         CBlockFileInfo info;
         if (pblocktree->ReadBlockFileInfo(nFile, info)) {
@@ -3460,7 +3460,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
 
         // Disconnect if we connected to ourself
         if (nNonce == nLocalHostNonce && nNonce > 1) {
-            LogPrintf("connected to self at %s, disconnecting\n", pfrom->addr.ToString());
+            LogPrintf("connected to self at %s, disconnecting\n", pfrom->addr);
             pfrom->fDisconnect = true;
             return true;
         }
@@ -3493,11 +3493,11 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
             if (fListen && !IsInitialBlockDownload()) {
                 CAddress addr = GetLocalAddress(&pfrom->addr);
                 if (addr.IsRoutable()) {
-                    LogPrintf("ProcessMessages: advertizing address %s\n", addr.ToString());
+                    LogPrintf("ProcessMessages: advertizing address %s\n", addr);
                     pfrom->PushAddress(addr);
                 } else if (IsPeerAddrLocalGood(pfrom)) {
                     addr.SetIP(pfrom->addrLocal);
-                    LogPrintf("ProcessMessages: advertizing address %s\n", addr.ToString());
+                    LogPrintf("ProcessMessages: advertizing address %s\n", addr);
                     pfrom->PushAddress(addr);
                 }
             }
@@ -3530,7 +3530,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
 
         LogPrintf("receive version message: %s: version %d, blocks=%d, us=%s, peer=%d%s\n",
                   pfrom->cleanSubVer, pfrom->nVersion,
-                  pfrom->nStartingHeight, addrMe.ToString(), pfrom->id,
+                  pfrom->nStartingHeight, addrMe, pfrom->id,
                   remoteAddr);
 
         AddTimeData(pfrom->addr, nTime);
@@ -3634,7 +3634,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
             pfrom->AddInventoryKnown(inv);
 
             bool fAlreadyHave = AlreadyHave(inv);
-            LogPrint("net", "got inv: %s  %s peer=%d\n", inv.ToString(), fAlreadyHave ? "have" : "new", pfrom->id);
+            LogPrint("net", "got inv: %s  %s peer=%d\n", inv, fAlreadyHave ? "have" : "new", pfrom->id);
 
             if (!fAlreadyHave && !fImporting && !fReindex && inv.type != MSG_BLOCK)
                 pfrom->AskFor(inv);
@@ -3674,7 +3674,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
         LogPrint("net", "received getdata (%u invsz) peer=%d\n", vInv.size(), pfrom->id);
 
         if (vInv.size() > 0)
-            LogPrint("net", "received getdata for: %s peer=%d\n", vInv[0].ToString(), pfrom->id);
+            LogPrint("net", "received getdata for: %s peer=%d\n", vInv[0], pfrom->id);
 
         pfrom->vRecvGetData.insert(pfrom->vRecvGetData.end(), vInv.begin(), vInv.end());
         ProcessGetData(pfrom);
@@ -4326,11 +4326,11 @@ bool SendMessages(CNode* pto, bool fSendTrickle)
 
         if (state->fShouldBan) {
             if (pto->fWhitelisted)
-                LogPrintf("Warning: not punishing whitelisted peer %s!\n", pto->addr.ToString());
+                LogPrintf("Warning: not punishing whitelisted peer %s!\n", pto->addr);
             else {
                 pto->fDisconnect = true;
                 if (pto->addr.IsLocal())
-                    LogPrintf("Warning: not banning local peer %s!\n", pto->addr.ToString());
+                    LogPrintf("Warning: not banning local peer %s!\n", pto->addr);
                 else {
                     CNode::Ban(pto->addr);
                 }
@@ -4456,7 +4456,7 @@ bool SendMessages(CNode* pto, bool fSendTrickle)
         while (!pto->fDisconnect && !pto->mapAskFor.empty() && (*pto->mapAskFor.begin()).first <= nNow) {
             const CInv& inv = (*pto->mapAskFor.begin()).second;
             if (!AlreadyHave(inv)) {
-                LogPrint("net", "Requesting %s peer=%d\n", inv.ToString(), pto->id);
+                LogPrint("net", "Requesting %s peer=%d\n", inv, pto->id);
                 vGetData.push_back(inv);
                 if (vGetData.size() >= 1000) {
                     pto->PushMessage("getdata", vGetData);

--- a/divi/src/masternode-payments.cpp
+++ b/divi/src/masternode-payments.cpp
@@ -200,7 +200,7 @@ void CMasternodePayments::FillBlockPayee(const CBlockIndex* pindexPrev, CMutable
         ExtractDestination(payee, address1);
         CBitcoinAddress address2(address1);
 
-        LogPrint("masternode","Masternode payment of %s to %s\n", FormatMoney(masternodePayment).c_str(), address2);
+        LogPrint("masternode","Masternode payment of %s to %s\n", FormatMoney(masternodePayment), address2);
     }
 }
 
@@ -447,7 +447,7 @@ bool CMasternodeBlockPayees::IsTransactionValid(const I_BlockSubsidyProvider& su
                 if(out.nValue >= requiredMasternodePayment)
                     found = true;
                 else
-                    LogPrint("masternode","Masternode payment is out of drift range. Paid=%s Min=%s\n", FormatMoney(out.nValue).c_str(), FormatMoney(requiredMasternodePayment).c_str());
+                    LogPrint("masternode","Masternode payment is out of drift range. Paid=%s Min=%s\n", FormatMoney(out.nValue), FormatMoney(requiredMasternodePayment));
             }
         }
 
@@ -466,7 +466,7 @@ bool CMasternodeBlockPayees::IsTransactionValid(const I_BlockSubsidyProvider& su
         }
     }
 
-    LogPrint("masternode","CMasternodePayments::IsTransactionValid - Missing required payment of %s to %s\n", FormatMoney(requiredMasternodePayment).c_str(), strPayeesPossible.c_str());
+    LogPrint("masternode","CMasternodePayments::IsTransactionValid - Missing required payment of %s to %s\n", FormatMoney(requiredMasternodePayment), strPayeesPossible);
     return false;
 }
 

--- a/divi/src/masternode-payments.cpp
+++ b/divi/src/masternode-payments.cpp
@@ -244,7 +244,7 @@ void CMasternodePayments::ProcessMessageMasternodePayments(CMasternodeSync& mast
         }
 
         if (GetPaymentWinnerForHash(winner.GetHash()) != nullptr) {
-            LogPrint("mnpayments", "mnw - Already seen - %s bestHeight %d\n", winner.GetHash().ToString().c_str(), nHeight);
+            LogPrint("mnpayments", "mnw - Already seen - %s bestHeight %d\n", winner.GetHash(), nHeight);
             masternodeSynchronization.AddedMasternodeWinner(winner.GetHash());
             return;
         }
@@ -308,7 +308,7 @@ bool CMasternodePayments::CheckMasternodeWinnerSignature(const CMasternodePaymen
         std::string errorMessage = "";
         if(!CObfuScationSigner::VerifySignature<CMasternodePaymentWinner>(winner,pmn->pubKeyMasternode,errorMessage))
         {
-            return error("%s - Got bad Masternode address signature %s (%s)\n",__func__, winner.vinMasternode.prevout.hash.ToString(),errorMessage);
+            return error("%s - Got bad Masternode address signature %s (%s)\n",__func__, winner.vinMasternode.prevout.hash, errorMessage);
         }
         return true;
     }

--- a/divi/src/masternode-payments.cpp
+++ b/divi/src/masternode-payments.cpp
@@ -200,7 +200,7 @@ void CMasternodePayments::FillBlockPayee(const CBlockIndex* pindexPrev, CMutable
         ExtractDestination(payee, address1);
         CBitcoinAddress address2(address1);
 
-        LogPrint("masternode","Masternode payment of %s to %s\n", FormatMoney(masternodePayment).c_str(), address2.ToString().c_str());
+        LogPrint("masternode","Masternode payment of %s to %s\n", FormatMoney(masternodePayment).c_str(), address2);
     }
 }
 
@@ -283,7 +283,7 @@ void CMasternodePayments::ProcessMessageMasternodePayments(CMasternodeSync& mast
         ExtractDestination(winner.payee, address1);
         CBitcoinAddress address2(address1);
 
-        //   LogPrint("mnpayments", "mnw - winning vote - Addr %s Height %d bestHeight %d - %s\n", address2.ToString().c_str(), winner.nBlockHeight, nHeight, winner.vinMasternode.prevout.ToStringShort());
+        //   LogPrint("mnpayments", "mnw - winning vote - Addr %s Height %d bestHeight %d - %s\n", address2, winner.nBlockHeight, nHeight, winner.vinMasternode.prevout.ToStringShort());
 
         if (AddWinningMasternode(winner)) {
             winner.Relay();

--- a/divi/src/masternodeman.cpp
+++ b/divi/src/masternodeman.cpp
@@ -338,7 +338,7 @@ bool CMasternodeMan::CheckAndUpdatePing(CMasternode& mn, CMasternodePing& mnp, i
     if (mn.protocolVersion >= ActiveProtocol()) {
         if (fRequireEnabled && !mn.IsEnabled()) return false;
 
-        // LogPrint("masternode","mnping - Found corresponding mn for vin: %s\n", vin.ToString());
+        // LogPrint("masternode","mnping - Found corresponding mn for vin: %s\n", vin);
         // update only if there is no known ping for this masternode or
         // last ping was more then MASTERNODE_MIN_MNP_SECONDS-60 ago comparing to this one
         if (!IsTooEarlyToReceivePingUpdate(mn,mnp.sigTime)) {

--- a/divi/src/net.cpp
+++ b/divi/src/net.cpp
@@ -241,7 +241,7 @@ void AdvertizeLocal(CNode* pnode)
             addrLocal.SetIP(pnode->addrLocal);
         }
         if (addrLocal.IsRoutable()) {
-            LogPrintf("AdvertizeLocal: advertizing address %s\n", addrLocal.ToString());
+            LogPrintf("AdvertizeLocal: advertizing address %s\n", addrLocal);
             pnode->PushAddress(addrLocal);
         }
     }
@@ -267,7 +267,7 @@ bool AddLocal(const CService& addr, int nScore)
     if (IsLimited(addr))
         return false;
 
-    LogPrintf("AddLocal(%s,%i)\n", addr.ToString(), nScore);
+    LogPrintf("AddLocal(%s,%i)\n", addr, nScore);
 
     {
         LOCK(cs_mapLocalHost);
@@ -291,7 +291,7 @@ bool AddLocal(const CNetAddr& addr, int nScore)
 bool RemoveLocal(const CService& addr)
 {
     LOCK(cs_mapLocalHost);
-    LogPrintf("RemoveLocal(%s)\n", addr.ToString());
+    LogPrintf("RemoveLocal(%s)\n", addr);
     mapLocalHost.erase(addr);
     return true;
 }
@@ -490,9 +490,9 @@ void CNode::PushVersion()
     CAddress addrMe = GetLocalAddress(&addr);
     GetRandBytes((unsigned char*)&nLocalHostNonce, sizeof(nLocalHostNonce));
     if (fLogIPs)
-        LogPrint("net", "send version message: version %d, blocks=%d, us=%s, them=%s, peer=%d\n", PROTOCOL_VERSION, nBestHeight, addrMe.ToString(), addrYou.ToString(), id);
+        LogPrint("net", "send version message: version %d, blocks=%d, us=%s, them=%s, peer=%d\n", PROTOCOL_VERSION, nBestHeight, addrMe, addrYou, id);
     else
-        LogPrint("net", "send version message: version %d, blocks=%d, us=%s, peer=%d\n", PROTOCOL_VERSION, nBestHeight, addrMe.ToString(), id);
+        LogPrint("net", "send version message: version %d, blocks=%d, us=%s, peer=%d\n", PROTOCOL_VERSION, nBestHeight, addrMe, id);
     PushMessage("version", PROTOCOL_VERSION, nLocalServices, nTime, addrYou, addrMe,
                 nLocalHostNonce, FormatSubVersion(std::vector<std::string>()), nBestHeight, true);
 }
@@ -966,13 +966,13 @@ void ThreadSocketHandler()
                     if (nErr != WSAEWOULDBLOCK)
                         LogPrintf("socket error accept failed: %s\n", NetworkErrorString(nErr));
                 } else if (!IsSelectableSocket(hSocket)) {
-                    LogPrintf("connection from %s dropped: non-selectable socket\n", addr.ToString());
+                    LogPrintf("connection from %s dropped: non-selectable socket\n", addr);
                     CloseSocket(hSocket);
                 } else if (nInbound >= nMaxConnections - MAX_OUTBOUND_CONNECTIONS) {
-                    LogPrint("net", "connection from %s dropped (full)\n", addr.ToString());
+                    LogPrint("net", "connection from %s dropped (full)\n", addr);
                     CloseSocket(hSocket);
                 } else if (CNode::IsBanned(addr) && !whitelisted) {
-                    LogPrintf("connection from %s dropped (banned)\n", addr.ToString());
+                    LogPrintf("connection from %s dropped (banned)\n", addr);
                     CloseSocket(hSocket);
                 } else {
                     CNode* pnode = new CNode(hSocket, addr, "", true);
@@ -1652,7 +1652,7 @@ bool BindListenPort(const CService& addrBind, string& strError, bool fWhiteliste
         CloseSocket(hListenSocket);
         return false;
     }
-    LogPrintf("Bound to %s\n", addrBind.ToString());
+    LogPrintf("Bound to %s\n", addrBind);
 
     // Listen for incoming connections
     if (listen(hListenSocket, SOMAXCONN) == SOCKET_ERROR) {
@@ -1683,7 +1683,7 @@ void static Discover(boost::thread_group& threadGroup)
         if (LookupHost(pszHostName, vaddr)) {
             BOOST_FOREACH (const CNetAddr& addr, vaddr) {
                 if (AddLocal(addr, LOCAL_IF))
-                    LogPrintf("%s: %s - %s\n", __func__, pszHostName, addr.ToString());
+                    LogPrintf("%s: %s - %s\n", __func__, pszHostName, addr);
             }
         }
     }
@@ -1700,12 +1700,12 @@ void static Discover(boost::thread_group& threadGroup)
                 struct sockaddr_in* s4 = (struct sockaddr_in*)(ifa->ifa_addr);
                 CNetAddr addr(s4->sin_addr);
                 if (AddLocal(addr, LOCAL_IF))
-                    LogPrintf("%s: IPv4 %s: %s\n", __func__, ifa->ifa_name, addr.ToString());
+                    LogPrintf("%s: IPv4 %s: %s\n", __func__, ifa->ifa_name, addr);
             } else if (ifa->ifa_addr->sa_family == AF_INET6) {
                 struct sockaddr_in6* s6 = (struct sockaddr_in6*)(ifa->ifa_addr);
                 CNetAddr addr(s6->sin6_addr);
                 if (AddLocal(addr, LOCAL_IF))
-                    LogPrintf("%s: IPv6 %s: %s\n", __func__, ifa->ifa_name, addr.ToString());
+                    LogPrintf("%s: IPv6 %s: %s\n", __func__, ifa->ifa_name, addr);
             }
         }
         freeifaddrs(myaddrs);
@@ -2122,7 +2122,7 @@ void CNode::AskFor(const CInv& inv)
         nRequestTime = it->second;
     else
         nRequestTime = 0;
-    LogPrint("net", "askfor %s  %d (%s) peer=%d\n", inv.ToString(), nRequestTime, DateTimeStrFormat("%H:%M:%S", nRequestTime / 1000000), id);
+    LogPrint("net", "askfor %s  %d (%s) peer=%d\n", inv, nRequestTime, DateTimeStrFormat("%H:%M:%S", nRequestTime / 1000000), id);
 
     // Make sure not to reuse time indexes to keep things in the same order
     int64_t nNow = GetTimeMicros() - 1000000;

--- a/divi/src/netbase.cpp
+++ b/divi/src/netbase.cpp
@@ -450,7 +450,7 @@ bool static ConnectSocketDirectly(const CService& addrConnect, SOCKET& hSocketRe
     struct sockaddr_storage sockaddr;
     socklen_t len = sizeof(sockaddr);
     if (!addrConnect.GetSockAddr((struct sockaddr*)&sockaddr, &len)) {
-        LogPrintf("Cannot connect to %s: unsupported network\n", addrConnect.ToString());
+        LogPrintf("Cannot connect to %s: unsupported network\n", addrConnect);
         return false;
     }
 
@@ -478,12 +478,12 @@ bool static ConnectSocketDirectly(const CService& addrConnect, SOCKET& hSocketRe
             FD_SET(hSocket, &fdset);
             int nRet = select(hSocket + 1, NULL, &fdset, NULL, &timeout);
             if (nRet == 0) {
-                LogPrint("net", "connection to %s timeout\n", addrConnect.ToString());
+                LogPrint("net", "connection to %s timeout\n", addrConnect);
                 CloseSocket(hSocket);
                 return false;
             }
             if (nRet == SOCKET_ERROR) {
-                LogPrintf("select() for %s failed: %s\n", addrConnect.ToString(), NetworkErrorString(WSAGetLastError()));
+                LogPrintf("select() for %s failed: %s\n", addrConnect, NetworkErrorString(WSAGetLastError()));
                 CloseSocket(hSocket);
                 return false;
             }
@@ -494,12 +494,12 @@ bool static ConnectSocketDirectly(const CService& addrConnect, SOCKET& hSocketRe
             if (getsockopt(hSocket, SOL_SOCKET, SO_ERROR, &nRet, &nRetSize) == SOCKET_ERROR)
 #endif
             {
-                LogPrintf("getsockopt() for %s failed: %s\n", addrConnect.ToString(), NetworkErrorString(WSAGetLastError()));
+                LogPrintf("getsockopt() for %s failed: %s\n", addrConnect, NetworkErrorString(WSAGetLastError()));
                 CloseSocket(hSocket);
                 return false;
             }
             if (nRet != 0) {
-                LogPrintf("connect() to %s failed after select(): %s\n", addrConnect.ToString(), NetworkErrorString(nRet));
+                LogPrintf("connect() to %s failed after select(): %s\n", addrConnect, NetworkErrorString(nRet));
                 CloseSocket(hSocket);
                 return false;
             }
@@ -510,7 +510,7 @@ bool static ConnectSocketDirectly(const CService& addrConnect, SOCKET& hSocketRe
         else
 #endif
         {
-            LogPrintf("connect() to %s failed: %s\n", addrConnect.ToString(), NetworkErrorString(WSAGetLastError()));
+            LogPrintf("connect() to %s failed: %s\n", addrConnect, NetworkErrorString(WSAGetLastError()));
             CloseSocket(hSocket);
             return false;
         }

--- a/divi/src/obfuscation.cpp
+++ b/divi/src/obfuscation.cpp
@@ -69,7 +69,7 @@ bool CObfuScationSigner::VerifyMessage(CKeyID pubkeyID, const std::vector<unsign
     }
 
     if (pubkey2.GetID() != pubkeyID)
-        LogPrint("sign","CObfuScationSigner::VerifyMessage -- keys don't match: %s %s\n", pubkey2.GetID().ToString(), pubkeyID.ToString());
+        LogPrint("sign","CObfuScationSigner::VerifyMessage -- keys don't match: %s %s\n", pubkey2.GetID(), pubkeyID);
 
     return (pubkey2.GetID() == pubkeyID);
 }

--- a/divi/src/rpcdump.cpp
+++ b/divi/src/rpcdump.cpp
@@ -260,7 +260,7 @@ Value importwallet(const Array& params, bool fHelp)
         assert(key.VerifyPubKey(pubkey));
         CKeyID keyid = pubkey.GetID();
         if (pwalletMain->HaveKey(keyid)) {
-            LogPrintf("Skipping import of %s (key already present)\n", CBitcoinAddress(keyid).ToString());
+            LogPrintf("Skipping import of %s (key already present)\n", CBitcoinAddress(keyid));
             continue;
         }
         int64_t nTime = DecodeDumpTime(vstr[1]);
@@ -278,7 +278,7 @@ Value importwallet(const Array& params, bool fHelp)
                 fLabel = true;
             }
         }
-        LogPrintf("Importing %s...\n", CBitcoinAddress(keyid).ToString());
+        LogPrintf("Importing %s...\n", CBitcoinAddress(keyid));
         if (!pwalletMain->AddKeyPubKey(key, pubkey)) {
             fGood = false;
             continue;

--- a/divi/src/rpcprotocol.cpp
+++ b/divi/src/rpcprotocol.cpp
@@ -173,7 +173,7 @@ int ReadHTTPStatus(std::basic_istream<char>& stream, int& proto)
 {
     std::string str;
     getline(stream, str);
-    //LogPrintf("ReadHTTPStatus - getline string: %s\n",str.c_str());
+    //LogPrintf("ReadHTTPStatus - getline string: %s\n", str);
     std::vector<std::string> vWords;
     boost::split(vWords, str, boost::is_any_of(" "));
     if (vWords.size() < 2)

--- a/divi/src/scriptCheck.cpp
+++ b/divi/src/scriptCheck.cpp
@@ -19,7 +19,7 @@ bool CScriptCheck::operator()()
 {
     const CScript& scriptSig = ptxTo->vin[nIn].scriptSig;
     if (!VerifyScript(scriptSig, scriptPubKey, nFlags, CachingTransactionSignatureChecker(ptxTo, nIn, cacheStore), &error)) {
-        return ::error("CScriptCheck(): %s:%d VerifySignature failed: %s", ptxTo->GetHash().ToString(), nIn, ScriptErrorString(error));
+        return ::error("CScriptCheck(): %s:%d VerifySignature failed: %s", ptxTo->GetHash(), nIn, ScriptErrorString(error));
     }
     return true;
 }

--- a/divi/src/spork.cpp
+++ b/divi/src/spork.cpp
@@ -226,7 +226,7 @@ void ReprocessBlocks(int nBlocks)
                 LOCK(cs_main);
 
                 CBlockIndex* pindex = (*mi).second;
-                LogPrintf("ReprocessBlocks - %s\n", (*it).first.ToString());
+                LogPrintf("ReprocessBlocks - %s\n", (*it).first);
 
                 CValidationState state;
                 ReconsiderBlock(state, pindex);

--- a/divi/src/swifttx.cpp
+++ b/divi/src/swifttx.cpp
@@ -83,7 +83,7 @@ void ProcessMessageSwiftTX(CNode* pfrom, std::string& strCommand, CDataStream& v
 
     //        LogPrintf("ProcessMessageSwiftTX::ix - Transaction Lock Request: %s %s : accepted %s\n",
     //            pfrom->addr.ToString().c_str(), pfrom->cleanSubVer.c_str(),
-    //            tx.GetHash().ToString().c_str());
+    //            tx.GetHash());
 
     //        return;
 
@@ -94,7 +94,7 @@ void ProcessMessageSwiftTX(CNode* pfrom, std::string& strCommand, CDataStream& v
 
     //        LogPrintf("ProcessMessageSwiftTX::ix - Transaction Lock Request: %s %s : rejected %s\n",
     //            pfrom->addr.ToString().c_str(), pfrom->cleanSubVer.c_str(),
-    //            tx.GetHash().ToString().c_str());
+    //            tx.GetHash());
 
     //        BOOST_FOREACH (const CTxIn& in, tx.vin) {
     //            if (!mapLockedInputs.count(in.prevout)) {
@@ -149,7 +149,7 @@ void ProcessMessageSwiftTX(CNode* pfrom, std::string& strCommand, CDataStream& v
     //                mapUnknownVotes[ctx.vinMasternode.prevout.hash] - GetAverageVoteTime() > 60 * 10) {
     //                LogPrintf("ProcessMessageSwiftTX::ix - masternode is spamming transaction votes: %s %s\n",
     //                    ctx.vinMasternode.ToString().c_str(),
-    //                    ctx.txHash.ToString().c_str());
+    //                    ctx.txHash);
     //                return;
     //            } else {
     //                mapUnknownVotes[ctx.vinMasternode.prevout.hash] = GetTime() + (60 * 10);
@@ -216,7 +216,7 @@ int64_t CreateNewLock(CTransaction tx)
     //    nTxAge = GetInputAge(i);
     //    if (nTxAge < 5) //1 less than the "send IX" gui requires, incase of a block propagating the network at the time
     //    {
-    //        LogPrintf("CreateNewLock - Transaction not found / too new: %d / %s\n", nTxAge, tx.GetHash().ToString().c_str());
+    //        LogPrintf("CreateNewLock - Transaction not found / too new: %d / %s\n", nTxAge, tx.GetHash());
     //        return 0;
     //    }
     //}
@@ -229,7 +229,7 @@ int64_t CreateNewLock(CTransaction tx)
     //int nBlockHeight = (chainActive.Tip()->nHeight - nTxAge) + 4;
 
     //if (!mapTxLocks.count(tx.GetHash())) {
-    //    LogPrintf("CreateNewLock - New Transaction Lock %s !\n", tx.GetHash().ToString().c_str());
+    //    LogPrintf("CreateNewLock - New Transaction Lock %s !\n", tx.GetHash());
 
     //    CTransactionLock newLock;
     //    newLock.nBlockHeight = nBlockHeight;
@@ -239,7 +239,7 @@ int64_t CreateNewLock(CTransaction tx)
     //    mapTxLocks.insert(make_pair(tx.GetHash(), newLock));
     //} else {
     //    mapTxLocks[tx.GetHash()].nBlockHeight = nBlockHeight;
-    //    LogPrint("swiftx", "CreateNewLock - Transaction Lock Exists %s !\n", tx.GetHash().ToString().c_str());
+    //    LogPrint("swiftx", "CreateNewLock - Transaction Lock Exists %s !\n", tx.GetHash());
     //}
 
 
@@ -305,7 +305,7 @@ bool ProcessConsensusVote(CNode* pnode, CConsensusVote& ctx)
 //    }
 //
 //    if (n > SWIFTTX_SIGNATURES_TOTAL) {
-//        LogPrint("swiftx", "SwiftX::ProcessConsensusVote - Masternode not in the top %d (%d) - %s\n", SWIFTTX_SIGNATURES_TOTAL, n, ctx.GetHash().ToString().c_str());
+//        LogPrint("swiftx", "SwiftX::ProcessConsensusVote - Masternode not in the top %d (%d) - %s\n", SWIFTTX_SIGNATURES_TOTAL, n, ctx.GetHash());
 //        return false;
 //    }
 //
@@ -317,7 +317,7 @@ bool ProcessConsensusVote(CNode* pnode, CConsensusVote& ctx)
 //    }
 //
 //    if (!mapTxLocks.count(ctx.txHash)) {
-//        LogPrintf("SwiftX::ProcessConsensusVote - New Transaction Lock %s !\n", ctx.txHash.ToString().c_str());
+//        LogPrintf("SwiftX::ProcessConsensusVote - New Transaction Lock %s !\n", ctx.txHash);
 //
 //        CTransactionLock newLock;
 //        newLock.nBlockHeight = 0;
@@ -326,7 +326,7 @@ bool ProcessConsensusVote(CNode* pnode, CConsensusVote& ctx)
 //        newLock.txHash = ctx.txHash;
 //        mapTxLocks.insert(make_pair(ctx.txHash, newLock));
 //    } else
-//        LogPrint("swiftx", "SwiftX::ProcessConsensusVote - Transaction Lock Exists %s !\n", ctx.txHash.ToString().c_str());
+//        LogPrint("swiftx", "SwiftX::ProcessConsensusVote - Transaction Lock Exists %s !\n", ctx.txHash);
 //
 //    //compile consessus vote
 //    std::map<uint256, CTransactionLock>::iterator i = mapTxLocks.find(ctx.txHash);
@@ -341,10 +341,10 @@ bool ProcessConsensusVote(CNode* pnode, CConsensusVote& ctx)
 //        }
 //#endif
 //
-//        LogPrint("swiftx", "SwiftX::ProcessConsensusVote - Transaction Lock Votes %d - %s !\n", (*i).second.CountSignatures(), ctx.GetHash().ToString().c_str());
+//        LogPrint("swiftx", "SwiftX::ProcessConsensusVote - Transaction Lock Votes %d - %s !\n", (*i).second.CountSignatures(), ctx.GetHash());
 //
 //        if ((*i).second.CountSignatures() >= SWIFTTX_SIGNATURES_REQUIRED) {
-//            LogPrint("swiftx", "SwiftX::ProcessConsensusVote - Transaction Lock Is Complete %s !\n", (*i).second.GetHash().ToString().c_str());
+//            LogPrint("swiftx", "SwiftX::ProcessConsensusVote - Transaction Lock Is Complete %s !\n", (*i).second.GetHash());
 //
 //            CTransaction& tx = mapTxLockReq[ctx.txHash];
 //            if (!CheckForConflictingLocks(tx)) {
@@ -392,7 +392,7 @@ bool CheckForConflictingLocks(CTransaction& tx)
     //BOOST_FOREACH (const CTxIn& in, tx.vin) {
     //    if (mapLockedInputs.count(in.prevout)) {
     //        if (mapLockedInputs[in.prevout] != tx.GetHash()) {
-    //            LogPrintf("SwiftX::CheckForConflictingLocks - found two complete conflicting locks - removing both. %s %s", tx.GetHash().ToString().c_str(), mapLockedInputs[in.prevout].ToString().c_str());
+    //            LogPrintf("SwiftX::CheckForConflictingLocks - found two complete conflicting locks - removing both. %s %s", tx.GetHash(), mapLockedInputs[in.prevout]);
     //            if (mapTxLocks.count(tx.GetHash())) mapTxLocks[tx.GetHash()].nExpiration = GetTime();
     //            if (mapTxLocks.count(mapLockedInputs[in.prevout])) mapTxLocks[mapLockedInputs[in.prevout]].nExpiration = GetTime();
     //            return true;
@@ -426,7 +426,7 @@ void CleanTransactionLocksList()
 
     //while (it != mapTxLocks.end()) {
     //    if (GetTime() > it->second.nExpiration) { //keep them for an hour
-    //        LogPrintf("Removing old transaction lock %s\n", it->second.txHash.ToString().c_str());
+    //        LogPrintf("Removing old transaction lock %s\n", it->second.txHash);
 
     //        if (mapTxLockReq.count(it->second.txHash)) {
     //            CTransaction& tx = mapTxLockReq[it->second.txHash];

--- a/divi/src/swifttx.cpp
+++ b/divi/src/swifttx.cpp
@@ -59,7 +59,7 @@ void ProcessMessageSwiftTX(CNode* pfrom, std::string& strCommand, CDataStream& v
     //        // IX supports normal scripts and unspendable scripts (used in DS collateral and Budget collateral).
     //        // TODO: Look into other script types that are normal and can be included
     //        if (!o.scriptPubKey.IsNormalPaymentScript() && !o.scriptPubKey.IsUnspendable()) {
-    //            LogPrintf("ProcessMessageSwiftTX::ix - Invalid Script %s\n", tx.ToString().c_str());
+    //            LogPrintf("ProcessMessageSwiftTX::ix - Invalid Script %s\n", tx);
     //            return;
     //        }
     //    }
@@ -82,7 +82,7 @@ void ProcessMessageSwiftTX(CNode* pfrom, std::string& strCommand, CDataStream& v
     //        mapTxLockReq.insert(make_pair(tx.GetHash(), tx));
 
     //        LogPrintf("ProcessMessageSwiftTX::ix - Transaction Lock Request: %s %s : accepted %s\n",
-    //            pfrom->addr.ToString().c_str(), pfrom->cleanSubVer.c_str(),
+    //            pfrom->addr, pfrom->cleanSubVer,
     //            tx.GetHash());
 
     //        return;
@@ -93,7 +93,7 @@ void ProcessMessageSwiftTX(CNode* pfrom, std::string& strCommand, CDataStream& v
     //        // can we get the conflicting transaction as proof?
 
     //        LogPrintf("ProcessMessageSwiftTX::ix - Transaction Lock Request: %s %s : rejected %s\n",
-    //            pfrom->addr.ToString().c_str(), pfrom->cleanSubVer.c_str(),
+    //            pfrom->addr, pfrom->cleanSubVer,
     //            tx.GetHash());
 
     //        BOOST_FOREACH (const CTxIn& in, tx.vin) {
@@ -148,7 +148,7 @@ void ProcessMessageSwiftTX(CNode* pfrom, std::string& strCommand, CDataStream& v
     //            if (mapUnknownVotes[ctx.vinMasternode.prevout.hash] > GetTime() &&
     //                mapUnknownVotes[ctx.vinMasternode.prevout.hash] - GetAverageVoteTime() > 60 * 10) {
     //                LogPrintf("ProcessMessageSwiftTX::ix - masternode is spamming transaction votes: %s %s\n",
-    //                    ctx.vinMasternode.ToString().c_str(),
+    //                    ctx.vinMasternode,
     //                    ctx.txHash);
     //                return;
     //            } else {
@@ -187,12 +187,12 @@ bool IsIXTXValid(const CTransaction& txCollateral)
     //}
 
     //if (nValueOut > GetSporkValue(SPORK_5_MAX_VALUE) * COIN) {
-    //    LogPrint("swiftx", "IsIXTXValid - Transaction value too high - %s\n", txCollateral.ToString().c_str());
+    //    LogPrint("swiftx", "IsIXTXValid - Transaction value too high - %s\n", txCollateral);
     //    return false;
     //}
 
     //if (missingTx) {
-    //    LogPrint("swiftx", "IsIXTXValid - Unknown inputs in IX transaction - %s\n", txCollateral.ToString().c_str());
+    //    LogPrint("swiftx", "IsIXTXValid - Unknown inputs in IX transaction - %s\n", txCollateral);
     //    /*
     //        This happens sometimes for an unknown reason, so we'll return that it's a valid transaction.
     //        If someone submits an invalid transaction it will be rejected by the network anyway and this isn't
@@ -202,7 +202,7 @@ bool IsIXTXValid(const CTransaction& txCollateral)
     //}
 
     //if (nValueIn - nValueOut < COIN * 0.01) {
-    //    LogPrint("swiftx", "IsIXTXValid - did not include enough fees in transaction %d\n%s\n", nValueOut - nValueIn, txCollateral.ToString().c_str());
+    //    LogPrint("swiftx", "IsIXTXValid - did not include enough fees in transaction %d\n%s\n", nValueOut - nValueIn, txCollateral);
     //    return false;
     //}
 
@@ -295,7 +295,7 @@ bool ProcessConsensusVote(CNode* pnode, CConsensusVote& ctx)
 //
 //    CMasternode* pmn = mnodeman.Find(ctx.vinMasternode);
 //    if (pmn != NULL)
-//        LogPrint("swiftx", "SwiftX::ProcessConsensusVote - Masternode ADDR %s %d\n", pmn->addr.ToString().c_str(), n);
+//        LogPrint("swiftx", "SwiftX::ProcessConsensusVote - Masternode ADDR %s %d\n", pmn->addr, n);
 //
 //    if (n == -1) {
 //        //can be caused by past versions trying to vote with an invalid protocol
@@ -482,11 +482,11 @@ bool CConsensusVote::Sign()
     //CKey key2;
     //CPubKey pubkey2;
     //std::string strMessage = txHash.ToString().c_str() + boost::lexical_cast<std::string>(nBlockHeight);
-    ////LogPrintf("signing strMessage %s \n", strMessage.c_str());
-    ////LogPrintf("signing privkey %s \n", strMasterNodePrivKey.c_str());
+    ////LogPrintf("signing strMessage %s \n", strMessage);
+    ////LogPrintf("signing privkey %s \n", strMasterNodePrivKey);
 
     //if (!obfuScationSigner.SetKey(strMasterNodePrivKey, errorMessage, key2, pubkey2)) {
-    //    LogPrintf("CConsensusVote::Sign() - ERROR: Invalid masternodeprivkey: '%s'\n", errorMessage.c_str());
+    //    LogPrintf("CConsensusVote::Sign() - ERROR: Invalid masternodeprivkey: '%s'\n", errorMessage);
     //    return false;
     //}
 

--- a/divi/src/swifttx.cpp
+++ b/divi/src/swifttx.cpp
@@ -458,7 +458,7 @@ bool CConsensusVote::SignatureValid()
 {
     //std::string errorMessage;
     //std::string strMessage = txHash.ToString().c_str() + boost::lexical_cast<std::string>(nBlockHeight);
-    ////LogPrintf("verify strMessage %s \n", strMessage.c_str());
+    ////LogPrintf("verify strMessage %s \n", strMessage);
 
     //CMasternode* pmn = mnodeman.Find(vinMasternode);
 

--- a/divi/src/sync.cpp
+++ b/divi/src/sync.cpp
@@ -53,6 +53,8 @@ private:
     int sourceLine;
 };
 
+LOG_FORMAT_WITH_TOSTRING(CLockLocation)
+
 typedef std::vector<std::pair<void*, CLockLocation> > LockStack;
 
 static boost::mutex dd_mutex;
@@ -69,7 +71,7 @@ static void potential_deadlock_detected(const std::pair<void*, void*>& mismatch,
             LogPrintf(" (1)");
         if (i.first == mismatch.second)
             LogPrintf(" (2)");
-        LogPrintf(" %s\n", i.second.ToString());
+        LogPrintf(" %s\n", i.second);
     }
     LogPrintf("Current lock order is:\n");
     BOOST_FOREACH (const PAIRTYPE(void*, CLockLocation) & i, s1) {
@@ -77,7 +79,7 @@ static void potential_deadlock_detected(const std::pair<void*, void*>& mismatch,
             LogPrintf(" (1)");
         if (i.first == mismatch.second)
             LogPrintf(" (2)");
-        LogPrintf(" %s\n", i.second.ToString());
+        LogPrintf(" %s\n", i.second);
     }
 
     tfm::format(std::cerr, "Assertion failed: detected inconsistent lock order for %s, details in debug log.\n", s2.back().second.ToString());
@@ -89,7 +91,7 @@ static void push_lock(void* c, const CLockLocation& locklocation, bool fTry)
     if (lockstack.get() == NULL)
         lockstack.reset(new LockStack);
 
-    LogPrint("lock", "Locking: %s\n", locklocation.ToString());
+    LogPrint("lock", "Locking: %s\n", locklocation);
     dd_mutex.lock();
 
     (*lockstack).push_back(std::make_pair(c, locklocation));
@@ -118,7 +120,7 @@ static void pop_lock()
 {
     if (fDebug) {
         const CLockLocation& locklocation = (*lockstack).rbegin()->second;
-        LogPrint("lock", "Unlocked: %s\n", locklocation.ToString());
+        LogPrint("lock", "Unlocked: %s\n", locklocation);
     }
     dd_mutex.lock();
     (*lockstack).pop_back();

--- a/divi/src/torcontrol.cpp
+++ b/divi/src/torcontrol.cpp
@@ -506,7 +506,7 @@ void TorController::add_onion_cb(TorControlConnection& _conn, const TorControlRe
             return;
         }
         LookupNumeric(std::string(service_id+".onion").c_str(), service, GetListenPort());
-        LogPrintf("tor: Got service ID %s, advertising service %s\n", service_id, service.ToString());
+        LogPrintf("tor: Got service ID %s, advertising service %s\n", service_id, service);
         if (WriteBinaryFile(GetPrivateKeyFile(), private_key)) {
             LogPrint("tor", "tor: Cached service private key to %s\n", GetPrivateKeyFile());
         } else {

--- a/divi/src/txdb.cpp
+++ b/divi/src/txdb.cpp
@@ -277,7 +277,7 @@ bool CBlockTreeDB::LoadBlockIndexGuts()
 
                 if (pindexNew->nHeight <= Params().LAST_POW_BLOCK()) {
                     if (!CheckProofOfWork(pindexNew->GetBlockHash(), pindexNew->nBits, Params()))
-                        return error("LoadBlockIndex() : CheckProofOfWork failed: %s", pindexNew->ToString());
+                        return error("LoadBlockIndex() : CheckProofOfWork failed: %s", *pindexNew);
                 }
                 // ppcoin: build setStakeSeen
                 if (pindexNew->IsProofOfStake())

--- a/divi/src/txmempool.cpp
+++ b/divi/src/txmempool.cpp
@@ -192,7 +192,7 @@ private:
             // don't know why they got confirmed.
         }
         LogPrint("estimatefee", "Seen TX confirm: %s : %s fee/%g priority, took %d blocks\n",
-            assignedTo, feeRate.ToString(), dPriority, nBlocksAgo);
+            assignedTo, feeRate, dPriority, nBlocksAgo);
     }
 
 public:
@@ -255,7 +255,7 @@ public:
                 LogPrint("estimatefee", "estimates: for confirming within %d blocks based on %d/%d samples, fee=%s, prio=%g\n",
                     i,
                     history[i].FeeSamples(), history[i].PrioritySamples(),
-                    estimateFee(i + 1).ToString(), estimatePriority(i + 1));
+                    estimateFee(i + 1), estimatePriority(i + 1));
         }
     }
 

--- a/divi/src/verifyDb.cpp
+++ b/divi/src/verifyDb.cpp
@@ -72,24 +72,24 @@ bool CVerifyDB::VerifyDB(CCoinsView* coinsview, CCoinsViewCache* pcoinsTip, int 
         CBlock block;
         // check level 0: read from disk
         if (!ReadBlockFromDisk(block, pindex))
-            return error("VerifyDB() : *** ReadBlockFromDisk failed at %d, hash=%s", pindex->nHeight, pindex->GetBlockHash().ToString());
+            return error("VerifyDB() : *** ReadBlockFromDisk failed at %d, hash=%s", pindex->nHeight, pindex->GetBlockHash());
         // check level 1: verify block validity
         if (nCheckLevel >= 1 && !CheckBlock(block, state))
-            return error("VerifyDB() : *** found bad block at %d, hash=%s\n", pindex->nHeight, pindex->GetBlockHash().ToString());
+            return error("VerifyDB() : *** found bad block at %d, hash=%s\n", pindex->nHeight, pindex->GetBlockHash());
         // check level 2: verify undo validity
         if (nCheckLevel >= 2 && pindex) {
             CBlockUndo undo;
             CDiskBlockPos pos = pindex->GetUndoPos();
             if (!pos.IsNull()) {
                 if (!undo.ReadFromDisk(pos, pindex->pprev->GetBlockHash()))
-                    return error("VerifyDB() : *** found bad undo data at %d, hash=%s\n", pindex->nHeight, pindex->GetBlockHash().ToString());
+                    return error("VerifyDB() : *** found bad undo data at %d, hash=%s\n", pindex->nHeight, pindex->GetBlockHash());
             }
         }
         // check level 3: check for inconsistencies during memory-only disconnect of tip blocks
         if (nCheckLevel >= 3 && pindex == pindexState && (coins.GetCacheSize() + pcoinsTip->GetCacheSize()) <= coinsCacheSize_) {
             bool fClean = true;
             if (!chainManager_.DisconnectBlock(block, state, pindex, coins, &fClean))
-                return error("VerifyDB() : *** irrecoverable inconsistency in block data at %d, hash=%s", pindex->nHeight, pindex->GetBlockHash().ToString());
+                return error("VerifyDB() : *** irrecoverable inconsistency in block data at %d, hash=%s", pindex->nHeight, pindex->GetBlockHash());
             pindexState = pindex->pprev;
             if (!fClean) {
                 nGoodTransactions = 0;
@@ -117,9 +117,9 @@ bool CVerifyDB::VerifyDB(CCoinsView* coinsview, CCoinsViewCache* pcoinsTip, int 
             pindex = activeChain_.Next(pindex);
             CBlock block;
             if (!ReadBlockFromDisk(block, pindex))
-                return error("VerifyDB() : *** ReadBlockFromDisk failed at %d, hash=%s", pindex->nHeight, pindex->GetBlockHash().ToString());
+                return error("VerifyDB() : *** ReadBlockFromDisk failed at %d, hash=%s", pindex->nHeight, pindex->GetBlockHash());
             if (!ConnectBlock(block, state, pindex, coins, false))
-                return error("VerifyDB() : *** found unconnectable block at %d, hash=%s", pindex->nHeight, pindex->GetBlockHash().ToString());
+                return error("VerifyDB() : *** found unconnectable block at %d, hash=%s", pindex->nHeight, pindex->GetBlockHash());
         }
     }
 

--- a/divi/src/wallet.cpp
+++ b/divi/src/wallet.cpp
@@ -1225,8 +1225,7 @@ bool CWallet::AddToWallet(const CWalletTx& wtxIn, bool fFromLoadWallet)
                 else
                 {
                     LogPrintf("AddToWallet() : found %s in block %s not in index\n",
-                              wtxIn.GetHash().ToString(),
-                              wtxIn.hashBlock.ToString());
+                              wtxIn.GetHash(), wtxIn.hashBlock);
                 }
             }
         }
@@ -1253,7 +1252,7 @@ bool CWallet::AddToWallet(const CWalletTx& wtxIn, bool fFromLoadWallet)
 
         //// debug print
         LogPrintf("AddToWallet %s  %s%s\n",
-            wtxIn.GetHash().ToString(),
+            wtxIn.GetHash(),
             (transactionHashIsNewToWallet ? "new" : ""),
             (walletTransactionHasBeenUpdated ? "update" : ""));
 
@@ -2317,7 +2316,7 @@ bool CWallet::CommitTransaction(CWalletTx& wtxNew, CReserveKey& reservekey, std:
                     CWalletTx* coinPtr = const_cast<CWalletTx*>(GetWalletTx(txin.prevout.hash));
                     if(!coinPtr)
                     {
-                        LogPrintf("%s: Spending inputs not recorded in wallet - %s\n", __func__, txin.prevout.hash.ToString());
+                        LogPrintf("%s: Spending inputs not recorded in wallet - %s\n", __func__, txin.prevout.hash);
                         assert(coinPtr);
                     }
                     coinPtr->RecomputeCachedQuantities();
@@ -3287,7 +3286,7 @@ void CWallet::GetAmounts(
         CTxDestination address;
         if (!ExtractDestination(txout.scriptPubKey, address)) {
             if (!wtx.IsCoinStake() && !wtx.IsCoinBase()) {
-                LogPrintf("CWalletTx::GetAmounts: Unknown transaction type found, txid %s\n", wtx.GetHash().ToString());
+                LogPrintf("CWalletTx::GetAmounts: Unknown transaction type found, txid %s\n", wtx.GetHash());
             }
             address = CNoDestination();
         }

--- a/divi/src/wallet.cpp
+++ b/divi/src/wallet.cpp
@@ -2292,7 +2292,7 @@ bool CWallet::CommitTransaction(CWalletTx& wtxNew, CReserveKey& reservekey, std:
 {
     {
         LOCK2(cs_main, cs_wallet);
-        LogPrintf("CommitTransaction:\n%s", wtxNew.ToString());
+        LogPrintf("CommitTransaction:\n%s", wtxNew);
         {
             // This is only to keep the database open to defeat the auto-flush for the
             // duration of this scope.  This is the only place where this optimization

--- a/divi/src/walletBackupCreator.cpp
+++ b/divi/src/walletBackupCreator.cpp
@@ -44,7 +44,7 @@ bool WalletBackupCreator::BackupFile(PathType& sourceFile, PathType& backupFile)
 {
     try {
         fileSystem_.copy_file(sourceFile, backupFile);
-        LogPrintf("Creating backup of %s -> %s\n", sourceFile.c_str(), backupFile.c_str());
+        LogPrintf("Creating backup of %s -> %s\n", sourceFile, backupFile);
         return true;
     } catch (...) {
         LogPrintf("Failed to create backup\n");
@@ -92,7 +92,7 @@ void WalletBackupCreator::PruneOldBackups(std::string strWalletFile, PathType ba
             // More than nWalletBackups backups: delete oldest one(s)
             try {
                 fileSystem_.remove(file.second);
-                LogPrintf("Old backup deleted: %s\n", file.second.c_str());
+                LogPrintf("Old backup deleted: %s\n", file.second);
             } catch (...) {
                 LogPrintf("Failed to delete backup\n");
             }

--- a/divi/src/walletdb.cpp
+++ b/divi/src/walletdb.cpp
@@ -660,7 +660,7 @@ DBErrors CWalletDB::LoadWallet(CWallet* pwallet)
         const CWalletTx* txPtr = pwallet->GetWalletTx(hash);
         if(!txPtr)
         {
-            LogPrintf("Trying to write unknown transaction to database!\nHash: %s",hash.ToString());
+            LogPrintf("Trying to write unknown transaction to database!\nHash: %s", hash);
         }
         else
         {

--- a/divi/src/zmq/zmqpublishnotifier.cpp
+++ b/divi/src/zmq/zmqpublishnotifier.cpp
@@ -147,7 +147,7 @@ bool CZMQAbstractPublishNotifier::SendMessage(const char *command, const void* d
 bool CZMQPublishHashBlockNotifier::NotifyBlock(const CBlockIndex *pindex)
 {
     uint256 hash = pindex->GetBlockHash();
-    LogPrint("zmq", "zmq: Publish hashblock %s\n", hash.GetHex());
+    LogPrint("zmq", "zmq: Publish hashblock %s\n", hash);
     char data[32];
     for (unsigned int i = 0; i < 32; i++)
         data[31 - i] = hash.begin()[i];
@@ -157,7 +157,7 @@ bool CZMQPublishHashBlockNotifier::NotifyBlock(const CBlockIndex *pindex)
 bool CZMQPublishHashTransactionNotifier::NotifyTransaction(const CTransaction &transaction)
 {
     uint256 hash = transaction.GetHash();
-    LogPrint("zmq", "zmq: Publish hashtx %s\n", hash.GetHex());
+    LogPrint("zmq", "zmq: Publish hashtx %s\n", hash);
     char data[32];
     for (unsigned int i = 0; i < 32; i++)
         data[31 - i] = hash.begin()[i];
@@ -167,7 +167,7 @@ bool CZMQPublishHashTransactionNotifier::NotifyTransaction(const CTransaction &t
 bool CZMQPublishHashTransactionLockNotifier::NotifyTransactionLock(const CTransaction &transaction)
 {
     uint256 hash = transaction.GetHash();
-    LogPrint("zmq", "zmq: Publish hashtxlock %s\n", hash.GetHex());
+    LogPrint("zmq", "zmq: Publish hashtxlock %s\n", hash);
     char data[32];
     for (unsigned int i = 0; i < 32; i++)
         data[31 - i] = hash.begin()[i];
@@ -176,7 +176,7 @@ bool CZMQPublishHashTransactionLockNotifier::NotifyTransactionLock(const CTransa
 
 bool CZMQPublishRawBlockNotifier::NotifyBlock(const CBlockIndex *pindex)
 {
-    LogPrint("zmq", "zmq: Publish rawblock %s\n", pindex->GetBlockHash().GetHex());
+    LogPrint("zmq", "zmq: Publish rawblock %s\n", pindex->GetBlockHash());
 
 // XX42    const Consensus::Params& consensusParams = Params().GetConsensus();
     CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
@@ -199,7 +199,7 @@ bool CZMQPublishRawBlockNotifier::NotifyBlock(const CBlockIndex *pindex)
 bool CZMQPublishRawTransactionNotifier::NotifyTransaction(const CTransaction &transaction)
 {
     uint256 hash = transaction.GetHash();
-    LogPrint("zmq", "zmq: Publish rawtx %s\n", hash.GetHex());
+    LogPrint("zmq", "zmq: Publish rawtx %s\n", hash);
     CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
     ss << transaction;
     return SendMessage(MSG_RAWTX, &(*ss.begin()), ss.size());
@@ -208,7 +208,7 @@ bool CZMQPublishRawTransactionNotifier::NotifyTransaction(const CTransaction &tr
 bool CZMQPublishRawTransactionLockNotifier::NotifyTransactionLock(const CTransaction &transaction)
 {
     uint256 hash = transaction.GetHash();
-    LogPrint("zmq", "zmq: Publish rawtxlock %s\n", hash.GetHex());
+    LogPrint("zmq", "zmq: Publish rawtxlock %s\n", hash);
     CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
     ss << transaction;
     return SendMessage(MSG_RAWTXLOCK, &(*ss.begin()), ss.size());


### PR DESCRIPTION
This set of changes simplifies the log formatting code.  It replaces macros in `Logging.h` with C++11 variadic templates, and introduces "auto conversion" of certain types (e.g. `uint256` or `CService`) to string with `ToString`.  Instead of explicitly calling `GetHex()` or `ToString()` in log invokations, the types can now simply be passed directly to `LogPrint` and `LogPrintf`.