### PR TITLE
Cleanups related to the OutputHash work

### DIFF
--- a/divi/src/BlockMemoryPoolTransactionCollector.cpp
+++ b/divi/src/BlockMemoryPoolTransactionCollector.cpp
@@ -106,7 +106,7 @@ void BlockMemoryPoolTransactionCollector::RecordOrphanTransaction (
     std::shared_ptr<COrphan>& porphan,
     const CTransaction& tx,
     const CTxIn& txin,
-    std::map<uint256, std::vector<std::shared_ptr<COrphan>>>& dependentTransactions) const
+    DependingTransactionsMap& dependentTransactions) const
 {
     if (porphan == nullptr)
         porphan = std::make_shared<COrphan>(&tx);
@@ -138,7 +138,7 @@ void BlockMemoryPoolTransactionCollector::ComputeTransactionPriority (
 }
 
 void BlockMemoryPoolTransactionCollector::AddDependingTransactionsToPriorityQueue (
-    std::map<uint256, std::vector<std::shared_ptr<COrphan>>>& dependentTransactions,
+    DependingTransactionsMap& dependentTransactions,
     const uint256& hash,
     std::vector<TxPriority>& vecPriority,
     TxPriorityCompare& comparer) const
@@ -184,7 +184,7 @@ void BlockMemoryPoolTransactionCollector::AddTransactionToBlock (
 
 std::vector<TxPriority> BlockMemoryPoolTransactionCollector::PrioritizeMempoolTransactions (
     const int& nHeight,
-    std::map<uint256, std::vector<std::shared_ptr<COrphan>>>& dependentTransactions,
+    DependingTransactionsMap& dependentTransactions,
     CCoinsViewCache& view) const
 {
     std::vector<TxPriority> vecPriority;
@@ -272,7 +272,7 @@ std::vector<PrioritizedTransactionData> BlockMemoryPoolTransactionCollector::Pri
     std::vector<TxPriority>& vecPriority,
     const int& nHeight,
     CCoinsViewCache& view,
-    std::map<uint256, std::vector<std::shared_ptr<COrphan>>>& dependentTransactions) const
+    DependingTransactionsMap& dependentTransactions) const
 {
     std::vector<PrioritizedTransactionData> prioritizedTransactions;
 
@@ -350,7 +350,7 @@ void BlockMemoryPoolTransactionCollector::AddTransactionsToBlockIfPossible (
     CCoinsViewCache& view,
     CBlockTemplate& blocktemplate) const
 {
-    std::map<uint256, std::vector<std::shared_ptr<COrphan>>> dependentTransactions;
+    DependingTransactionsMap dependentTransactions;
 
     std::vector<TxPriority> vecPriority =
         PrioritizeMempoolTransactions(nHeight, dependentTransactions, view);

--- a/divi/src/BlockMemoryPoolTransactionCollector.h
+++ b/divi/src/BlockMemoryPoolTransactionCollector.h
@@ -50,6 +50,8 @@ class CChain;
 class BlockMemoryPoolTransactionCollector: public I_BlockTransactionCollector
 {
 private:
+    using DependingTransactionsMap = std::map<uint256, std::vector<std::shared_ptr<COrphan>>>;
+
     CCoinsViewCache* baseCoinsViewCache_;
     const CChain& activeChain_;
     CTxMemPool& mempool_;
@@ -58,13 +60,14 @@ private:
     const unsigned blockMaxSize_;
     const unsigned blockPrioritySize_;
     const unsigned blockMinSize_;
+
 private:
     void UpdateTime(CBlockHeader* block, const CBlockIndex* pindexPrev) const;
     void RecordOrphanTransaction (
         std::shared_ptr<COrphan>& porphan,
         const CTransaction& tx,
         const CTxIn& txin,
-        std::map<uint256, std::vector<std::shared_ptr<COrphan>>>& mapDependers) const;
+        DependingTransactionsMap& mapDependers) const;
 
     void ComputeTransactionPriority (
         double& dPriority,
@@ -74,7 +77,7 @@ private:
         std::vector<TxPriority>& vecPriority,
         const CTransaction* mempoolTx) const;
     void AddDependingTransactionsToPriorityQueue (
-        std::map<uint256, std::vector<std::shared_ptr<COrphan>>>& mapDependers,
+        DependingTransactionsMap& mapDependers,
         const uint256& hash,
         std::vector<TxPriority>& vecPriority,
         TxPriorityCompare& comparer) const;
@@ -93,7 +96,7 @@ private:
 
     std::vector<TxPriority> PrioritizeMempoolTransactions (
         const int& nHeight,
-        std::map<uint256, std::vector<std::shared_ptr<COrphan>>>& mapDependers,
+        DependingTransactionsMap& mapDependers,
         CCoinsViewCache& view) const;
 
     void PrioritizeFeePastPrioritySize (
@@ -107,7 +110,7 @@ private:
         std::vector<TxPriority>& vecPriority,
         const int& nHeight,
         CCoinsViewCache& view,
-        std::map<uint256, std::vector<std::shared_ptr<COrphan>>>& mapDependers) const;
+        DependingTransactionsMap& mapDependers) const;
     void AddTransactionsToBlockIfPossible (
         const int& nHeight,
         CCoinsViewCache& view,

--- a/divi/src/Logging.cpp
+++ b/divi/src/Logging.cpp
@@ -10,6 +10,7 @@
 #include <DataDirectory.h>
 #include <chainparamsbase.h>
 #include <uint256.h>
+#include <serialize.h>
 #include <Settings.h>
 
 bool fDebug = false;
@@ -25,17 +26,6 @@ LOG_FORMAT_WITH_TOSTRING(uint256)
 
 namespace
 {
-template <class T, class TAl>
-inline T* begin_ptr(std::vector<T, TAl>& v)
-{
-    return v.empty() ? NULL : &v[0];
-}
-/** Get begin pointer of vector (const version) */
-template <class T, class TAl>
-inline const T* begin_ptr(const std::vector<T, TAl>& v)
-{
-    return v.empty() ? NULL : &v[0];
-}
 
 FILE* fileout = nullptr;
 

--- a/divi/src/OrphanTransactions.cpp
+++ b/divi/src/OrphanTransactions.cpp
@@ -27,7 +27,7 @@ std::map<uint256, std::set<uint256> > mapOrphanTransactionsByPrev;
 const std::set<uint256>& GetOrphanSpendingTransactionIds(const uint256& txHash)
 {
     static std::set<uint256> emptySet;
-    std::map<uint256, std::set<uint256> >::const_iterator it = mapOrphanTransactionsByPrev.find(txHash);
+    const auto it = mapOrphanTransactionsByPrev.find(txHash);
     if(it == mapOrphanTransactionsByPrev.end()) return emptySet;
 
     return it->second;
@@ -76,7 +76,7 @@ void EraseOrphanTx(uint256 hash)
     if (it == mapOrphanTransactions.end())
         return;
     BOOST_FOREACH (const CTxIn& txin, it->second.tx.vin) {
-        std::map<uint256, std::set<uint256> >::iterator itPrev = mapOrphanTransactionsByPrev.find(txin.prevout.hash);
+        const auto itPrev = mapOrphanTransactionsByPrev.find(txin.prevout.hash);
         if (itPrev == mapOrphanTransactionsByPrev.end())
             continue;
         itPrev->second.erase(hash);

--- a/divi/src/VaultManager.h
+++ b/divi/src/VaultManager.h
@@ -14,7 +14,6 @@ class CTransaction;
 class CBlock;
 class CWalletTx;
 class uint256;
-using TransactionsByHash = std::map<uint256,CWalletTx>;
 
 class I_VaultManagerDatabase;
 class WalletTransactionRecord;

--- a/divi/src/addressindex.h
+++ b/divi/src/addressindex.h
@@ -18,7 +18,7 @@ struct CMempoolAddressDelta
     uint256 prevhash;
     unsigned int prevout;
 
-    CMempoolAddressDelta(int64_t t, CAmount a, uint256 hash, unsigned int out) {
+    CMempoolAddressDelta(int64_t t, CAmount a, const uint256& hash, unsigned int out) {
         time = t;
         amount = a;
         prevhash = hash;
@@ -240,7 +240,7 @@ struct CAddressUnspentKey {
         index = ser_readdata32(s);
     }
 
-    CAddressUnspentKey(unsigned int addressType, uint160 addressHash, uint256 txid, size_t indexValue) {
+    CAddressUnspentKey(unsigned int addressType, uint160 addressHash, const uint256& txid, size_t indexValue) {
         type = addressType;
         hashBytes = addressHash;
         txhash = txid;

--- a/divi/src/coins.cpp
+++ b/divi/src/coins.cpp
@@ -8,6 +8,7 @@
 #include "random.h"
 
 #include <assert.h>
+#include <sstream>
 
 #include "FeeAndPriorityCalculator.h"
 
@@ -137,6 +138,19 @@ bool CCoins::Spend(const int nPos)
 {
     CTxInUndo undo;
     return Spend(nPos, undo);
+}
+
+std::string CCoins::ToString() const
+{
+    std::ostringstream res;
+    res << "CCoins(coinbase=" << fCoinBase << ", coinstake=" << fCoinStake;
+    res << ", height=" << nHeight << ", version=" << nVersion << "):";
+    res << std::endl;
+
+    for (const auto& out : vout)
+      res << "  " << out.ToString() << std::endl;
+
+    return res.str();
 }
 
 

--- a/divi/src/coins.h
+++ b/divi/src/coins.h
@@ -311,12 +311,12 @@ protected:
 
 public:
     CCoinsViewBacked(CCoinsView* viewIn);
-    bool GetCoins(const uint256& txid, CCoins& coins) const;
-    bool HaveCoins(const uint256& txid) const;
-    uint256 GetBestBlock() const;
+    bool GetCoins(const uint256& txid, CCoins& coins) const override;
+    bool HaveCoins(const uint256& txid) const override;
+    uint256 GetBestBlock() const override;
     void SetBackend(CCoinsView& viewIn);
-    bool BatchWrite(CCoinsMap& mapCoins, const uint256& hashBlock);
-    bool GetStats(CCoinsStats& stats) const;
+    bool BatchWrite(CCoinsMap& mapCoins, const uint256& hashBlock) override;
+    bool GetStats(CCoinsStats& stats) const override;
 };
 
 class CCoinsViewCache;
@@ -372,11 +372,11 @@ public:
     ~CCoinsViewCache();
 
     // Standard CCoinsView methods
-    bool GetCoins(const uint256& txid, CCoins& coins) const;
-    bool HaveCoins(const uint256& txid) const;
-    uint256 GetBestBlock() const;
+    bool GetCoins(const uint256& txid, CCoins& coins) const override;
+    bool HaveCoins(const uint256& txid) const override;
+    uint256 GetBestBlock() const override;
     void SetBestBlock(const uint256& hashBlock);
-    bool BatchWrite(CCoinsMap& mapCoins, const uint256& hashBlock);
+    bool BatchWrite(CCoinsMap& mapCoins, const uint256& hashBlock) override;
 
     /**
      * Return a pointer to CCoins in the cache, or NULL if not found. This is

--- a/divi/src/coins.h
+++ b/divi/src/coins.h
@@ -227,6 +227,7 @@ public:
         Cleanup();
     }
 
+    std::string ToString() const;
 
 };
 

--- a/divi/src/divi-tx.cpp
+++ b/divi/src/divi-tx.cpp
@@ -204,8 +204,7 @@ static void MutateTxAddInput(CMutableTransaction& tx, const string& strInput)
         throw runtime_error("invalid TX input vout");
 
     // append to transaction input list
-    CTxIn txin(txid, vout);
-    tx.vin.push_back(txin);
+    tx.vin.emplace_back(COutPoint(txid, vout));
 }
 
 static void MutateTxAddOutAddr(CMutableTransaction& tx, const string& strInput)

--- a/divi/src/init.cpp
+++ b/divi/src/init.cpp
@@ -168,7 +168,7 @@ class CCoinsViewErrorCatcher : public CCoinsViewBacked
 {
 public:
     CCoinsViewErrorCatcher(CCoinsView* view) : CCoinsViewBacked(view) {}
-    bool GetCoins(const uint256& txid, CCoins& coins) const
+    bool GetCoins(const uint256& txid, CCoins& coins) const override
     {
         try {
             return CCoinsViewBacked::GetCoins(txid, coins);

--- a/divi/src/main.cpp
+++ b/divi/src/main.cpp
@@ -709,7 +709,7 @@ bool GetAddressUnspent(bool addresIndexEnabled,
     return true;
 }
 
-bool GetSpentIndex(CSpentIndexKey &key, CSpentIndexValue &value)
+bool GetSpentIndex(const CSpentIndexKey &key, CSpentIndexValue &value)
 {
     if (!fSpentIndex)
         return false;

--- a/divi/src/main.h
+++ b/divi/src/main.h
@@ -184,6 +184,6 @@ bool GetAddressUnspent(bool addresIndexEnabled,
                       int type,
                       std::vector<std::pair<CAddressUnspentKey,
                       CAddressUnspentValue> > &unspentOutputs);
-bool GetSpentIndex(CSpentIndexKey &key, CSpentIndexValue &value);
+bool GetSpentIndex(const CSpentIndexKey &key, CSpentIndexValue &value);
 
 #endif // BITCOIN_MAIN_H

--- a/divi/src/primitives/transaction.cpp
+++ b/divi/src/primitives/transaction.cpp
@@ -18,7 +18,10 @@
 
 
 COutPoint::COutPoint() { SetNull(); }
-COutPoint::COutPoint(uint256 hashIn, uint32_t nIn) { hash = hashIn; n = nIn; }
+COutPoint::COutPoint(const uint256& hashIn, uint32_t nIn)
+  : hash(hashIn), n(nIn)
+{}
+
 void COutPoint::SetNull() { hash.SetNull(); n = (uint32_t) -1; }
 bool COutPoint::IsNull() const { return (hash.IsNull() && n == (uint32_t) -1); }
 bool operator<(const COutPoint& a, const COutPoint& b)
@@ -80,7 +83,7 @@ CTxIn::CTxIn(COutPoint prevoutIn, CScript scriptSigIn, uint32_t nSequenceIn)
     nSequence = nSequenceIn;
 }
 
-CTxIn::CTxIn(uint256 hashPrevTx, uint32_t nOut, CScript scriptSigIn, uint32_t nSequenceIn)
+CTxIn::CTxIn(const uint256& hashPrevTx, uint32_t nOut, CScript scriptSigIn, uint32_t nSequenceIn)
 {
     prevout = COutPoint(hashPrevTx, nOut);
     scriptSig = scriptSigIn;

--- a/divi/src/primitives/transaction.h
+++ b/divi/src/primitives/transaction.h
@@ -22,13 +22,14 @@ public:
     uint32_t n;
 
     COutPoint();
-    COutPoint(uint256 hashIn, uint32_t nIn);
+    COutPoint(const uint256& hashIn, uint32_t nIn);
 
     ADD_SERIALIZE_METHODS;
 
     template <typename Stream, typename Operation>
     inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
-        READWRITE(FLATDATA(*this));
+        READWRITE(hash);
+        READWRITE(n);
     }
 
     void SetNull();
@@ -56,7 +57,7 @@ public:
 
     CTxIn();
     explicit CTxIn(COutPoint prevoutIn, CScript scriptSigIn=CScript(), uint32_t nSequenceIn=std::numeric_limits<uint32_t>::max());
-    CTxIn(uint256 hashPrevTx, uint32_t nOut, CScript scriptSigIn=CScript(), uint32_t nSequenceIn=std::numeric_limits<uint32_t>::max());
+    CTxIn(const uint256& hashPrevTx, uint32_t nOut, CScript scriptSigIn=CScript(), uint32_t nSequenceIn=std::numeric_limits<uint32_t>::max());
 
     ADD_SERIALIZE_METHODS;
 

--- a/divi/src/rpcmisc.cpp
+++ b/divi/src/rpcmisc.cpp
@@ -75,7 +75,7 @@ bool GetAddressIndex(bool addresIndexEnabled,
 
 std::string GetWarnings(std::string strFor);
 
-bool GetSpentIndex(CSpentIndexKey &key, CSpentIndexValue &value);
+bool GetSpentIndex(const CSpentIndexKey &key, CSpentIndexValue &value);
 
 bool GetAddressUnspent(bool addresIndexEnabled,
                       CBlockTreeDB* pblocktree,
@@ -1016,7 +1016,7 @@ Value getspentinfo(const Array& params, bool fHelp)
     uint256 txid = ParseHashV(txidValue, "txid");
     int outputIndex = indexValue.get_int();
 
-    CSpentIndexKey key(txid, outputIndex);
+    const CSpentIndexKey key(txid, outputIndex);
     CSpentIndexValue value;
 
     if (!GetSpentIndex(key, value)) {

--- a/divi/src/rpcrawtransaction.cpp
+++ b/divi/src/rpcrawtransaction.cpp
@@ -481,8 +481,7 @@ Value createrawtransaction(const Array& params, bool fHelp)
         if (nOutput < 0)
             throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid parameter, vout must be positive");
 
-        CTxIn in(COutPoint(txid, nOutput));
-        rawTx.vin.push_back(in);
+        rawTx.vin.emplace_back(COutPoint(txid, nOutput));
     }
 
     set<CBitcoinAddress> setAddress;

--- a/divi/src/rpcrawtransaction.cpp
+++ b/divi/src/rpcrawtransaction.cpp
@@ -93,7 +93,7 @@ void TxToJSONExpanded(const CTransaction& tx, const uint256 hashBlock, Object& e
 
             // Add address and value info if spentindex enabled
             CSpentIndexValue spentInfo;
-            CSpentIndexKey spentKey(txin.prevout.hash, txin.prevout.n);
+            const CSpentIndexKey spentKey(txin.prevout.hash, txin.prevout.n);
             if (GetSpentIndex(spentKey, spentInfo)) {
                 in.push_back(Pair("value", ValueFromAmount(spentInfo.satoshis)));
                 in.push_back(Pair("valueSat", spentInfo.satoshis));

--- a/divi/src/spentindex.h
+++ b/divi/src/spentindex.h
@@ -22,7 +22,7 @@ struct CSpentIndexKey {
         READWRITE(outputIndex);
     }
 
-    CSpentIndexKey(uint256 t, unsigned int i) {
+    CSpentIndexKey(const uint256& t, unsigned int i) {
         txid = t;
         outputIndex = i;
     }

--- a/divi/src/test/BlockSignature_tests.cpp
+++ b/divi/src/test/BlockSignature_tests.cpp
@@ -78,8 +78,8 @@ public:
         CScript outputScript = (isP2SH)? ConvertToP2SH(redeemScript):redeemScript;
         vaultKeyStore.AddCScript(redeemScript);
 
-        coinstake.vin.push_back( CTxIn(uint256S("0x25"),0, createDummyVaultScriptSig(redeemScript)) );
-        coinstake.vout.push_back( CTxOut(0,outputScript) );
+        coinstake.vin.emplace_back(uint256S("0x25"), 0, createDummyVaultScriptSig(redeemScript));
+        coinstake.vout.emplace_back(0, outputScript);
 
         block.vtx.emplace_back();
         block.vtx.push_back(coinstake);

--- a/divi/src/test/coins_tests.cpp
+++ b/divi/src/test/coins_tests.cpp
@@ -24,7 +24,7 @@ class CCoinsViewTest : public CCoinsView
 public:
     bool GetCoins(const uint256& txid, CCoins& coins) const
     {
-        std::map<uint256, CCoins>::const_iterator it = map_.find(txid);
+        auto it = map_.find(txid);
         if (it == map_.end()) {
             return false;
         }
@@ -46,7 +46,7 @@ public:
 
     bool BatchWrite(CCoinsMap& mapCoins, const uint256& hashBlock)
     {
-        for (CCoinsMap::iterator it = mapCoins.begin(); it != mapCoins.end(); ) {
+        for (auto it = mapCoins.begin(); it != mapCoins.end(); ) {
             map_[it->first] = it->second.coins;
             if (it->second.coins.IsPruned() && insecure_rand() % 3 == 0) {
                 // Randomly delete empty entries on write.
@@ -128,7 +128,7 @@ BOOST_AUTO_TEST_CASE(coins_cache_simulation_test)
 
         // Once every 1000 iterations and at the end, verify the full cache.
         if (insecure_rand() % 1000 == 1 || i == NUM_SIMULATION_ITERATIONS - 1) {
-            for (std::map<uint256, CCoins>::iterator it = result.begin(); it != result.end(); it++) {
+            for (auto it = result.begin(); it != result.end(); it++) {
                 const CCoins* coins = stack.back()->AccessCoins(it->first);
                 if (coins) {
                     BOOST_CHECK(*coins == it->second);

--- a/divi/src/test/coins_tests.cpp
+++ b/divi/src/test/coins_tests.cpp
@@ -22,7 +22,7 @@ class CCoinsViewTest : public CCoinsView
     std::map<uint256, CCoins> map_;
 
 public:
-    bool GetCoins(const uint256& txid, CCoins& coins) const
+    bool GetCoins(const uint256& txid, CCoins& coins) const override
     {
         auto it = map_.find(txid);
         if (it == map_.end()) {
@@ -36,15 +36,15 @@ public:
         return true;
     }
 
-    bool HaveCoins(const uint256& txid) const
+    bool HaveCoins(const uint256& txid) const override
     {
         CCoins coins;
         return GetCoins(txid, coins);
     }
 
-    uint256 GetBestBlock() const { return hashBestBlock_; }
+    uint256 GetBestBlock() const override { return hashBestBlock_; }
 
-    bool BatchWrite(CCoinsMap& mapCoins, const uint256& hashBlock)
+    bool BatchWrite(CCoinsMap& mapCoins, const uint256& hashBlock) override
     {
         for (auto it = mapCoins.begin(); it != mapCoins.end(); ) {
             map_[it->first] = it->second.coins;
@@ -59,7 +59,7 @@ public:
         return true;
     }
 
-    bool GetStats(CCoinsStats& stats) const { return false; }
+    bool GetStats(CCoinsStats& stats) const override { return false; }
 };
 }
 

--- a/divi/src/txdb.cpp
+++ b/divi/src/txdb.cpp
@@ -437,7 +437,7 @@ bool CBlockTreeDB::ReadAddressIndex(uint160 addressHash, int type,
     return true;
 }
 
-bool CBlockTreeDB::ReadSpentIndex(CSpentIndexKey &key, CSpentIndexValue &value) {
+bool CBlockTreeDB::ReadSpentIndex(const CSpentIndexKey &key, CSpentIndexValue &value) {
     return Read(make_pair(DB_SPENTINDEX, key), value);
 }
 

--- a/divi/src/txdb.cpp
+++ b/divi/src/txdb.cpp
@@ -84,7 +84,7 @@ bool CCoinsViewDB::BatchWrite(CCoinsMap& mapCoins, const uint256& hashBlock)
     CLevelDBBatch batch;
     size_t count = 0;
     size_t changed = 0;
-    for (CCoinsMap::iterator it = mapCoins.begin(); it != mapCoins.end();) {
+    for (auto it = mapCoins.begin(); it != mapCoins.end();) {
         if (it->second.flags & CCoinsCacheEntry::DIRTY) {
             BatchWriteCoins(batch, it->first, it->second.coins);
             changed++;

--- a/divi/src/txdb.h
+++ b/divi/src/txdb.h
@@ -39,11 +39,11 @@ protected:
 public:
     CCoinsViewDB(size_t nCacheSize, bool fMemory = false, bool fWipe = false);
 
-    bool GetCoins(const uint256& txid, CCoins& coins) const;
-    bool HaveCoins(const uint256& txid) const;
-    uint256 GetBestBlock() const;
-    bool BatchWrite(CCoinsMap& mapCoins, const uint256& hashBlock);
-    bool GetStats(CCoinsStats& stats) const;
+    bool GetCoins(const uint256& txid, CCoins& coins) const override;
+    bool HaveCoins(const uint256& txid) const override;
+    uint256 GetBestBlock() const override;
+    bool BatchWrite(CCoinsMap& mapCoins, const uint256& hashBlock) override;
+    bool GetStats(CCoinsStats& stats) const override;
 };
 
 /** Access to the block database (blocks/index/) */

--- a/divi/src/txdb.h
+++ b/divi/src/txdb.h
@@ -71,7 +71,7 @@ public:
     bool ReadAddressIndex(uint160 addressHash, int type,
                           std::vector<std::pair<CAddressIndexKey, CAmount> > &addressIndex,
                           int start = 0, int end = 0);
-    bool ReadSpentIndex(CSpentIndexKey &key, CSpentIndexValue &value);
+    bool ReadSpentIndex(const CSpentIndexKey &key, CSpentIndexValue &value);
     bool UpdateSpentIndex(const std::vector<std::pair<CSpentIndexKey, CSpentIndexValue> >&vect);
     bool UpdateAddressUnspentIndex(const std::vector<std::pair<CAddressUnspentKey, CAddressUnspentValue > >&vect);
     bool ReadAddressUnspentIndex(uint160 addressHash, int type,

--- a/divi/src/txmempool.cpp
+++ b/divi/src/txmempool.cpp
@@ -389,7 +389,7 @@ void CTxMemPool::pruneSpent(const uint256& hashTx, CCoins& coins)
 {
     LOCK(cs);
 
-    std::map<COutPoint, CInPoint>::iterator it = mapNextTx.lower_bound(COutPoint(hashTx, 0));
+    auto it = mapNextTx.lower_bound(COutPoint(hashTx, 0));
 
     // iterate over all COutPoints in mapNextTx whose hash equals the provided hashTx
     while (it != mapNextTx.end() && it->first.hash == hashTx) {

--- a/divi/src/txmempool.h
+++ b/divi/src/txmempool.h
@@ -222,8 +222,8 @@ protected:
 
 public:
     CCoinsViewMemPool(CCoinsView* baseIn, CTxMemPool& mempoolIn);
-    bool GetCoins(const uint256& txid, CCoins& coins) const;
-    bool HaveCoins(const uint256& txid) const;
+    bool GetCoins(const uint256& txid, CCoins& coins) const override;
+    bool HaveCoins(const uint256& txid) const override;
 };
 
 #endif // BITCOIN_TXMEMPOOL_H

--- a/divi/src/wallet.cpp
+++ b/divi/src/wallet.cpp
@@ -2263,10 +2263,10 @@ bool CWallet::CommitTransaction(CWalletTx& wtxNew, CReserveKey& reservekey)
 
             // Notify that old coins are spent
             {
-                set<uint256> updated_hahes;
+                std::set<uint256> updated_hashes;
                 BOOST_FOREACH (const CTxIn& txin, wtxNew.vin) {
                     // notify only once
-                    if (updated_hahes.find(txin.prevout.hash) != updated_hahes.end()) continue;
+                    if (updated_hashes.find(txin.prevout.hash) != updated_hashes.end()) continue;
 
                     CWalletTx* coinPtr = const_cast<CWalletTx*>(GetWalletTx(txin.prevout.hash));
                     if(!coinPtr)
@@ -2275,8 +2275,8 @@ bool CWallet::CommitTransaction(CWalletTx& wtxNew, CReserveKey& reservekey)
                         assert(coinPtr);
                     }
                     coinPtr->RecomputeCachedQuantities();
-                    NotifyTransactionChanged(this, txin.prevout.hash, CT_UPDATED);
-                    updated_hahes.insert(txin.prevout.hash);
+                    NotifyTransactionChanged(this, coinPtr->GetHash(), CT_UPDATED);
+                    updated_hashes.insert(txin.prevout.hash);
                 }
             }
 

--- a/divi/src/wallet.cpp
+++ b/divi/src/wallet.cpp
@@ -2831,7 +2831,7 @@ void CWallet::UnlockAllCoins()
     setLockedCoins.clear();
 }
 
-bool CWallet::IsLockedCoin(uint256 hash, unsigned int n) const
+bool CWallet::IsLockedCoin(const uint256& hash, unsigned int n) const
 {
     AssertLockHeld(cs_wallet); // setLockedCoins
     COutPoint outpt(hash, n);

--- a/divi/src/wallet.h
+++ b/divi/src/wallet.h
@@ -214,7 +214,7 @@ public:
         CAmount& nValueRet);
 
     bool IsTrusted(const CWalletTx& walletTransaction) const;
-    bool IsLockedCoin(uint256 hash, unsigned int n) const;
+    bool IsLockedCoin(const uint256& hash, unsigned int n) const;
     void LockCoin(const COutPoint& output);
     void UnlockCoin(const COutPoint& output);
     void UnlockAllCoins();


### PR DESCRIPTION
This is a collection of straight-forward cleanups and refactorings, which have been split out of #80 but are independent of the UTXO hasher or segwit light.