### PR TITLE
More split-outs from UTXO hasher

### DIFF
--- a/divi/src/ActiveChainManager.cpp
+++ b/divi/src/ActiveChainManager.cpp
@@ -92,15 +92,15 @@ bool ActiveChainManager::DisconnectBlock(
     // undo transactions in reverse order
     for (int transactionIndex = block.vtx.size() - 1; transactionIndex >= 0; transactionIndex--) {
         const CTransaction& tx = block.vtx[transactionIndex];
+        const TransactionLocationReference txLocationReference(tx, pindex->nHeight, transactionIndex);
         const auto* undo = (transactionIndex > 0 ? &blockUndo.vtxundo[transactionIndex - 1] : nullptr);
-        const TxReversalStatus status = UpdateCoinsReversingTransaction(tx, view, undo, pindex->nHeight);
+        const TxReversalStatus status = UpdateCoinsReversingTransaction(tx, txLocationReference, view, undo);
         if(!CheckTxReversalStatus(status,fClean))
         {
             return false;
         }
         if(!pfClean)
         {
-            TransactionLocationReference txLocationReference(tx.GetHash(),pindex->nHeight,transactionIndex);
             IndexDatabaseUpdateCollector::ReverseTransaction(tx,txLocationReference,view,indexDBUpdates);
         }
     }

--- a/divi/src/BlockMemoryPoolTransactionCollector.cpp
+++ b/divi/src/BlockMemoryPoolTransactionCollector.cpp
@@ -206,7 +206,7 @@ std::vector<TxPriority> BlockMemoryPoolTransactionCollector::PrioritizeMempoolTr
             // Read prev transaction
             if (!view.HaveCoins(txin.prevout.hash)) {
                 CTransaction prevTx;
-                if(!mempool_.lookup(txin.prevout.hash, prevTx)) {
+                if(!mempool_.lookupOutpoint(txin.prevout.hash, prevTx)) {
                     // This should never happen; all transactions in the memory
                     // pool should connect to either transactions in the chain
                     // or other transactions in the memory pool.

--- a/divi/src/BlockTransactionChecker.cpp
+++ b/divi/src/BlockTransactionChecker.cpp
@@ -60,7 +60,7 @@ bool BlockTransactionChecker::Check(const CBlockRewards& nExpectedMint,bool fJus
     pindex_->nMint = 0;
     for (unsigned int i = 0; i < block_.vtx.size(); i++) {
         const CTransaction& tx = block_.vtx[i];
-        const TransactionLocationReference txLocationRef(tx.GetHash(),pindex_->nHeight,i);
+        const TransactionLocationReference txLocationRef(tx, pindex_->nHeight, i);
 
         if(!txInputChecker_.TotalSigOpsAreBelowMaximum(tx))
         {

--- a/divi/src/IndexDatabaseUpdates.cpp
+++ b/divi/src/IndexDatabaseUpdates.cpp
@@ -1,5 +1,7 @@
 #include <IndexDatabaseUpdates.h>
 
+#include <primitives/transaction.h>
+
 IndexDatabaseUpdates::IndexDatabaseUpdates(
     ): addressIndex()
     , addressUnspentIndex()
@@ -9,10 +11,10 @@ IndexDatabaseUpdates::IndexDatabaseUpdates(
 }
 
 TransactionLocationReference::TransactionLocationReference(
-    uint256 hashValue,
+    const CTransaction& tx,
     unsigned blockheightValue,
     int transactionIndexValue
-    ): hash(hashValue)
+    ): hash(tx.GetHash())
     , blockHeight(blockheightValue)
     , transactionIndex(transactionIndexValue)
 {

--- a/divi/src/IndexDatabaseUpdates.h
+++ b/divi/src/IndexDatabaseUpdates.h
@@ -6,6 +6,8 @@
 #include <spentindex.h>
 #include <uint256.h>
 
+class CTransaction;
+
 /** One entry in the tx index, which locates transactions on disk by their txid
  *  or bare txid (both keys are possible).  */
 struct TxIndexEntry
@@ -36,7 +38,7 @@ struct TransactionLocationReference
     int transactionIndex;
 
     TransactionLocationReference(
-        uint256 hashValue,
+        const CTransaction& tx,
         unsigned blockheightValue,
         int transactionIndexValue);
 };

--- a/divi/src/UtxoCheckingAndUpdating.h
+++ b/divi/src/UtxoCheckingAndUpdating.h
@@ -9,6 +9,8 @@ class CTransaction;
 class CValidationState;
 class CCoinsViewCache;
 class CTxUndo;
+class TransactionLocationReference;
+
 enum class TxReversalStatus
 {
     ABORT_NO_OTHER_ERRORS,
@@ -17,7 +19,7 @@ enum class TxReversalStatus
     OK,
 };
 void UpdateCoinsWithTransaction(const CTransaction& tx, CCoinsViewCache& inputs, CTxUndo& txundo, int nHeight);
-TxReversalStatus UpdateCoinsReversingTransaction(const CTransaction& tx, CCoinsViewCache& inputs, const CTxUndo* txundo, int nHeight);
+TxReversalStatus UpdateCoinsReversingTransaction(const CTransaction& tx, const TransactionLocationReference& txLocationReference, CCoinsViewCache& inputs, const CTxUndo* txundo);
 bool CheckInputs(
     const CTransaction& tx,
     CValidationState& state,

--- a/divi/src/rpcblockchain.cpp
+++ b/divi/src/rpcblockchain.cpp
@@ -218,8 +218,9 @@ Value getrawmempool(const Array& params, bool fHelp)
             info.push_back(Pair("currentpriority", e.GetPriority(chainActive.Height())));
             const CTransaction& tx = e.GetTx();
             set<string> setDepends;
-            BOOST_FOREACH (const CTxIn& txin, tx.vin) {
-                if (mempool.exists(txin.prevout.hash))
+            for (const CTxIn& txin : tx.vin) {
+                CTransaction dummyResult;
+                if (mempool.lookupOutpoint(txin.prevout.hash, dummyResult))
                     setDepends.insert(txin.prevout.hash.ToString());
             }
             Array depends(setDepends.begin(), setDepends.end());

--- a/divi/src/txmempool.h
+++ b/divi/src/txmempool.h
@@ -201,6 +201,10 @@ public:
     bool lookup(const uint256& hash, CTransaction& result) const;
     bool lookupBareTxid(const uint256& btxid, CTransaction& result) const;
 
+    /** Looks up a transaction by its outpoint for spending, taking potential changes
+     *  from the raw txid (e.g. segwit light) into account.  */
+    bool lookupOutpoint(const uint256& hash, CTransaction& result) const;
+
     /** Estimate fee rate needed to get into the next nBlocks */
     CFeeRate estimateFee(int nBlocks) const;
 


### PR DESCRIPTION
This is a set of two more independent changes split out from #80:
- Use `TransactionLocationReference` more consistently in the code; instead of passing around raw transaction heights in some places, pass in the `TransactionLocationReference`
- Define a new `CTxMemPool::lookupOutpoint` method, which looks up a mempool transaction by the outpoint for spending (what will be the UTXO hash in the future)
- Some more unit tests for the mempool