### PR TITLE
Stored masternode broadcasts

### DIFF
--- a/divi/qa/rpc-tests/mnstoredbroadcast.py
+++ b/divi/qa/rpc-tests/mnstoredbroadcast.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+# Copyright (c) 2021 The DIVI developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+# Tests handling of pre-signed, stored masternode broadcasts.
+#
+# This test uses two nodes:  Node 0 is used for mining and funding
+# the masternode (as the cold node) and node 1 is the actual masternode
+# with empty wallet and imported broadcast (the hot node).
+
+from test_framework import BitcoinTestFramework
+from util import *
+from masternode import *
+
+import codecs
+import time
+
+
+def modifyHexByte (hexStr, n):
+  """Takes a hex string and modifies the n-th byte in it."""
+
+  arr = bytearray (codecs.decode (hexStr, "hex"))
+  arr[n] = (arr[n] + 1) % 256
+
+  return arr.hex ()
+
+def txidFromBroadcast (hexStr):
+  """Extracts the hex txid from a broadcast in hex."""
+
+  # The prevout txid is the first part of the broadcast data
+  # in serialised form.  But we need to reverse the bytes.
+
+  hexRev = hexStr[:64]
+  bytesRev = codecs.decode (hexRev, "hex")
+
+  return bytesRev[::-1].hex ()
+
+
+class MnStoredBroadcastTest (BitcoinTestFramework):
+
+  def setup_network (self, config_line=None):
+    args = [["-spendzeroconfchange"]] * 2
+    config_lines = [[]] * 2
+
+    if config_line:
+      config_lines = [[config_line.line]] * 2
+      args[1].append ("-masternode")
+      args[1].append ("-masternodeprivkey=%s" % config_line.privkey)
+
+    self.nodes = start_nodes(2, self.options.tmpdir, extra_args=args, mn_config_lines=config_lines)
+    connect_nodes_bi (self.nodes, 0, 1)
+    self.is_network_split = False
+    self.sync_all ()
+
+  def run_test (self):
+    print ("Funding masternode...")
+    self.nodes[0].setgenerate (True, 30)
+    txid = self.nodes[0].allocatefunds ("masternode", "mn", "copper")["txhash"]
+    self.nodes[0].setgenerate (True, 1)
+    cfg = fund_masternode (self.nodes[0], "mn", "copper", txid, "1.2.3.4")
+
+    print ("Updating masternode.conf...")
+    stop_nodes (self.nodes)
+    wait_bitcoinds ()
+    self.setup_network (config_line=cfg)
+
+    print ("Preparing the masternode broadcast...")
+    mnb = self.nodes[0].startmasternode ("mn", True)
+    assert_equal (mnb["status"], "success")
+    mnb = mnb["broadcastData"]
+
+    # We construct two modified broadcasts:  One for the same prevout with just
+    # some of the other data modified, and one for a different prevout.
+    # The prevout is the first part in the broadcast data.
+    #
+    # When we later import all three, the one for the other prevout will stay
+    # and the later one for the same prevout (the correct) will replace the
+    # modified one.
+    mnbOtherPrevout = modifyHexByte (mnb, 3)
+    mnbSamePrevout = modifyHexByte (mnb, 100)
+
+    print ("Importing broadcast data...")
+    assert_raises (JSONRPCException,
+                   self.nodes[1].importmnbroadcast, "invalid")
+    assert_equal (self.nodes[1].importmnbroadcast (mnbOtherPrevout), True)
+    assert_equal (self.nodes[1].importmnbroadcast (mnb), True)
+    assert_equal (self.nodes[1].importmnbroadcast (mnbSamePrevout), True)
+    assert_equal (self.nodes[1].importmnbroadcast (mnb), True)
+    assert_equal (self.nodes[0].listmnbroadcasts (), [])
+    expected = [
+      {
+        "txhash": txidFromBroadcast (mnbOtherPrevout),
+        "outidx": cfg.vout,
+        "broadcast": mnbOtherPrevout,
+      },
+      {
+        "txhash": cfg.txid,
+        "outidx": cfg.vout,
+        "broadcast": mnb,
+      }
+    ]
+    expected.sort (key=lambda x: x["txhash"])
+    assert_equal (self.nodes[1].listmnbroadcasts (), expected)
+
+    print ("Restarting node...")
+    stop_nodes (self.nodes)
+    wait_bitcoinds ()
+    self.setup_network (config_line=cfg)
+
+    print ("Testing imported data...")
+    assert_equal (self.nodes[1].listmnbroadcasts (), expected)
+
+
+if __name__ == '__main__':
+  MnStoredBroadcastTest ().main ()

--- a/divi/qa/rpc-tests/test_runner.py
+++ b/divi/qa/rpc-tests/test_runner.py
@@ -94,6 +94,7 @@ BASE_SCRIPTS = [
     'MnAreSafeToRestart.py',
     'mncollateral.py',
     'mnoperation.py',
+    'mnstoredbroadcast.py',
     'mnvaults.py',
     'multisig.py',
     'NoBlocksForLongTime.py',

--- a/divi/src/Makefile.am
+++ b/divi/src/Makefile.am
@@ -289,6 +289,7 @@ BITCOIN_CORE_H = \
   spork.h \
   sporkdb.h \
   spentindex.h \
+  StoredMasternodeBroadcasts.h \
   streams.h \
   sync.h \
   SpentOutputTracker.h \
@@ -494,6 +495,7 @@ libbitcoin_wallet_a_SOURCES = \
   SuperblockSubsidyContainer.cpp \
   SuperblockHeightValidator.cpp \
   SpentOutputTracker.cpp \
+  StoredMasternodeBroadcasts.cpp \
   masternode-sync.cpp \
   masternodeconfig.cpp \
   MasternodeNetworkMessageManager.cpp \

--- a/divi/src/MasternodeModule.cpp
+++ b/divi/src/MasternodeModule.cpp
@@ -28,6 +28,7 @@
 #include <netfulfilledman.h>
 #include <spork.h>
 #include <keystore.h>
+#include <StoredMasternodeBroadcasts.h>
 
 #include <blockmap.h>
 #include <ThreadManagementHelpers.h>
@@ -82,6 +83,8 @@ MasternodeModule::MasternodeModule(
 
 MasternodeModule::~MasternodeModule()
 {
+    /* The order of destruction matters, so we explicitly reset
+       the unique_ptr's manually here.  */
     masternodePayments_.reset();
     mnodeman_.reset();
     masternodeSync_.reset();
@@ -124,6 +127,19 @@ CMasternodeSync& MasternodeModule::getMasternodeSynchronization() const
 {
     return *masternodeSync_;
 }
+StoredMasternodeBroadcasts& MasternodeModule::getStoredBroadcasts() const
+{
+    /* We use lazy initialisation of the stored broadcasts instance, since it
+       relies on GetDataDir() and thus needs the parameters to be already
+       parsed when constructed.  */
+    if (storedBroadcasts_ == nullptr)
+    {
+        const_cast<MasternodeModule*>(this)->storedBroadcasts_.reset(
+            new StoredMasternodeBroadcasts("mnbroadcasts.dat"));
+    }
+    return *storedBroadcasts_;
+}
+
  bool MasternodeModule::localNodeIsAMasternode() const
  {
      return fMasterNode_;

--- a/divi/src/MasternodeModule.h
+++ b/divi/src/MasternodeModule.h
@@ -27,6 +27,7 @@ class I_PeerSyncQueryService;
 class I_Clock;
 class CNetFulfilledRequestManager;
 class CAddrMan;
+class StoredMasternodeBroadcasts;
 
 class MasternodeModule
 {
@@ -42,6 +43,7 @@ private:
     std::unique_ptr<CMasternodeSync> masternodeSync_;
     std::unique_ptr<CMasternodeMan> mnodeman_;
     std::unique_ptr<CMasternodePayments> masternodePayments_;
+    std::unique_ptr<StoredMasternodeBroadcasts> storedBroadcasts_;
 public:
     MasternodeModule(
         const I_Clock& clock,
@@ -59,6 +61,7 @@ public:
     CActiveMasternode& getActiveMasternode() const;
     CMasternodePayments& getMasternodePayments() const;
     CMasternodeSync& getMasternodeSynchronization() const;
+    StoredMasternodeBroadcasts& getStoredBroadcasts() const;
     bool localNodeIsAMasternode() const;
     void designateLocalNodeAsMasternode();
 };

--- a/divi/src/RpcMasternodeFeatures.h
+++ b/divi/src/RpcMasternodeFeatures.h
@@ -54,7 +54,7 @@ struct MasternodeCountData
 /** Relays a broadcast given in serialised form as hex string.  If the signature
  *  is present, then it will replace the signature in the broadcast.  If
  *  updatePing is true, then the masternode ping is re-signed freshly.  */
-bool RelayMasternodeBroadcast(const std::string& hexData, const std::string& signature, bool updatePing);
+MasternodeStartResult RelayMasternodeBroadcast(const std::string& hexData, const std::string& signature, bool updatePing);
 MasternodeStartResult StartMasternode(const CKeyStore& keyStore, std::string alias, bool deferRelay);
 ActiveMasternodeStatus GetActiveMasternodeStatus();
 std::vector<MasternodeListEntry> GetMasternodeList(std::string strFilter);

--- a/divi/src/RpcMasternodeFeatures.h
+++ b/divi/src/RpcMasternodeFeatures.h
@@ -3,8 +3,9 @@
 #include <string>
 #include <vector>
 #include <stdint.h>
-class CKeyStore;
 class CBlockIndex;
+class CKeyStore;
+class StoredMasternodeBroadcasts;
 struct MasternodeStartResult
 {
     bool status;
@@ -55,7 +56,7 @@ struct MasternodeCountData
  *  is present, then it will replace the signature in the broadcast.  If
  *  updatePing is true, then the masternode ping is re-signed freshly.  */
 MasternodeStartResult RelayMasternodeBroadcast(const std::string& hexData, const std::string& signature, bool updatePing);
-MasternodeStartResult StartMasternode(const CKeyStore& keyStore, std::string alias, bool deferRelay);
+MasternodeStartResult StartMasternode(const CKeyStore& keyStore, const StoredMasternodeBroadcasts& stored, std::string alias, bool deferRelay);
 ActiveMasternodeStatus GetActiveMasternodeStatus();
 std::vector<MasternodeListEntry> GetMasternodeList(std::string strFilter);
 MasternodeCountData GetMasternodeCounts(const CBlockIndex* chainTip);

--- a/divi/src/StoredMasternodeBroadcasts.cpp
+++ b/divi/src/StoredMasternodeBroadcasts.cpp
@@ -1,0 +1,94 @@
+#include "StoredMasternodeBroadcasts.h"
+
+namespace
+{
+
+/** Magic string for stored broadcasts.  */
+constexpr const char* MAGIC_BROADCAST = "mnBroadcast";
+
+/** Wrapper around CMasternodeBroadcast that allows to serialise/unserialise
+ *  it and that also implements extra methods as required by the AppendOnlyFile
+ *  template code.  */
+class MasternodeBroadcastSerializer
+{
+
+private:
+
+  CMasternodeBroadcast mnb;
+
+public:
+
+  MasternodeBroadcastSerializer() = default;
+
+  explicit MasternodeBroadcastSerializer(const CMasternodeBroadcast& b)
+    : mnb(b)
+  {}
+
+  ADD_SERIALIZE_METHODS;
+
+  template <typename Stream, typename Operation>
+  inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion)
+  {
+    READWRITE(mnb);
+  }
+
+  void Clear()
+  {
+    mnb = CMasternodeBroadcast();
+  }
+
+  std::string ToString() const
+  {
+    return strprintf("CMasternodeBroadcast(%s)", mnb.vin.prevout.ToString());
+  }
+
+  const CMasternodeBroadcast& Get() const
+  {
+    return mnb;
+  }
+
+};
+
+} // anonymous namespace
+
+StoredMasternodeBroadcasts::StoredMasternodeBroadcasts(const std::string& file)
+  : AppendOnlyFile(file)
+{
+  auto reader = Read ();
+  if (reader != nullptr)
+    {
+      while (reader->Next())
+        {
+          const std::string magic = reader->GetMagic();
+          if (magic != MAGIC_BROADCAST)
+            {
+              LogPrint("masternode", "Ignoring chunk '%s' in datafile", magic);
+              continue;
+            }
+
+          MasternodeBroadcastSerializer mnb;
+          if (reader->Parse(mnb))
+            broadcasts[mnb.Get().vin.prevout] = mnb.Get();
+        }
+    }
+}
+
+bool StoredMasternodeBroadcasts::AddBroadcast(const CMasternodeBroadcast& mnb)
+{
+  const MasternodeBroadcastSerializer serializer(mnb);
+  if (!Append(MAGIC_BROADCAST, serializer))
+    return false;
+
+  broadcasts[serializer.Get().vin.prevout] = serializer.Get();
+  return true;
+}
+
+bool StoredMasternodeBroadcasts::GetBroadcast(const COutPoint& outp, CMasternodeBroadcast& mnb) const
+{
+  const auto mit = broadcasts.find(outp);
+  if (mit == broadcasts.end())
+    return false;
+
+  mnb = mit->second;
+  return true;
+}

--- a/divi/src/StoredMasternodeBroadcasts.h
+++ b/divi/src/StoredMasternodeBroadcasts.h
@@ -1,0 +1,42 @@
+#ifndef STORED_MASTERNODE_BROADCASTS_H
+#define STORED_MASTERNODE_BROADCASTS_H
+
+#include "flat-database.h"
+#include "masternode.h"
+#include "primitives/transaction.h"
+
+#include <map>
+
+/** Helper class that keeps track of pre-signed and stored masternode
+ *  broadcasts this node knows about.  They are stored on-disk in an
+ *  append-only data file.  */
+class StoredMasternodeBroadcasts : private AppendOnlyFile
+{
+
+private:
+
+  /** In-memory map of all the broadcasts (loaded from the file).  */
+  std::map<COutPoint, CMasternodeBroadcast> broadcasts;
+
+public:
+
+  /** Constructs the instance based on the given data file.  */
+  explicit StoredMasternodeBroadcasts(const std::string& file);
+
+  /** Imports a new broadcast, which is stored in memory and written
+   *  to the on-disk file.  */
+  bool AddBroadcast(const CMasternodeBroadcast& mnb);
+
+  /** Tries to look up a broadcast by outpoint.  Returns true and fills in
+   *  the broadcast if found, and false if not.  */
+  bool GetBroadcast(const COutPoint& outp, CMasternodeBroadcast& mnb) const;
+
+  /** Returns the entire map of stored broadcasts.  */
+  const std::map<COutPoint, CMasternodeBroadcast>& GetMap() const
+  {
+    return broadcasts;
+  }
+
+};
+
+#endif // STORED_MASTERNODE_BROADCASTS_H

--- a/divi/src/masternodeconfig.cpp
+++ b/divi/src/masternodeconfig.cpp
@@ -10,8 +10,26 @@
 #include <Settings.h>
 #include <DataDirectory.h>
 #include <Logging.h>
+#include <primitives/transaction.h>
 
 // clang-format on
+
+bool CMasternodeConfig::CMasternodeEntry::parseInputReference(COutPoint& outp) const
+{
+    outp.hash = uint256S(getTxHash());
+
+    try {
+        outp.n = std::stoi(getOutputIndex().c_str());
+    } catch (const std::exception& e) {
+        LogPrintf("%s: %s on getOutputIndex\n", __func__, e.what());
+        return false;
+    }
+
+    return true;
+}
+
+namespace
+{
 
 boost::filesystem::path GetMasternodeConfigFile(const Settings& settings)
 {
@@ -19,6 +37,8 @@ boost::filesystem::path GetMasternodeConfigFile(const Settings& settings)
     if (!pathConfigFile.is_complete()) pathConfigFile = GetDataDir() / pathConfigFile;
     return pathConfigFile;
 }
+
+} // anonymous namespace
 
 void CMasternodeConfig::add(const std::string& alias, const std::string& ip, const std::string& privKey,
                             const std::string& txHash, const std::string& outputIndex)
@@ -73,19 +93,6 @@ bool CMasternodeConfig::read(const Settings& settings, std::string& strErr)
     streamConfig.close();
     return true;
 }
-
-bool CMasternodeConfig::CMasternodeEntry::castOutputIndex(int &n)
-{
-    try {
-        n = std::stoi(outputIndex);
-    } catch (const std::exception e) {
-        LogPrintf("%s: %s on getOutputIndex\n", __func__, e.what());
-        return false;
-    }
-
-    return true;
-}
-
 
 CMasternodeConfig::CMasternodeConfig(
     ): entries()

--- a/divi/src/masternodeconfig.h
+++ b/divi/src/masternodeconfig.h
@@ -12,7 +12,9 @@
 #include <boost/filesystem.hpp>
 #include <boost/filesystem/fstream.hpp>
 
+class COutPoint;
 class Settings;
+
 class CMasternodeConfig
 {
 public:
@@ -52,8 +54,6 @@ public:
             return outputIndex;
         }
 
-        bool castOutputIndex(int& n);
-
         void setOutputIndex(const std::string& outputIndex)
         {
             this->outputIndex = outputIndex;
@@ -88,6 +88,10 @@ public:
         {
             this->ip = ip;
         }
+
+        /** Tries to parse the entry's input reference into an outpoint.
+         *  Returns true on success.  */
+        bool parseInputReference(COutPoint& outp) const;
     };
 
     CMasternodeConfig();

--- a/divi/src/rpcmasternode.cpp
+++ b/divi/src/rpcmasternode.cpp
@@ -434,15 +434,13 @@ Value broadcaststartmasternode(const Array& params, bool fHelp)
         updatePing = true;
     }
 
+    const auto mnResult = RelayMasternodeBroadcast(params[0].get_str(), signature, updatePing);
+
     Object result;
-    if(RelayMasternodeBroadcast(params[0].get_str(), signature, updatePing))
-    {
-        result.push_back(Pair("status", "success"));
-    }
-    else
-    {
-        result.push_back(Pair("status","failed"));
-    }
+    result.emplace_back("status", mnResult.status ? "success" : "failed");
+    if(!mnResult.status)
+        result.emplace_back("error", mnResult.errorMessage);
+
     return result;
 }
 

--- a/divi/src/rpcmasternode.cpp
+++ b/divi/src/rpcmasternode.cpp
@@ -463,7 +463,7 @@ Value startmasternode(const Array& params, bool fHelp)
 
     EnsureWalletIsUnlocked();
     Object result;
-    MasternodeStartResult mnResult = StartMasternode(*pwalletMain,alias,deferRelay);
+    MasternodeStartResult mnResult = StartMasternode(*pwalletMain, GetMasternodeModule().getStoredBroadcasts(), alias, deferRelay);
 
     result.push_back(Pair("status",mnResult.status?"success":"failed"));
     if(!mnResult.status)

--- a/divi/src/rpcserver.cpp
+++ b/divi/src/rpcserver.cpp
@@ -145,6 +145,8 @@ extern json_spirit::Value listmasternodeconf(const json_spirit::Array& params, b
 extern json_spirit::Value getmasternodestatus(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value getmasternodewinners(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value getmasternodescores(const json_spirit::Array& params, bool fHelp);
+extern json_spirit::Value importmnbroadcast(const json_spirit::Array& params, bool fHelp);
+extern json_spirit::Value listmnbroadcasts(const json_spirit::Array& params, bool fHelp);
 
 extern json_spirit::Value getinfo(const json_spirit::Array& params, bool fHelp); // in rpcmisc.cpp
 extern json_spirit::Value mnsync(const json_spirit::Array& params, bool fHelp);
@@ -476,6 +478,8 @@ static const CRPCCommand vRPCCommands[] =
         {"divi", "getmasternodestatus", &getmasternodestatus, true, true, false},
         {"divi", "getmasternodewinners", &getmasternodewinners, true, true, false},
         {"divi", "getmasternodescores", &getmasternodescores, true, true, false},
+        {"divi", "importmnbroadcast", &importmnbroadcast, true, false, false},
+        {"divi", "listmnbroadcasts", &listmnbroadcasts, true, false, false},
         //{"divi", "mnbudget", &mnbudget, true, true, false},
         //{"divi", "preparebudget", &preparebudget, true, true, false},
         //{"divi", "submitbudget", &submitbudget, true, true, false},


### PR DESCRIPTION
This implements a new feature:  Pre-signed masternode broadcasts (e.g. from deferred `startmasternode`) can be imported and stored in a node's wallet, and used from there to start a masternode.  This makes the workflow for a hot/cold masternode simpler:

- Deferred start the masternode on the cold node
- `importmnbroadcast` the activation message on the hot node
- Whenever the hot node needs to be restarted, just `startmasternode` on the *hot* node

No need to manually record / transfer the broadcast message each time the hot node is restarted.