### PR TITLE
Simplify StakableCoin

### DIFF
--- a/divi/src/PoSTransactionCreator.h
+++ b/divi/src/PoSTransactionCreator.h
@@ -61,7 +61,7 @@ private:
         const StakableCoin& stakeData,
         CMutableTransaction& txNew);
 
-    StakableCoin FindProofOfStake(
+    const StakableCoin* FindProofOfStake(
         const CBlockIndex* chainTip,
         uint32_t blockBits,
         CMutableTransaction& txCoinStake,

--- a/divi/src/StakableCoin.h
+++ b/divi/src/StakableCoin.h
@@ -5,31 +5,29 @@
 struct StakableCoin
 {
     const CTransaction* tx;
-    unsigned outputIndex;
-    uint256 blockHashOfFirstConfirmation;
     COutPoint utxo;
+    uint256 blockHashOfFirstConfirmation;
 
-    StakableCoin(
-        ): tx(nullptr)
-        , outputIndex(0u)
-        , blockHashOfFirstConfirmation(0u)
-        , utxo(uint256(0),outputIndex)
-    {
-    }
-
-    StakableCoin(
-        const CTransaction* txIn,
-        unsigned outputIndexIn,
+    explicit StakableCoin(
+        const CTransaction& txIn,
+        const COutPoint& utxoIn,
         uint256 blockHashIn
-        ): tx(txIn)
-        , outputIndex(outputIndexIn)
+        ): tx(&txIn)
         , blockHashOfFirstConfirmation(blockHashIn)
-        , utxo( tx?tx->GetHash():uint256(0), outputIndex)
+        , utxo(utxoIn)
     {
     }
+
     bool operator<(const StakableCoin& other) const
     {
         return utxo < other.utxo;
     }
+
+    /** Convenience method to access the staked tx out.  */
+    const CTxOut& GetTxOut() const
+    {
+        return tx->vout[utxo.n];
+    }
+
 };
 #endif//STAKABLE_COIN_H

--- a/divi/src/test/wallet_coinmanagement_tests.cpp
+++ b/divi/src/test/wallet_coinmanagement_tests.cpp
@@ -395,8 +395,8 @@ BOOST_AUTO_TEST_CASE(willEnsureStakingBalanceAndTotalBalanceAgreeEvenIfTxsBelong
     wallet.FakeAddToChain(secondNormalTx);
 
     std::set<StakableCoin> stakableCoins;
-    stakableCoins.insert(StakableCoin(&firstNormalTx,firstTxOutputIndex,firstNormalTx.hashBlock));
-    stakableCoins.insert(StakableCoin(&secondNormalTx,secondTxOutputIndex,secondNormalTx.hashBlock));
+    stakableCoins.insert(StakableCoin(firstNormalTx,COutPoint(firstNormalTx.GetHash(),firstTxOutputIndex),firstNormalTx.hashBlock));
+    stakableCoins.insert(StakableCoin(secondNormalTx,COutPoint(secondNormalTx.GetHash(),secondTxOutputIndex),secondNormalTx.hashBlock));
     BOOST_CHECK_EQUAL_MESSAGE(stakableCoins.size(),2,"Missing coins in the stakable set");
 }
 

--- a/divi/src/wallet.cpp
+++ b/divi/src/wallet.cpp
@@ -1797,7 +1797,7 @@ bool CWallet::SelectStakeCoins(std::set<StakableCoin>& setCoins) const
             continue;
 
         //add to our stake set
-        setCoins.insert(StakableCoin(out.tx, out.i,out.tx->hashBlock));
+        setCoins.emplace(*out.tx, COutPoint(out.tx->GetHash(), out.i), out.tx->hashBlock);
         nAmountSelected += out.tx->vout[out.i].nValue;
     }
     return true;


### PR DESCRIPTION
This is a refactor of the `StakableCoin` utility class.  There was some redundancy (e.g. between `outputIndex` and `utxo`), and also there was support for "empty" `StakableCoin` instances, which was needed only in one place but added extra complications to the class itself.

With this, the class and usage is simplified and easier to reason about.  It also makes it easier to switch to segwit light in the future, since we now just pass in the UTXO outpoint from the wallet and never explicitly deal with transaction hashes afterwards.