### PR TITLE
Fix lock-order issue with reject messages

### DIFF
--- a/divi/qa/rpc-tests/mempool_reject.py
+++ b/divi/qa/rpc-tests/mempool_reject.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+# Copyright (c) 2021 The DIVI developers
+# Distributed under the MIT/X11 software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+# Tests that rejecting transactions passed on from a peer into the mempool
+# works as expected.  In particular, there used to be a bug that triggered
+# a lock-order violation when reject messages were sent.
+
+from test_framework import BitcoinTestFramework
+from authproxy import JSONRPCException
+from messages import *
+from util import *
+from script import *
+
+from decimal import Decimal
+import time
+
+
+class MempoolRejectTest (BitcoinTestFramework):
+
+    def setup_network (self, split=False):
+        base_args = ["-debug=net", "-debug=mempool"]
+        # Node 0 accepts non-standard transactions, and node 1 does not.
+        args = [base_args + ["-acceptnonstandard"], base_args]
+        self.nodes = start_nodes (2, self.options.tmpdir, extra_args=args)
+        connect_nodes (self.nodes[0], 1)
+        self.is_network_split = False
+
+    def run_test (self):
+        # To make one node broadcast a transaction that the other node
+        # rejects, we use a nonstandard transaction while one of the
+        # nodes is set to allow that and the other to reject them
+        # according to their relay policy.
+
+        self.nodes[0].setgenerate (True, 30)
+        utxo = self.nodes[0].listunspent ()[0]
+
+        value = utxo["amount"]
+        fee = Decimal ("0.01")
+
+        tx = CTransaction ()
+        tx.vin.append (CTxIn (COutPoint (txid=utxo["txid"], n=utxo["vout"])))
+        tx.vout.append (CTxOut (int (100_000_000 * (value - fee)),
+                                CScript ([1234, OP_EQUAL])))
+
+        unsigned = tx.serialize ().hex ()
+        signed = self.nodes[0].signrawtransaction (unsigned)
+        assert_equal (signed["complete"], True)
+
+        # The transaction will be rejected by node 1.
+        assert_raises (JSONRPCException, self.nodes[1].sendrawtransaction,
+                       signed["hex"])
+        txid = self.nodes[0].sendrawtransaction (signed["hex"])
+        time.sleep (1)
+        assert_equal (self.nodes[0].getrawmempool (), [txid])
+        assert_equal (self.nodes[1].getrawmempool (), [])
+
+
+if __name__ == '__main__':
+    MempoolRejectTest ().main ()

--- a/divi/qa/rpc-tests/test_runner.py
+++ b/divi/qa/rpc-tests/test_runner.py
@@ -86,6 +86,7 @@ BASE_SCRIPTS = [
     'listtransactions.py',
     'mempool_coinbase_spends.py',
     'mempool_indices.py',
+    'mempool_reject.py',
     'mempool_resurrect_test.py',
     'mempool_spendcoinbase.py',
     'MnAreSafeToRestart.py',

--- a/divi/src/main.cpp
+++ b/divi/src/main.cpp
@@ -3292,10 +3292,11 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
         CInv inv(MSG_TX, tx.GetHash());
         pfrom->AddInventoryKnown(inv);
 
-        LOCK(cs_main);
-
         bool fMissingInputs = false;
         CValidationState state;
+
+        {
+        LOCK(cs_main);
 
         CNode::ClearInventoryItem(inv);
 
@@ -3367,6 +3368,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
 
             RelayTransaction(tx);
         }
+        } // cs_main
 
         int nDoS = 0;
         if (state.IsInvalid(nDoS)) {


### PR DESCRIPTION
When a transaction gets relayed from a peer that we actually don't accept into the mempool, we send back a `reject` message.  This is something that does not happen often in practice and was not covered by tests so far (but is now with a new regtest).

If this happened, it triggered a lock-order violation:  The code processing the `tx` message would first lock `cs_main`, and then a peer's `cs_vSend` (for the `reject` message) while still holding onto `cs_main`.  On the other hand, when relaying wallet transactions, the locks are used in the reverse order (the `cs_vSend` when processing messages to send to a peer in general, and the `cs_main` is used when determining whether or not a wallet transaction is already in the main chain).

This fixes this issue, by releasing `cs_main` before sending the `reject` message; there is no need to hold onto the lock then anyway.