### PR TITLE
Set -nolistenonion in all regtests

### DIFF
--- a/divi/qa/rpc-tests/MnAreSafeToRestart.py
+++ b/divi/qa/rpc-tests/MnAreSafeToRestart.py
@@ -28,7 +28,7 @@ class MnAreSafeToRestart (BitcoinTestFramework):
 
   def __init__ (self):
     super ().__init__ ()
-    self.base_args = ["-debug=masternode", "-debug=mocktime", "-nolistenonion"]
+    self.base_args = ["-debug=masternode", "-debug=mocktime"]
 
   def setup_chain (self):
     for i in range (7):

--- a/divi/qa/rpc-tests/NoBlocksForLongTime.py
+++ b/divi/qa/rpc-tests/NoBlocksForLongTime.py
@@ -34,7 +34,7 @@ class NoBlocksForLongTimeTest (BitcoinTestFramework):
 
   def __init__ (self):
     super ().__init__ ()
-    self.base_args = ["-debug=masternode", "-debug=mocktime", "-nolistenonion"]
+    self.base_args = ["-debug=masternode", "-debug=mocktime"]
 
   def setup_chain (self):
     print ("Initializing test directory " + self.options.tmpdir)

--- a/divi/qa/rpc-tests/mnoperation.py
+++ b/divi/qa/rpc-tests/mnoperation.py
@@ -27,7 +27,7 @@ class MnStatusTest (BitcoinTestFramework):
 
   def __init__ (self):
     super ().__init__ ()
-    self.base_args = ["-debug=masternode", "-debug=mocktime", "-nolistenonion"]
+    self.base_args = ["-debug=masternode", "-debug=mocktime"]
 
   def setup_chain (self):
     for i in range (7):

--- a/divi/qa/rpc-tests/mnvaults.py
+++ b/divi/qa/rpc-tests/mnvaults.py
@@ -27,7 +27,7 @@ class MnVaultsTest (BitcoinTestFramework):
 
   def __init__ (self):
     super (MnVaultsTest, self).__init__ ()
-    self.base_args = ["-debug=masternode", "-debug=mocktime", "-nolistenonion"]
+    self.base_args = ["-debug=masternode", "-debug=mocktime"]
     self.cfg = None
 
   def setup_chain (self):

--- a/divi/qa/rpc-tests/proxy_test.py
+++ b/divi/qa/rpc-tests/proxy_test.py
@@ -62,12 +62,7 @@ class ProxyTest(BitcoinTestFramework):
         self.serv3.start()
 
     def setup_nodes(self):
-        # By default, Divi checks if Tor is running on the system and if it is,
-        # then the real Tor instance will be used as proxy for .onion
-        # connections even if -proxy is set otherwise.  To avoid this behaviour
-        # (which we don't want here in the test), we turn off Tor control
-        # with -nolistenonion.
-        base_args = ['-listen', '-nolistenonion', '-debug']
+        base_args = ['-listen', '-debug']
 
         # Note: proxies are not used to connect to local nodes
         # this is because the proxy to use is based on CService.GetNetwork(), which return NET_UNROUTABLE for localhost

--- a/divi/qa/rpc-tests/smartfees.py
+++ b/divi/qa/rpc-tests/smartfees.py
@@ -78,7 +78,7 @@ class EstimateFeeTest(BitcoinTestFramework):
 
     def setup_network(self):
         self.nodes = []
-        base = ["-debug=mempool", "-debug=estimatefee", "-relaypriority=0", "-spendzeroconfchange", "-nolistenonion"]
+        base = ["-debug=mempool", "-debug=estimatefee", "-relaypriority=0", "-spendzeroconfchange"]
         self.nodes.append(start_node(0, self.options.tmpdir, base))
         # Node1 mines small-but-not-tiny blocks, and allows free transactions.
         # NOTE: the CreateNewBlock code starts counting block size at 1,000 bytes,

--- a/divi/qa/rpc-tests/util.py
+++ b/divi/qa/rpc-tests/util.py
@@ -128,7 +128,12 @@ def start_node(i, dirname, extra_args=None, mn_config_lines=[], rpchost=None):
     if os.getenv("RUNNER") is not None:
       binary.append(os.getenv("RUNNER"))
     binary.append(os.getenv("BITCOIND", "divid"))
-    args = binary + ["-datadir="+datadir, "-keypool=1", "-discover=0", "-rest"]
+    # By default, Divi checks if Tor is running on the system and if it is,
+    # then the real Tor instance will be used as proxy for .onion
+    # connections even if -proxy is set otherwise, and it will try to set up
+    # a hidden service listening.  To avoid this behaviour (which we don't want
+    # in tests), we turn off Tor control with -nolistenonion.
+    args = binary + ["-datadir="+datadir, "-keypool=1", "-discover=0", "-rest", "-nolistenonion"]
     if extra_args is not None: args.extend(extra_args)
     bitcoind_processes[i] = subprocess.Popen(args)
     devnull = open("/dev/null", "w+")


### PR DESCRIPTION
Previously, we set `-nolistenonion` selectively in some of the regtests.  Without this flag, `divid` tries to connect to a locally-running Tor instance and listen with a hidden service on mainnet, which we do not want in tests and which causes them to use far more CPU and time than without.

In this change, we simply set the flag explicitly in the test framework for *all* regtests (which is really what we want) instead of setting it individually in some of them.