### PR TITLE
Introduce CTransaction::ToStringShort

### DIFF
--- a/divi/src/Output.cpp
+++ b/divi/src/Output.cpp
@@ -35,5 +35,5 @@ const CScript& COutput::scriptPubKey() const
 
 std::string COutput::ToString() const
 {
-    return strprintf("COutput(%s, %d, %d) [%s]", tx->GetHash().ToString(), i, nDepth, FormatMoney(tx->vout[i].nValue));
+    return strprintf("COutput(%s, %d, %d) [%s]", tx->ToStringShort(), i, nDepth, FormatMoney(tx->vout[i].nValue));
 }

--- a/divi/src/PoSTransactionCreator.cpp
+++ b/divi/src/PoSTransactionCreator.cpp
@@ -206,7 +206,7 @@ bool PoSTransactionCreator::FindHashproof(
             LogPrintf("%s : kernel found, but it is too far in the past \n",__func__);
             return false;
         }
-        LogPrint("staking","%s : kernel found for %s\n",__func__, stakeData.tx->GetHash());
+        LogPrint("staking","%s : kernel found for %s\n",__func__, stakeData.tx->ToStringShort());
 
         SetSuportedStakingScript(stakeData,txNew);
         nTxNewTime = hashproofResult.timestamp();

--- a/divi/src/UtxoCheckingAndUpdating.cpp
+++ b/divi/src/UtxoCheckingAndUpdating.cpp
@@ -151,7 +151,7 @@ bool CheckInputs(
                                  REJECT_INVALID, "bad-txns-inputs-missingorspent");
             }
             return state.Invalid(
-                error("CheckInputs() : %s inputs unavailable", tx.GetHash()) );
+                error("CheckInputs() : %s inputs unavailable", tx.ToStringShort()) );
         }
 
 
@@ -184,13 +184,13 @@ bool CheckInputs(
         if (!tx.IsCoinStake()) {
             if (nValueIn < tx.GetValueOut())
                 return state.DoS(100, error("CheckInputs() : %s value in (%s) < value out (%s)",
-                                            tx.GetHash(), FormatMoney(nValueIn), FormatMoney(tx.GetValueOut())),
+                                            tx.ToStringShort(), FormatMoney(nValueIn), FormatMoney(tx.GetValueOut())),
                                  REJECT_INVALID, "bad-txns-in-belowout");
 
             // Tally transaction fees
             CAmount nTxFee = nValueIn - tx.GetValueOut();
             if (nTxFee < 0)
-                return state.DoS(100, error("CheckInputs() : %s nTxFee < 0", tx.GetHash()),
+                return state.DoS(100, error("CheckInputs() : %s nTxFee < 0", tx.ToStringShort()),
                                  REJECT_INVALID, "bad-txns-fee-negative");
             nFees += nTxFee;
             if (!MoneyRange(nFees))

--- a/divi/src/WalletTx.cpp
+++ b/divi/src/WalletTx.cpp
@@ -99,8 +99,7 @@ void CWalletTx::RelayWalletTransaction()
     if (!IsCoinBase()) {
         if (GetNumberOfBlockConfirmations() == 0)
         {
-            uint256 hash = GetHash();
-            LogPrintf("Relaying wtx %s\n", hash);
+            LogPrintf("Relaying wtx %s\n", ToStringShort());
             RelayTransaction((CTransaction) * this);
         }
     }

--- a/divi/src/kernel.cpp
+++ b/divi/src/kernel.cpp
@@ -241,7 +241,7 @@ bool CheckProofOfStakeContextAndRecoverStakingData(
     static const unsigned maxInputs = settings.MaxNumberOfPoSCombinableInputs();
     const CTransaction tx = block.vtx[1];
     if (!tx.IsCoinStake())
-        return error("CheckProofOfStake() : called on non-coinstake %s", tx.GetHash());
+        return error("CheckProofOfStake() : called on non-coinstake %s", tx.ToStringShort());
 
     if(tx.vin.size() > maxInputs) {
         return error("CheckProofOfStake() : invalid amount of stake inputs, current: %d, max: %d", tx.vin.size(), maxInputs);
@@ -270,7 +270,7 @@ bool CheckProofOfStakeContextAndRecoverStakingData(
 
     //verify signature and script
     if (!VerifyScript(txin.scriptSig, txPrev.vout[txin.prevout.n].scriptPubKey, POS_SCRIPT_VERIFY_FLAGS, TransactionSignatureChecker(&tx, 0)))
-        return error("CheckProofOfStake() : VerifySignature failed on coinstake %s", tx.GetHash());
+        return error("CheckProofOfStake() : VerifySignature failed on coinstake %s", tx.ToStringShort());
 
     CBlockIndex* pindex = NULL;
     BlockMap::iterator it = mapBlockIndex.find(hashBlock);
@@ -303,7 +303,7 @@ bool CheckProofOfStake(CChain& activeChain, const CBlock& block, CBlockIndex* pi
         return false;
     if (!posGenerator.ComputeAndVerifyProofOfStake(stakingData, block.nTime, hashProofOfStake))
         return error("CheckProofOfStake() : INFO: check kernel failed on coinstake %s, hashProof=%s \n",
-            block.vtx[1].GetHash(), hashProofOfStake); // may occur during initial download or if behind on block chain sync
+            block.vtx[1].ToStringShort(), hashProofOfStake); // may occur during initial download or if behind on block chain sync
 
     return true;
 }

--- a/divi/src/main.cpp
+++ b/divi/src/main.cpp
@@ -864,7 +864,7 @@ bool CheckFeesPaidAreAcceptable(
     bool txShouldHavePriority = TxShouldBePrioritized(hash, nSize);
     if (fLimitFree && !txShouldHavePriority && nFees < minimumRelayFee)
         return state.DoS(0, error("%s : not enough fees %s, %d < %d",__func__,
-                                    hash, nFees, minimumRelayFee),
+                                    tx.ToStringShort(), nFees, minimumRelayFee),
                             REJECT_INSUFFICIENTFEE, "insufficient fee");
     // Require that free transactions have sufficient priority to be mined in the next block.
     if (settings.GetBoolArg("-relaypriority", true) &&
@@ -2270,7 +2270,7 @@ bool CheckBlock(const CBlock& block, CValidationState& state, bool fCheckMerkleR
                     if (mapLockedInputs.count(in.prevout)) {
                         if (mapLockedInputs[in.prevout] != tx.GetHash()) {
                             mapRejectedBlocks.insert(make_pair(block.GetHash(), GetTime()));
-                            LogPrintf("%s : found conflicting transaction with transaction lock %s %s\n",__func__, mapLockedInputs[in.prevout], tx.GetHash());
+                            LogPrintf("%s : found conflicting transaction with transaction lock %s %s\n",__func__, mapLockedInputs[in.prevout], tx.ToStringShort());
                             return state.DoS(0, error("%s : found conflicting transaction with transaction lock",__func__),
                                              REJECT_INVALID, "conflicting-tx-ix");
                         }
@@ -3799,7 +3799,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
             LogPrint("mempool", "%s: peer=%d %s : accepted %s (poolsz %u)\n",
                     __func__,
                      pfrom->id, pfrom->cleanSubVer,
-                     tx.GetHash(),
+                     tx.ToStringShort(),
                      mempool.mapTx.size());
 
             // Recursively process any orphan transactions that depended on this one
@@ -3861,7 +3861,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
 
         int nDoS = 0;
         if (state.IsInvalid(nDoS)) {
-            LogPrint("mempool", "%s from peer=%d %s was not accepted into the memory pool: %s\n", tx.GetHash(),
+            LogPrint("mempool", "%s from peer=%d %s was not accepted into the memory pool: %s\n", tx.ToStringShort(),
                      pfrom->id, pfrom->cleanSubVer,
                      state.GetRejectReason());
             pfrom->PushMessage("reject", strCommand, state.GetRejectCode(),

--- a/divi/src/primitives/transaction.cpp
+++ b/divi/src/primitives/transaction.cpp
@@ -302,8 +302,8 @@ CAmount CTransaction::GetValueOut() const
 std::string CTransaction::ToString() const
 {
     std::string str;
-    str += strprintf("CTransaction(hash=%s, ver=%d, vin.size=%u, vout.size=%u, nLockTime=%u)\n",
-        GetHash().ToString().substr(0,10),
+    str += strprintf("CTransaction(%s, ver=%d, vin.size=%u, vout.size=%u, nLockTime=%u)\n",
+        ToStringShort(),
         nVersion,
         vin.size(),
         vout.size(),
@@ -313,4 +313,9 @@ std::string CTransaction::ToString() const
     for (unsigned int i = 0; i < vout.size(); i++)
         str += "    " + vout[i].ToString() + "\n";
     return str;
+}
+
+std::string CTransaction::ToStringShort() const
+{
+    return GetHash().ToString().substr(0, 10);
 }

--- a/divi/src/primitives/transaction.h
+++ b/divi/src/primitives/transaction.h
@@ -160,6 +160,11 @@ public:
     friend bool operator==(const CTransaction& a, const CTransaction& b);
     friend bool operator!=(const CTransaction& a, const CTransaction& b);
     std::string ToString() const;
+
+    /** Converts the transcation to a short representation for use in
+     *  logs that just want to refer to it (rather than show the details),
+     *  which is just the transaction ID for now.  */
+    std::string ToStringShort() const;
 };
 
 /** A mutable version of CTransaction. */

--- a/divi/src/scriptCheck.cpp
+++ b/divi/src/scriptCheck.cpp
@@ -19,7 +19,7 @@ bool CScriptCheck::operator()()
 {
     const CScript& scriptSig = ptxTo->vin[nIn].scriptSig;
     if (!VerifyScript(scriptSig, scriptPubKey, nFlags, CachingTransactionSignatureChecker(ptxTo, nIn, cacheStore), &error)) {
-        return ::error("CScriptCheck(): %s:%d VerifySignature failed: %s", ptxTo->GetHash(), nIn, ScriptErrorString(error));
+        return ::error("CScriptCheck(): %s:%d VerifySignature failed: %s", ptxTo->ToStringShort(), nIn, ScriptErrorString(error));
     }
     return true;
 }

--- a/divi/src/wallet.cpp
+++ b/divi/src/wallet.cpp
@@ -1159,7 +1159,7 @@ bool CWallet::AddToWallet(const CWalletTx& wtxIn, bool fFromLoadWallet)
                 else
                 {
                     LogPrintf("AddToWallet() : found %s in block %s not in index\n",
-                              wtxIn.GetHash(), wtxIn.hashBlock);
+                              wtxIn.ToStringShort(), wtxIn.hashBlock);
                 }
             }
         }
@@ -1186,7 +1186,7 @@ bool CWallet::AddToWallet(const CWalletTx& wtxIn, bool fFromLoadWallet)
 
         //// debug print
         LogPrintf("AddToWallet %s  %s%s\n",
-            wtxIn.GetHash(),
+            wtxIn.ToStringShort(),
             (transactionHashIsNewToWallet ? "new" : ""),
             (walletTransactionHasBeenUpdated ? "update" : ""));
 
@@ -3188,7 +3188,7 @@ void CWallet::GetAmounts(
         CTxDestination address;
         if (!ExtractDestination(txout.scriptPubKey, address)) {
             if (!wtx.IsCoinStake() && !wtx.IsCoinBase()) {
-                LogPrintf("CWalletTx::GetAmounts: Unknown transaction type found, txid %s\n", wtx.GetHash());
+                LogPrintf("CWalletTx::GetAmounts: Unknown transaction type found, txid %s\n", wtx.ToStringShort());
             }
             address = CNoDestination();
         }


### PR DESCRIPTION
`CTransaction::ToString` exists already, but converts the transaction to a string with lots of details.  Many logging calls want just a short reference to the transaction, like its txid (or the first part).

This introduces `ToStringShort` as a method that does this (convert to a short string reference for use in logging), and replaces calls to `GetHash()` in logging with `ToStringShort`.