### PR TITLE
Avoid blanko -debug in masternode tests

### DIFF
--- a/divi/qa/rpc-tests/MnAreSafeToRestart.py
+++ b/divi/qa/rpc-tests/MnAreSafeToRestart.py
@@ -28,7 +28,7 @@ class MnAreSafeToRestart (BitcoinTestFramework):
 
   def __init__ (self):
     super ().__init__ ()
-    self.base_args = ["-debug", "-nolistenonion"]
+    self.base_args = ["-debug=masternode", "-debug=mocktime", "-nolistenonion"]
 
   def setup_chain (self):
     for i in range (7):

--- a/divi/qa/rpc-tests/mnoperation.py
+++ b/divi/qa/rpc-tests/mnoperation.py
@@ -27,7 +27,7 @@ class MnStatusTest (BitcoinTestFramework):
 
   def __init__ (self):
     super ().__init__ ()
-    self.base_args = ["-debug", "-nolistenonion"]
+    self.base_args = ["-debug=masternode", "-debug=mocktime", "-nolistenonion"]
 
   def setup_chain (self):
     for i in range (7):

--- a/divi/qa/rpc-tests/mnvaults.py
+++ b/divi/qa/rpc-tests/mnvaults.py
@@ -27,7 +27,7 @@ class MnVaultsTest (BitcoinTestFramework):
 
   def __init__ (self):
     super (MnVaultsTest, self).__init__ ()
-    self.base_args = ["-debug", "-nolistenonion"]
+    self.base_args = ["-debug=masternode", "-debug=mocktime", "-nolistenonion"]
     self.cfg = None
 
   def setup_chain (self):

--- a/divi/qa/rpc-tests/remotestart.py
+++ b/divi/qa/rpc-tests/remotestart.py
@@ -27,7 +27,7 @@ class MnRemoteStartTest (BitcoinTestFramework):
 
   def __init__ (self):
     super ().__init__ ()
-    self.base_args = ["-debug"]
+    self.base_args = ["-debug=masternode", "-debug=mocktime"]
 
   def add_options(self, parser):
           parser.add_option("--outdated_ping", dest="outdated_ping", default=False, action="store_true",


### PR DESCRIPTION
Replace a blanko `-debug` with more specific flags (e.g. `-debug=masternode`) in the masternode regtests.  With the recent fix to log filtering (#86), in particular the "lock" log messages are quite spammy and might cause these already long-running and delicate-in-timing tests to break easily.