### PR TITLE
Fix out-of-bounds access in std::vector

### DIFF
--- a/divi/src/ActiveChainManager.cpp
+++ b/divi/src/ActiveChainManager.cpp
@@ -92,7 +92,8 @@ bool ActiveChainManager::DisconnectBlock(
     // undo transactions in reverse order
     for (int transactionIndex = block.vtx.size() - 1; transactionIndex >= 0; transactionIndex--) {
         const CTransaction& tx = block.vtx[transactionIndex];
-        const TxReversalStatus status = UpdateCoinsReversingTransaction(tx,view,blockUndo.vtxundo[transactionIndex-1],pindex->nHeight);
+        const auto* undo = (transactionIndex > 0 ? &blockUndo.vtxundo[transactionIndex - 1] : nullptr);
+        const TxReversalStatus status = UpdateCoinsReversingTransaction(tx, view, undo, pindex->nHeight);
         if(!CheckTxReversalStatus(status,fClean))
         {
             return false;

--- a/divi/src/UtxoCheckingAndUpdating.h
+++ b/divi/src/UtxoCheckingAndUpdating.h
@@ -16,7 +16,7 @@ enum class TxReversalStatus
     OK,
 };
 void UpdateCoinsWithTransaction(const CTransaction& tx, CCoinsViewCache& inputs, CTxUndo& txundo, int nHeight);
-TxReversalStatus UpdateCoinsReversingTransaction(const CTransaction& tx, CCoinsViewCache& inputs, const CTxUndo& txundo, int nHeight);
+TxReversalStatus UpdateCoinsReversingTransaction(const CTransaction& tx, CCoinsViewCache& inputs, const CTxUndo* txundo, int nHeight);
 bool CheckInputs(
     const CTransaction& tx,
     CValidationState& state,


### PR DESCRIPTION
The code changed here did access `blockUndo.vtxundo` out of bounds (at index -1) for the coinbase transaction of a block (`transactionIndex == 0`).  This had no practical implication as the reference passed into `UpdateCoinsReversingTransaction` was not used in that situation, but it is still undefined behaviour, and the fix is easy.

The change also makes it more explicit that txundo could be "invalid" in `UpdateCoinsReversingTransaction`, and in which situation it should be accessed.