### PR TITLE
-nolistenonion for smartfees.py

### DIFF
--- a/divi/qa/rpc-tests/smartfees.py
+++ b/divi/qa/rpc-tests/smartfees.py
@@ -78,7 +78,7 @@ class EstimateFeeTest(BitcoinTestFramework):
 
     def setup_network(self):
         self.nodes = []
-        base = ["-debug=mempool", "-debug=estimatefee", "-relaypriority=0", "-spendzeroconfchange"]
+        base = ["-debug=mempool", "-debug=estimatefee", "-relaypriority=0", "-spendzeroconfchange", "-nolistenonion"]
         self.nodes.append(start_node(0, self.options.tmpdir, base))
         # Node1 mines small-but-not-tiny blocks, and allows free transactions.
         # NOTE: the CreateNewBlock code starts counting block size at 1,000 bytes,


### PR DESCRIPTION
Explicitly add `-nolistenonion` in the `smartfees.py` regtest.  Without it, `divid` tries to listen (publicly) with a Tor hidden service if Tor is running on the test system.  This is unnecessary and causes excessive CPU usage during the test.