### PR TITLE
Allow transaction lookup by bare txid

### DIFF
--- a/divi/qa/rpc-tests/txindex.py
+++ b/divi/qa/rpc-tests/txindex.py
@@ -22,12 +22,12 @@ class TxIndexTest (BitcoinTestFramework):
         self.is_network_split = False
         self.sync_all ()
 
-    def expect_found (self, node, txid):
-        data = node.getrawtransaction (txid, 1)
-        assert_equal (data["txid"], txid)
+    def expect_found (self, node, key, value):
+        data = node.getrawtransaction (value, 1)
+        assert_equal (data[key], value)
 
-    def expect_not_found (self, node, txid):
-        assert_raises (JSONRPCException, node.getrawtransaction, txid)
+    def expect_not_found (self, node, value):
+        assert_raises (JSONRPCException, node.getrawtransaction, value)
 
     def run_test (self):
         self.nodes[0].setgenerate (True, 30)
@@ -46,13 +46,17 @@ class TxIndexTest (BitcoinTestFramework):
         tx = self.nodes[0].createrawtransaction (inputs, {addr: value - 1})
         signed = self.nodes[0].signrawtransaction (tx)
         assert_equal (signed["complete"], True)
-        txid = self.nodes[0].sendrawtransaction (signed["hex"])
+        self.nodes[0].sendrawtransaction (signed["hex"])
+        data = self.nodes[0].decoderawtransaction (signed["hex"])
+        txid = data["txid"]
+        bareTxid = data["baretxid"]
         sync_mempools (self.nodes)
 
         print ("Lookup through mempool...")
         for n in self.nodes:
           assert_equal (n.getrawmempool (), [txid])
-          self.expect_found (n, txid)
+          self.expect_found (n, "txid", txid)
+          self.expect_found (n, "baretxid", bareTxid)
 
         print ("Lookup through UTXO set...")
         self.nodes[0].setgenerate (True, 1)
@@ -60,7 +64,7 @@ class TxIndexTest (BitcoinTestFramework):
         for n in self.nodes:
           assert_equal (n.getrawmempool (), [])
           assert n.gettxout (txid, 0) is not None
-          self.expect_found (n, txid)
+          self.expect_found (n, "txid", txid)
 
         print ("Spending test output...")
         tx = self.nodes[0].createrawtransaction ([{"txid": txid, "vout": 0}], {addr: value - 2})
@@ -74,8 +78,10 @@ class TxIndexTest (BitcoinTestFramework):
         for n in self.nodes:
           assert_equal (n.getrawmempool (), [])
           assert_equal (n.gettxout (txid, 0), None)
-        self.expect_found (self.nodes[0], txid)
+        self.expect_found (self.nodes[0], "txid", txid)
+        self.expect_found (self.nodes[0], "baretxid", bareTxid)
         self.expect_not_found (self.nodes[1], txid)
+        self.expect_not_found (self.nodes[1], bareTxid)
 
 
 if __name__ == '__main__':

--- a/divi/src/BlockTransactionChecker.cpp
+++ b/divi/src/BlockTransactionChecker.cpp
@@ -25,14 +25,14 @@ TransactionLocationRecorder::TransactionLocationRecorder(
 
 void TransactionLocationRecorder::RecordTxLocationData(
     const CTransaction& tx,
-    std::vector<std::pair<uint256, CDiskTxPos> >& txLocationData)
+    std::vector<TxIndexEntry>& txLocationData)
 {
     if(!txLocationDataSizeHasBeenPreallocated_)
     {
         txLocationData.reserve(numberOfTransactions_);
         txLocationDataSizeHasBeenPreallocated_ = true;
     }
-    txLocationData.emplace_back(tx.GetHash(), nextBlockTxOnDiskLocation_);
+    txLocationData.emplace_back(tx.GetHash(), tx.GetBareTxid(), nextBlockTxOnDiskLocation_);
     nextBlockTxOnDiskLocation_.nTxOffset += ::GetSerializeSize(tx, SER_DISK, CLIENT_VERSION);
 }
 

--- a/divi/src/BlockTransactionChecker.h
+++ b/divi/src/BlockTransactionChecker.h
@@ -27,7 +27,7 @@ public:
         const CBlock& block);
     void RecordTxLocationData(
         const CTransaction& tx,
-        std::vector<std::pair<uint256, CDiskTxPos> >& txLocationData);
+        std::vector<TxIndexEntry>& txLocationData);
 };
 
 class BlockTransactionChecker

--- a/divi/src/IndexDatabaseUpdates.h
+++ b/divi/src/IndexDatabaseUpdates.h
@@ -6,12 +6,25 @@
 #include <spentindex.h>
 #include <uint256.h>
 
+/** One entry in the tx index, which locates transactions on disk by their txid
+ *  or bare txid (both keys are possible).  */
+struct TxIndexEntry
+{
+    uint256 txid;
+    uint256 bareTxid;
+    CDiskTxPos diskPos;
+
+    explicit TxIndexEntry(const uint256& t, const uint256& b, const CDiskTxPos& p)
+      : txid(t), bareTxid(b), diskPos(p)
+    {}
+};
+
 struct IndexDatabaseUpdates
 {
     std::vector<std::pair<CAddressIndexKey, CAmount> > addressIndex;
     std::vector<std::pair<CAddressUnspentKey, CAddressUnspentValue> > addressUnspentIndex;
     std::vector<std::pair<CSpentIndexKey, CSpentIndexValue> > spentIndex;
-    std::vector<std::pair<uint256, CDiskTxPos> > txLocationData;
+    std::vector<TxIndexEntry> txLocationData;
 
     IndexDatabaseUpdates();
 };

--- a/divi/src/TransactionDiskAccessor.cpp
+++ b/divi/src/TransactionDiskAccessor.cpp
@@ -44,14 +44,14 @@ bool GetTransaction(const uint256& hash, CTransaction& txOut, uint256& hashBlock
                     return error("%s : Deserialize or I/O error - %s", __func__, e.what());
                 }
                 hashBlock = header.GetHash();
-                if (txOut.GetHash() != hash)
+                if (txOut.GetHash() != hash && txOut.GetBareTxid() != hash)
                     return error("%s : txid mismatch", __func__);
                 return true;
             }
 
-            // The index only keys by txid.  So even if we did not find the
-            // transaction here, it could be that the lookup is by bare txid
-            // and can be found through UTXO lookup.
+            // Transaction not found in the index (which works both with
+            // txid and bare txid), nothing more can be done.
+            return false;
         }
 
         if (fAllowSlow) { // use coin database to locate block that contains transaction, and scan it

--- a/divi/src/WalletTransactionRecord.h
+++ b/divi/src/WalletTransactionRecord.h
@@ -10,12 +10,20 @@ private:
     CCriticalSection& cs_walletTxRecord;
     const std::string walletFilename_;
     const bool databaseWritesAreDisallowed_;
+
+    /** Map from the bare txid of transactions in the wallet to the matching
+     *  transactions themselves.  */
+    std::map<uint256, const CWalletTx*> mapBareTxid;
+
 public:
     std::map<uint256, CWalletTx> mapWallet;
 
     WalletTransactionRecord(CCriticalSection& requiredWalletLock,const std::string& walletFilename);
     WalletTransactionRecord(CCriticalSection& requiredWalletLock);
     const CWalletTx* GetWalletTx(const uint256& hash) const;
+
+    /** Tries to look up a transaction in the wallet, either by hash (txid) or
+     *  the bare txid that is used after segwit-light to identify outputs.  */
     std::vector<const CWalletTx*> GetWalletTransactionReferences() const;
     std::pair<std::map<uint256, CWalletTx>::iterator, bool> AddTransaction(const CWalletTx& newlyAddedTransaction);
     void UpdateMetadata(const uint256& hashOfTransactionToUpdate, const CWalletTx& updatedTransaction, bool updateDiskAndTimestamp,bool writeToWalletDb=false);

--- a/divi/src/rpcmasternode.cpp
+++ b/divi/src/rpcmasternode.cpp
@@ -81,7 +81,7 @@ Value allocatefunds(const Array& params, bool fHelp)
 			"      <future>     (numeric, required) amount of divi funded will also be accepted for partially funding master nodes and other purposes.\n"
 
 			"\nResult:\n"
-			"\"vin\"			(string) funding transaction id necessary for next step.\n");
+			"\"vin\"			(string) funding transaction id or bare txid necessary for next step.\n");
 
     if (params[0].get_str() != "masternode")
     {
@@ -117,7 +117,7 @@ Value fundmasternode(const Array& params, bool fHelp)
 			"1. alias			(string, required) helpful identifier to recognize this allocation later.\n"
 			"2. amount			(diamond, platinum, gold, silver, copper) tier of masternode. \n"
 			"      <future>     (numeric, required) amount of divi funded will also be accepted for partially funding master nodes and other purposes.\n"
-			"3. TxID			(string, required) funding transaction id .\n"
+			"3. TxID			(string, required) funding transaction id or bare txid.\n"
             "4. masternode		(string, required) ip address of masternode.\n"
 			"(use an empty string for the pay wallet if the same as the funding wallet and you wish to assign a different voting wallet).\n"
 
@@ -232,7 +232,7 @@ Value setupmasternode(const Array& params, bool fHelp)
 
 			"\nArguments:\n"
 			"1. alias			    (string, required) Helpful identifier to recognize this masternode later. \n"
-			"2. txHash              (string, required) Funding transaction. \n"
+			"2. txHash              (string, required) Funding transaction hash or bare txid. \n"
             "3. outputIndex         (string, required) Output index transaction. \n"
             "4. collateralPubkey    (string, required) collateral pubkey. \n"
             "5. ip_address          (string, required) Local ip address of this node\n"

--- a/divi/src/txdb.h
+++ b/divi/src/txdb.h
@@ -28,6 +28,7 @@ struct CAddressUnspentValue;
 struct CDiskTxPos;
 struct CCoinsStats;
 struct CSpentIndexValue;
+struct TxIndexEntry;
 
 /** CCoinsView backed by the LevelDB coin database (chainstate/) */
 class CCoinsViewDB : public CCoinsView
@@ -64,7 +65,7 @@ public:
     bool WriteReindexing(bool fReindex);
     bool ReadReindexing(bool& fReindex);
     bool ReadTxIndex(const uint256& txid, CDiskTxPos& pos);
-    bool WriteTxIndex(const std::vector<std::pair<uint256, CDiskTxPos> >& list);
+    bool WriteTxIndex(const std::vector<TxIndexEntry>& list);
     bool WriteAddressIndex(const std::vector<std::pair<CAddressIndexKey, CAmount> > &vect);
     bool EraseAddressIndex(const std::vector<std::pair<CAddressIndexKey, CAmount> > &vect);
     bool ReadAddressIndex(uint160 addressHash, int type,


### PR DESCRIPTION
This extends `GetTransaction` (lookup of a transaction from disk) and `GetWalletTx` (lookup of a transaction in the wallet) to find transactions both by txid and bare txid.  For this, we also extend the on-disk index created when `-txindex` is enabled.

This will be needed after segwit light, to look up previous transactions given a `CTxIn` `prevout` pointer.  Note that this change by itself does not affect consensus.  It only makes those lookups succeed in some cases that failed before, and all places that do lookups with `GetTransaction` in the consensus logic do that just as part of more checks (e.g. to access a previous transaction's output script) where other checks will fail accordingly before the fork.

This is #76 reopened after some changes made to the branches.