### PR TITLE
Some test refactorings

### DIFF
--- a/divi/src/Makefile.test.include
+++ b/divi/src/Makefile.test.include
@@ -100,6 +100,7 @@ BITCOIN_TESTS =\
   test/ProofOfStake_tests.cpp \
   test/IsMine_tests.cpp \
   test/PoSStakeModifierService_tests.cpp \
+  test/PoSTransactionCreator_tests.cpp \
   test/LegacyPoSStakeModifierService_tests.cpp \
   test/LotteryWinnersCalculatorTests.cpp \
   test/VaultManager_tests.cpp \

--- a/divi/src/test/FakeWallet.cpp
+++ b/divi/src/test/FakeWallet.cpp
@@ -115,6 +115,11 @@ void FakeWallet::AddBlock()
   fakeChain.addBlocks(1, version);
 }
 
+void FakeWallet::AddConfirmations(const unsigned numConf, const int64_t minAge)
+{
+  fakeChain.addBlocks(numConf, version, fakeChain.activeChain->Tip()->nTime + minAge);
+}
+
 const CWalletTx& FakeWallet::AddDefaultTx(const CScript& scriptToPayTo, unsigned& outputIndex,
                                           const CAmount amount)
 {

--- a/divi/src/test/FakeWallet.h
+++ b/divi/src/test/FakeWallet.h
@@ -39,6 +39,12 @@ public:
   /** Adds a new block to our fake chain.  */
   void AddBlock();
 
+  /** Adds a couple of new blocks and bumps the time at least
+   *  the given amount.  This can be used to make sure some
+   *  coins fake added to the chain have at least a given age
+   *  and number of confirmations.  */
+  void AddConfirmations(unsigned numConf, int64_t minAge = 0);
+
   /** Adds a new ordinary transaction to the wallet, paying a given amount
    *  to a given script.  The transaction is returned, and the output index
    *  with the output to the requested script is set.  */

--- a/divi/src/test/PoSTransactionCreator_tests.cpp
+++ b/divi/src/test/PoSTransactionCreator_tests.cpp
@@ -1,0 +1,125 @@
+// Copyright (c) 2021 The Divi developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "PoSTransactionCreator.h"
+
+#include "chain.h"
+#include "chainparams.h"
+#include "ProofOfStakeModule.h"
+#include "script/standard.h"
+#include "Settings.h"
+#include "WalletTx.h"
+
+#include "test/FakeBlockIndexChain.h"
+#include "test/FakeWallet.h"
+#include "test/MockBlockIncentivesPopulator.h"
+#include "test/MockBlockSubsidyProvider.h"
+
+#include <boost/test/unit_test.hpp>
+#include "test/test_only.h"
+
+#include <gmock/gmock.h>
+
+#include <map>
+
+extern Settings& settings;
+
+namespace
+{
+
+using testing::_;
+using testing::AtLeast;
+using testing::Return;
+
+class PoSTransactionCreatorTestFixture
+{
+
+protected:
+
+  FakeBlockIndexWithHashes fakeChain;
+  FakeWallet wallet;
+
+private:
+
+  const CChainParams& chainParams;
+
+  MockBlockIncentivesPopulator blockIncentivesPopulator;
+  MockBlockSubsidyProvider blockSubsidyProvider;
+  ProofOfStakeModule posModule;
+
+  std::map<unsigned, unsigned> hashedBlockTimestamps;
+
+  PoSTransactionCreator txCreator;
+
+protected:
+
+  /** A script from the wallet for convenience.  */
+  const CScript walletScript;
+
+  /* Convenience variables for tests to use in calls to CreatePoS.  */
+  CMutableTransaction mtx;
+  unsigned txTime;
+
+  /* Convenience variable for the wallet's AddDefaultTx.  */
+  unsigned outputIndex;
+
+  PoSTransactionCreatorTestFixture()
+    : fakeChain(1, 1600000000, 1),
+      wallet(fakeChain),
+      chainParams(Params(CBaseChainParams::REGTEST)),
+      posModule(chainParams, *fakeChain.activeChain, *fakeChain.blockIndexByHash),
+      txCreator(settings, chainParams, *fakeChain.activeChain, *fakeChain.blockIndexByHash,
+                blockSubsidyProvider, blockIncentivesPopulator,
+                posModule.proofOfStakeGenerator(), wallet, hashedBlockTimestamps),
+      walletScript(GetScriptForDestination(wallet.getNewKey().GetID()))
+  {
+    /* Set up a default block reward if we don't need anything else.  */
+    EXPECT_CALL(blockSubsidyProvider, GetFullBlockValue(_))
+        .WillRepeatedly(Return(11 * COIN));
+    EXPECT_CALL(blockSubsidyProvider, GetBlockSubsidity(_))
+        .WillRepeatedly(Return(CBlockRewards(10 * COIN, COIN, 0, 0, 0, 0)));
+
+    /* We don't care about the block payments.  */
+    EXPECT_CALL(blockIncentivesPopulator, FillBlockPayee(_, _, _, _)).Times(AtLeast(0));
+    EXPECT_CALL(blockIncentivesPopulator, IsBlockValueValid(_, _, _))
+        .WillRepeatedly(Return(true));
+    EXPECT_CALL(blockIncentivesPopulator, HasValidPayees(_, _))
+        .WillRepeatedly(Return(true));
+  }
+
+  /** Calls CreateProofOfStake on our PoSTransactionCreator with the
+   *  fake wallet's chain tip and regtest difficulty.  */
+  bool CreatePoS(CMutableTransaction& txCoinStake, unsigned& nTxNewTime)
+  {
+    return txCreator.CreateProofOfStake(fakeChain.activeChain->Tip(), 0x207fffff, txCoinStake, nTxNewTime);
+  }
+
+  bool CreatePoS()
+  {
+    return CreatePoS(mtx, txTime);
+  }
+
+};
+
+BOOST_FIXTURE_TEST_SUITE(PoSTransactionCreator_tests, PoSTransactionCreatorTestFixture)
+
+BOOST_AUTO_TEST_CASE(failsWithoutCoinsInWallet)
+{
+  BOOST_CHECK(!CreatePoS());
+}
+
+BOOST_AUTO_TEST_CASE(checksForConfirmationsAndAge)
+{
+  const auto& tx = wallet.AddDefaultTx(walletScript, outputIndex, 1000 * COIN);
+  wallet.FakeAddToChain(tx);
+
+  BOOST_CHECK(!CreatePoS());
+
+  wallet.AddConfirmations(20, 1000);
+  BOOST_CHECK(CreatePoS());
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+} // anonymous namespace

--- a/divi/src/test/mempool_tests.cpp
+++ b/divi/src/test/mempool_tests.cpp
@@ -2,8 +2,9 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include "main.h"
 #include "txmempool.h"
+
+#include "FakeBlockIndexChain.h"
 
 #include <boost/test/unit_test.hpp>
 #include <list>
@@ -30,6 +31,9 @@ protected:
   /** Three grand children.  */
   CMutableTransaction txGrandChild[3];
 
+  /** Our fake blockchain.  */
+  FakeBlockIndexWithHashes fakeChain;
+
   /** The test mempool instance.  */
   CTxMemPool testPool;
 
@@ -42,13 +46,16 @@ protected:
 public:
 
   MempoolTestFixture()
-    : testPool(CFeeRate(0), addressIndex, spentIndex),
+    : fakeChain(1, 1500000000, 1),
+      testPool(CFeeRate(0), addressIndex, spentIndex),
       coinsMemPool(&coinsDummy, testPool), coins(&coinsMemPool)
   {
     CMutableTransaction mtx;
-    mtx.vout.emplace_back(COIN, CScript () << OP_TRUE);
+    mtx.vout.emplace_back(2 * COIN, CScript () << OP_TRUE);
     mtx.vout.emplace_back(COIN, CScript () << OP_TRUE);
     coins.ModifyCoins(mtx.GetHash())->FromTx(mtx, 0);
+
+    coins.SetBestBlock(fakeChain.activeChain->Tip()->GetBlockHash());
 
     txParent.vin.resize(2);
     txParent.vin[0].prevout = COutPoint(mtx.GetHash(), 0);
@@ -61,7 +68,7 @@ public:
     for (int i = 0; i < 3; i++)
     {
         txParent.vout[i].scriptPubKey = CScript() << OP_11 << OP_EQUAL;
-        txParent.vout[i].nValue = 33000LL;
+        txParent.vout[i].nValue = COIN;
     }
     assert(txParent.GetHash() != txParent.GetBareTxid());
 
@@ -73,7 +80,7 @@ public:
         txChild[i].vin[0].prevout.n = i;
         txChild[i].vout.resize(1);
         txChild[i].vout[0].scriptPubKey = CScript() << OP_11 << OP_EQUAL;
-        txChild[i].vout[0].nValue = 11000LL;
+        txChild[i].vout[0].nValue = COIN;
     }
 
     for (int i = 0; i < 3; i++)
@@ -84,8 +91,22 @@ public:
         txGrandChild[i].vin[0].prevout.n = 0;
         txGrandChild[i].vout.resize(1);
         txGrandChild[i].vout[0].scriptPubKey = CScript() << OP_11 << OP_EQUAL;
-        txGrandChild[i].vout[0].nValue = 11000LL;
+        txGrandChild[i].vout[0].nValue = COIN;
     }
+
+    testPool.setSanityCheck(true);
+    testPool.clear();
+  }
+
+  /** Adds the parent, childs and grandchilds to the mempool.  */
+  void AddAll()
+  {
+      testPool.addUnchecked(txParent.GetHash(), CTxMemPoolEntry(txParent, 0, 0, 0.0, 1), coins);
+      for (int i = 0; i < 3; i++)
+      {
+          testPool.addUnchecked(txChild[i].GetHash(), CTxMemPoolEntry(txChild[i], 0, 0, 0.0, 1), coins);
+          testPool.addUnchecked(txGrandChild[i].GetHash(), CTxMemPoolEntry(txGrandChild[i], 0, 0, 0.0, 1), coins);
+      }
   }
 
 };
@@ -109,12 +130,10 @@ BOOST_AUTO_TEST_CASE(MempoolRemoveTest)
     removed.clear();
     
     // Parent, children, grandchildren:
-    testPool.addUnchecked(txParent.GetHash(), CTxMemPoolEntry(txParent, 0, 0, 0.0, 1), coins);
-    for (int i = 0; i < 3; i++)
-    {
-        testPool.addUnchecked(txChild[i].GetHash(), CTxMemPoolEntry(txChild[i], 0, 0, 0.0, 1), coins);
-        testPool.addUnchecked(txGrandChild[i].GetHash(), CTxMemPoolEntry(txGrandChild[i], 0, 0, 0.0, 1), coins);
-    }
+    AddAll();
+
+    testPool.check(&coins, *fakeChain.blockIndexByHash);
+
     // Remove Child[0], GrandChild[0] should be removed:
     testPool.remove(txChild[0], removed, true);
     BOOST_CHECK_EQUAL(removed.size(), 2);
@@ -149,12 +168,7 @@ BOOST_AUTO_TEST_CASE(MempoolIndexByBareTxid)
     CTransaction tx;
     std::list<CTransaction> removed;
 
-    testPool.addUnchecked(txParent.GetHash(), CTxMemPoolEntry(txParent, 0, 0, 0.0, 1), coins);
-    for (int i = 0; i < 3; ++i)
-    {
-        testPool.addUnchecked(txChild[i].GetHash(), CTxMemPoolEntry(txChild[i], 0, 0, 0.0, 1), coins);
-        testPool.addUnchecked(txGrandChild[i].GetHash(), CTxMemPoolEntry(txGrandChild[i], 0, 0, 0.0, 1), coins);
-    }
+    AddAll();
 
     BOOST_CHECK(testPool.lookupBareTxid(txParent.GetBareTxid(), tx));
     BOOST_CHECK(tx.GetHash() == txParent.GetHash());


### PR DESCRIPTION
This is a collection of two simple unit-test changes, which have been split out of #80 (but are as they stand independent of the UTXO hasher changes):
- Basic refactoring, simplification and extension of the mempool tests
- New (very basic) tests for `PoSTransactionCreator`, including the necessary framework to make a real `PoSTransactionCreator` instance work in a unit test