### PR TITLE
Don't query UTXO set in AlreadyHave

### DIFF
--- a/divi/src/main.cpp
+++ b/divi/src/main.cpp
@@ -2772,8 +2772,7 @@ bool static AlreadyHave(const CInv& inv)
     case MSG_TX: {
         bool txInMap = false;
         txInMap = mempool.exists(inv.hash);
-        return txInMap || OrphanTransactionIsKnown(inv.hash) ||
-                pcoinsTip->HaveCoins(inv.hash);
+        return txInMap || OrphanTransactionIsKnown(inv.hash);
     }
 
     case MSG_BLOCK:


### PR DESCRIPTION
`AlreadyHave` (on transactions) is used to check if a transaction is already known before we request it from a peer (e.g. after they sent an `inv` message for it).  This method checks the mempool but also the UTXO set as a fall-back for transactions that are already confirmed.

The latter, however, is a far-from-perfect check, as a confirmed transaction will not show up if all outputs have been spent already.  Furthermore, nodes will send inv (or follow-up tx) messages only for transactions in their mempool and not ones they consider already confirmed; so the only case where the UTXO check actually makes a difference is during race-conditions when a transaction has just been confirmed.

This commit removes the check, so that we only look at the mempool.  This makes the behaviour clear, so it does not rely on that half-working UTXO check, and also streamlines the logic for segwit light in the future.

In the rare cases where the UTXO check would have made a difference, this now simply means that we may request a transaction that is actually already confirmed, and if we receive it from the peer (if they don't yet know it is confirmed), reject it with a similar check inside `AcceptToMemoryPool` (without applying a banscore to the peer!).

Note in particular that the removed check is not a defense against deliberate DoS attacks from peers, as they could easily use confirmed transactions with fully spent outputs to circumvent it anyway.