### PR TITLE
Fix for category filtering in logging

### DIFF
--- a/divi/src/Logging.cpp
+++ b/divi/src/Logging.cpp
@@ -107,17 +107,15 @@ bool LogAcceptCategory(const char* category)
             const std::vector<std::string> categories = settings.GetMultiParameter("-debug");
             ptrCategory.reset(new std::set<std::string>(categories.begin(), categories.end()));
             // thread_specific_ptr automatically deletes the set when the thread ends.
-            // "all" is a composite category enabling all DIVI-related debug output
-            if (ptrCategory->count(std::string("all")) || ptrCategory->count(std::string("")))
-            {
-                return true;
-            }
         }
         const std::set<std::string>& setCategories = *ptrCategory.get();
 
-        // if not debugging everything and not debugging specific category, LogPrint does nothing.
-        if (setCategories.count(std::string(category)) == 0)
-            return false;
+        // "all" is a composite category enabling all DIVI-related debug output
+        if (ptrCategory->count(std::string("all")) || ptrCategory->count(std::string("")))
+            return true;
+
+        // if not debugging specific category, LogPrint does nothing.
+        return setCategories.count(std::string(category)) > 0;
     }
     return true;
 }

--- a/divi/src/utiltime.cpp
+++ b/divi/src/utiltime.cpp
@@ -7,6 +7,7 @@
 #include "config/divi-config.h"
 #endif
 
+#include "Logging.h"
 #include "tinyformat.h"
 #include "utiltime.h"
 
@@ -30,6 +31,7 @@ int64_t GetTime()
 void SetMockTime(int64_t nMockTimeIn)
 {
     boost::unique_lock<boost::mutex> lock(csMockTime);
+    LogPrint("mocktime", "Setting mocktime to %d\n", nMockTime);
     nMockTime = nMockTimeIn;
     cvMockTimeChanged.notify_all();
 }


### PR DESCRIPTION
This fixes a bug with category filtering in logging (see the commit message for more details), and also adds a new `LogPrint` statement for mocktime changes.  The latter is useful in particular to interpret and debug regtests using mocktime.