### PR TITLE
Avoid tx lookup in SpentOutputTracker

### DIFF
--- a/divi/src/SpentOutputTracker.h
+++ b/divi/src/SpentOutputTracker.h
@@ -14,12 +14,14 @@ class SpentOutputTracker
 {
 private:
     WalletTransactionRecord& transactionRecord_;
-protected:
+
     using TxSpends = std::multimap<COutPoint, uint256>;
     TxSpends mapTxSpends;
+
     void AddToSpends(const COutPoint& outpoint, const uint256& wtxid);
-    void AddToSpends(const uint256& wtxid);
+    void AddToSpends(const CWalletTx& tx);
     void SyncMetaData(std::pair<TxSpends::iterator, TxSpends::iterator>);
+
 public:
     SpentOutputTracker(WalletTransactionRecord& transactionRecord);
     /**


### PR DESCRIPTION
This refactors `SpentOutputTracker::AddToSpends` so that the `CWalletTx&` being operated on is passed in directly, rather than passing in the ID and then looking up the transaction.

The only place that actually calls this method already has the transaction reference itself readily available anyway.