### PR TITLE
Implement BIP65 (OP_CHECKLOCKTIMEVERIFY) and support for atomic trades

### DIFF
--- a/divi/qa/rpc-tests/AtomicTrading.py
+++ b/divi/qa/rpc-tests/AtomicTrading.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+# Copyright (c) 2021 The DIVI developers
+# Distributed under the MIT/X11 software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+# Tests execution of HTLCs (which are one side of atomic trades).
+
+from test_framework import BitcoinTestFramework
+from authproxy import JSONRPCException
+from messages import *
+from util import *
+from script import *
+
+from CheckLockTimeVerify import ACTIVATION_TIME
+
+
+class AtomicTradingTest (BitcoinTestFramework):
+
+    def setup_network (self, split=False):
+        self.nodes = start_nodes (2, self.options.tmpdir)
+        connect_nodes (self.nodes[0], 1)
+        self.is_network_split = False
+
+    def generateOutput (self, n, addr, amount):
+        """Sends amount DIVI to the given address, and returns
+        a (txid, n) pair corresponding to the created output."""
+
+        txid = n.sendtoaddress (addr, amount)
+
+        tx = n.getrawtransaction (txid, 1)
+        for i in range (len (tx["vout"])):
+          if tx["vout"][i]["scriptPubKey"]["addresses"] == [addr]:
+            return (txid, i)
+
+        raise AssertionError ("failed to find destination address")
+
+    def buildSpend (self, node, output, address, secret, lockTime=0):
+        """Builds a transaction that spends the given output.  It uses
+        the passed secret in the scriptSig, and the pubkey/signature
+        associated to the address to sign with the given node (which
+        must know the private key to the address)."""
+
+        (txid, n) = output
+        outpoint = COutPoint (txid=txid, n=n)
+
+        tx = CTransaction ()
+        tx.nLockTime = lockTime
+        tx.vin.append (CTxIn (outpoint));
+        tx.vout.append (CTxOut (1, CScript ([OP_META])))
+
+        prevout = node.gettxout (txid, n)
+        prevtx = [{
+          "txid": txid,
+          "vout": n,
+          "scriptPubKey": prevout["scriptPubKey"]["hex"],
+          "redeemScript": self.htlc.hex (),
+        }]
+
+        privkeys = [node.dumpprivkey (address)]
+
+        signed = node.signrawtransaction (ToHex (tx), prevtx, privkeys)
+        # It is not necessarily the case that signed["complete"] is true
+        # here, as the solver does not have the secret preimage.  It will
+        # add the right signatures, though, so then we just need to fill
+        # in the secret.
+
+        sigTx = FromHex (CTransaction (), signed["hex"])
+        sig = [x for x in CScript (sigTx.vin[0].scriptSig)]
+        sig[2] = secret
+        tx.vin[0].scriptSig = CScript (sig)
+
+        return tx
+
+    def expectInvalid (self, tx):
+        """Expects that a given transaction is invalid."""
+        assert_raises (JSONRPCException, self.nodes[0].generateblock,
+                       {"extratx": [ToHex (tx)]})
+
+    def run_test (self):
+        set_node_times (self.nodes, ACTIVATION_TIME)
+        connect_nodes (self.nodes[0], 1)
+        self.nodes[0].setgenerate (True, 30)
+
+        # We need two addresses from our two nodes, and mainly
+        # also the raw pubkey hashes.
+        addr = [n.getnewaddress () for n in self.nodes]
+        p2pkh = [
+            self.nodes[0].validateaddress (a)["scriptPubKey"]
+            for a in addr
+        ]
+        baseScripts = [
+            CScript (binascii.unhexlify (h))
+            for h in p2pkh
+        ]
+        pkh = [
+            [x for x in b][2]
+            for b in baseScripts
+        ]
+
+        # Define a secret preimage and its hash value.
+        secret = b"foobar"
+        secretHash = hashlib.sha256 (secret).digest ()
+
+        # We lock two coins in two identical outputs (two instances
+        # of our HTLC), so that we can test spending them both
+        # according to the relevant paths.
+        #
+        # The output can be spent with a signature of addr[0] after
+        # a time lock (i.e. after block 100), or with a SHA-256
+        # preimage by addr[1] immediately.
+        #
+        # The scriptSig will be "sig pubkey preimage" for both spends,
+        # where preimage can be an arbitrary value (not matching the hash)
+        # for spending with addr[0] after the time lock.
+        self.htlc = CScript ([
+            OP_SHA256, secretHash, OP_EQUAL,
+            OP_IF,
+              pkh[1],
+            OP_ELSE,
+              100, OP_CHECKLOCKTIMEVERIFY, OP_DROP, pkh[0],
+            OP_ENDIF,
+            OP_OVER, OP_HASH160, OP_EQUALVERIFY, OP_CHECKSIG,
+        ])
+        htlcAddress = self.nodes[0].decodescript (self.htlc.hex ())["p2sh"]
+        outputs = [
+            self.generateOutput (self.nodes[0], htlcAddress, 1)
+            for _ in range (2)
+        ]
+        self.nodes[0].setgenerate (True, 1)
+        sync_blocks (self.nodes)
+
+        # addr[1] can spend the output immediately with the right secret.
+        tx = self.buildSpend (self.nodes[1], outputs[0], addr[1], b"wrong")
+        self.expectInvalid (tx)
+        tx = self.buildSpend (self.nodes[1], outputs[0], addr[1], secret)
+        self.nodes[0].sendrawtransaction (ToHex (tx))
+        self.nodes[0].setgenerate (True, 1)
+
+        # addr[0] can't spend before the time lock runs out, independent
+        # of the secret.
+        tx = self.buildSpend (self.nodes[0], outputs[1], addr[0], b"wrong")
+        self.expectInvalid (tx)
+        tx = self.buildSpend (self.nodes[0], outputs[1], addr[0], secret)
+        self.expectInvalid (tx)
+        tx = self.buildSpend (self.nodes[0], outputs[1], addr[0], b"wrong",
+                              lockTime=100)
+        self.expectInvalid (tx)
+
+        # Bump the block height to after the time lock.  Now addr[0] can
+        # spend the output (with a wrong secret, since otherwise
+        # the codepath for addr[1] activates).
+        self.nodes[0].setgenerate (True, 100)
+        sync_blocks (self.nodes)
+        tx = self.buildSpend (self.nodes[0], outputs[1], addr[0], b"wrong",
+                              lockTime=100)
+        self.nodes[0].sendrawtransaction (ToHex (tx))
+        self.nodes[0].setgenerate (True, 1)
+
+        # Both outputs should now really be spent.
+        for txid, n in outputs:
+          assert_equal (self.nodes[0].gettxout (txid, n), None)
+
+
+if __name__ == '__main__':
+    AtomicTradingTest ().main ()

--- a/divi/qa/rpc-tests/CheckLockTimeVerify.py
+++ b/divi/qa/rpc-tests/CheckLockTimeVerify.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+# Copyright (c) 2021 The DIVI developers
+# Distributed under the MIT/X11 software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+# Tests the BIP65 (OP_CHECKLOCKTIMEVERIFY) opcode and fork activation.
+
+from test_framework import BitcoinTestFramework
+from authproxy import JSONRPCException
+from messages import *
+from util import *
+from script import *
+
+ACTIVATION_TIME = 2_000_000_000
+
+
+class CheckLockTimeVerifyTest (BitcoinTestFramework):
+
+    def setup_network (self, split=False):
+        self.nodes = start_nodes (1, self.options.tmpdir)
+        self.node = self.nodes[0]
+        self.is_network_split = False
+
+    def generateOutput (self, addr, amount):
+        """Sends amount DIVI to the given address, and returns
+        a (txid, n) pair corresponding to the created output."""
+
+        txid = self.node.sendtoaddress (addr, amount)
+
+        tx = self.node.getrawtransaction (txid, 1)
+        for i in range (len (tx["vout"])):
+          if tx["vout"][i]["scriptPubKey"]["addresses"] == [addr]:
+            return (txid, i)
+
+        raise AssertionError ("failed to find destination address")
+
+    def buildSpend (self, output):
+        """Builds a transaction that spends one of our test outputs."""
+
+        (txid, n) = output
+        outpoint = COutPoint (txid=txid, n=n)
+
+        scriptSig = CScript ([42, self.cltvScript])
+
+        tx = CTransaction ()
+        tx.vin.append (CTxIn (outpoint, scriptSig))
+        tx.vout.append (CTxOut (1, CScript ([OP_META])))
+
+        return tx
+
+    def run_test (self):
+        set_node_times (self.nodes, ACTIVATION_TIME - 1_000)
+
+        # Generate outputs locked to block height 100, but spendable
+        # easily (by pushing 42 on the stack) afterwards.
+        self.node.setgenerate (True, 30)
+        self.cltvScript = CScript ([100, OP_CHECKLOCKTIMEVERIFY, OP_DROP,
+                                   42, OP_EQUAL])
+        addr = self.node.decodescript (self.cltvScript.hex ())["p2sh"]
+        outputs = [self.generateOutput (addr, 1) for _ in range (2)]
+        self.node.setgenerate (True, 1)
+
+        # Spending an output before the fork is activated should work
+        # even without a proper lock time on the transaction, although
+        # mempool policy will not allow it.
+        tx = self.buildSpend (outputs[0])
+        assert_raises (JSONRPCException, self.node.sendrawtransaction,
+                       tx.serialize ().hex ())
+        self.node.generateblock ({"extratx": [tx.serialize ().hex ()]})
+
+        # After the fork, the output should not be spendable (even directly
+        # in a block) without the lock time.
+        set_node_times (self.nodes, ACTIVATION_TIME)
+        self.node.setgenerate (True, 1)
+        tx = self.buildSpend (outputs[1])
+        assert_raises (JSONRPCException, self.node.generateblock,
+                       {"extratx": [tx.serialize ().hex ()]})
+
+        # With the lock time, it should still not be spendable before
+        # the actual block height.
+        tx.nLockTime = 100
+        assert_raises (JSONRPCException, self.node.generateblock,
+                       {"extratx": [tx.serialize ().hex ()]})
+
+        # Once the lock height is reached (exceeded), the transaction should
+        # be fine, even in the mempool.
+        self.node.setgenerate (True, 100)
+        self.node.sendrawtransaction (tx.serialize ().hex ())
+        self.node.setgenerate (True, 1)
+
+        # Make sure the outputs have really been spent.
+        assert_equal (self.node.getrawmempool (), [])
+        for o in outputs:
+          assert_equal (self.node.gettxout (o[0], o[1]), None)
+
+
+if __name__ == '__main__':
+    CheckLockTimeVerifyTest ().main ()

--- a/divi/qa/rpc-tests/test_runner.py
+++ b/divi/qa/rpc-tests/test_runner.py
@@ -74,6 +74,7 @@ BASE_SCRIPTS = [
     # Longest test should go first, to favor running tests in parallel
     'AddressAndSpentIndicesAreOperational.py',
     'BlocksOnlyHaveSingleCoinstake.py',
+    'CheckLockTimeVerify.py',
     'StakingVaultFunding.py',
     'StakingVaultStaking.py',
     'StakingVaultDeactivation.py',

--- a/divi/qa/rpc-tests/test_runner.py
+++ b/divi/qa/rpc-tests/test_runner.py
@@ -73,6 +73,7 @@ BASE_SCRIPTS = [
     # Scripts that are run by default.
     # Longest test should go first, to favor running tests in parallel
     'AddressAndSpentIndicesAreOperational.py',
+    'AtomicTrading.py',
     'BlocksOnlyHaveSingleCoinstake.py',
     'CheckLockTimeVerify.py',
     'StakingVaultFunding.py',

--- a/divi/src/BlockTransactionChecker.h
+++ b/divi/src/BlockTransactionChecker.h
@@ -5,7 +5,8 @@
 #include <vector>
 #include <uint256.h>
 #include <BlockUndo.h>
-#include  <TransactionInputChecker.h>
+#include <ForkActivation.h>
+#include <TransactionInputChecker.h>
 #include <IndexDatabaseUpdates.h>
 
 class BlockMap;
@@ -36,6 +37,7 @@ class BlockTransactionChecker
 private:
     CBlockUndo blockundo_;
     const CBlock& block_;
+    const ActivationState activation_;
     CValidationState& state_;
     CBlockIndex* pindex_;
     CCoinsViewCache& view_;

--- a/divi/src/ForkActivation.cpp
+++ b/divi/src/ForkActivation.cpp
@@ -25,6 +25,8 @@ const std::unordered_map<Fork, int64_t,std::hash<int>> ACTIVATION_TIMES = {
   {Fork::TestByTimestamp, 1000000000},
   {Fork::HardenedStakeModifier, unixTimestampForDec31stMidnight},
   {Fork::UniformLotteryWinners, unixTimestampForDec31stMidnight},
+  /* FIXME: Schedule for a real time.  */
+  {Fork::CheckLockTimeVerify, 2000000000},
 };
 
 } // anonymous namespace

--- a/divi/src/ForkActivation.h
+++ b/divi/src/ForkActivation.h
@@ -22,6 +22,7 @@ enum Fork
   TestByTimestamp,
   HardenedStakeModifier,
   UniformLotteryWinners,
+  CheckLockTimeVerify,
 };
 
 /**

--- a/divi/src/Makefile.test.include
+++ b/divi/src/Makefile.test.include
@@ -73,6 +73,7 @@ BITCOIN_TESTS =\
   test/pmt_tests.cpp \
   test/rpc_tests.cpp \
   test/sanity_tests.cpp \
+  test/script_CLTV_tests.cpp \
   test/script_P2SH_tests.cpp \
   test/script_tests.cpp \
   test/scriptnum_tests.cpp \

--- a/divi/src/TransactionInputChecker.cpp
+++ b/divi/src/TransactionInputChecker.cpp
@@ -40,13 +40,14 @@ void TransactionInputChecker::ScheduleBackgroundThreadScriptChecking()
 }
 bool TransactionInputChecker::CheckInputsAndUpdateCoinSupplyRecords(
     const CTransaction& tx,
+    const unsigned flags,
     const bool fJustCheck,
     CBlockIndex* pindex)
 {
     assert(vChecks.empty());
     CAmount txFees =0;
     CAmount txInputAmount=0;
-    if (!CheckInputs(tx, state_, view_, blockIndexMap_, txFees, txInputAmount, fScriptChecks, MANDATORY_SCRIPT_VERIFY_FLAGS, fJustCheck, nScriptCheckThreads ? &vChecks : NULL, true))
+    if (!CheckInputs(tx, state_, view_, blockIndexMap_, txFees, txInputAmount, fScriptChecks, flags, fJustCheck, nScriptCheckThreads ? &vChecks : NULL, true))
     {
         vChecks.clear();
         return false;

--- a/divi/src/TransactionInputChecker.h
+++ b/divi/src/TransactionInputChecker.h
@@ -32,6 +32,7 @@ public:
     void ScheduleBackgroundThreadScriptChecking();
     bool CheckInputsAndUpdateCoinSupplyRecords(
         const CTransaction& tx,
+        unsigned flags,
         const bool fJustCheck,
         CBlockIndex* pindex);
     bool TotalSigOpsAreBelowMaximum(const CTransaction& tx);

--- a/divi/src/core_io.cpp
+++ b/divi/src/core_io.cpp
@@ -42,6 +42,8 @@ CScript ParseScript(std::string s)
     if (mapOpNames.empty()) {
         mapOpNames["OP_RETURN"] = opcodetype::OP_META;
         mapOpNames["RETURN"] = opcodetype::OP_META;
+        mapOpNames["OP_NOP2"] = opcodetype::OP_CHECKLOCKTIMEVERIFY;
+        mapOpNames["NOP2"] = opcodetype::OP_CHECKLOCKTIMEVERIFY;
         mapOpNames["OP_NOP10"] = opcodetype::OP_REQUIRE_COINSTAKE;
         mapOpNames["NOP10"] = opcodetype::OP_REQUIRE_COINSTAKE;
 

--- a/divi/src/script/SignatureCheckers.h
+++ b/divi/src/script/SignatureCheckers.h
@@ -10,6 +10,7 @@
 
 class CPubKey;
 class CScript;
+class CScriptNum;
 class CTransaction;
 class uint256;
 class CMutableTransaction;
@@ -24,6 +25,13 @@ public:
         return false;
     }
     virtual bool CheckCoinstake() const
+    {
+        return false;
+    }
+
+    /** Checks if the transaction's lock time matches the given value
+     *  (is later than it) according to BIP65.  */
+    virtual bool CheckLockTime(const CScriptNum& nLockTime) const
     {
         return false;
     }
@@ -47,6 +55,7 @@ public:
     TransactionSignatureChecker(const CTransaction* txToIn, unsigned int nInIn) : txTo(txToIn), nIn(nInIn) {}
     bool CheckSig(const std::vector<unsigned char>& scriptSig, const std::vector<unsigned char>& vchPubKey, const CScript& scriptCode) const;
     bool CheckCoinstake() const;
+    bool CheckLockTime(const CScriptNum& nLockTime) const override;
 };
 
 class MutableTransactionSignatureChecker : public TransactionSignatureChecker

--- a/divi/src/script/opcodes.cpp
+++ b/divi/src/script/opcodes.cpp
@@ -121,7 +121,7 @@ const char* GetOpName(opcodetype opcode)
 
     // expanson
     case OP_NOP1                   : return "OP_NOP1";
-    case OP_NOP2                   : return "OP_NOP2";
+    case OP_CHECKLOCKTIMEVERIFY    : return "OP_CHECKLOCKTIMEVERIFY";
     case OP_NOP3                   : return "OP_NOP3";
     case OP_NOP4                   : return "OP_NOP4";
     case OP_NOP5                   : return "OP_NOP5";

--- a/divi/src/script/opcodes.h
+++ b/divi/src/script/opcodes.h
@@ -139,6 +139,8 @@ enum opcodetype
     OP_NOP10 = OP_REQUIRE_COINSTAKE,
 
     // template matching params
+    OP_ANYDATA = 0xf8,
+    OP_ANYHASH = 0xf9,
     OP_SMALLINTEGER = 0xfa,
     OP_PUBKEYS = 0xfb,
     OP_PUBKEYHASH = 0xfd,

--- a/divi/src/script/opcodes.h
+++ b/divi/src/script/opcodes.h
@@ -126,7 +126,8 @@ enum opcodetype
 
     // expansion
     OP_NOP1 = 0xb0,
-    OP_NOP2 = 0xb1,
+    OP_CHECKLOCKTIMEVERIFY = 0xb1,
+    OP_NOP2 = OP_CHECKLOCKTIMEVERIFY,
     OP_NOP3 = 0xb2,
     OP_NOP4 = 0xb3,
     OP_NOP5 = 0xb4,

--- a/divi/src/script/script.h
+++ b/divi/src/script/script.h
@@ -53,7 +53,7 @@ public:
         m_value = n;
     }
 
-    explicit CScriptNum(const std::vector<unsigned char>& vch, bool fRequireMinimal)
+    explicit CScriptNum(const std::vector<unsigned char>& vch, bool fRequireMinimal, const size_t nMaxNumSize = nDefaultMaxNumSize)
     {
         if (vch.size() > nMaxNumSize) {
             throw scriptnum_error("script number overflow");
@@ -176,7 +176,7 @@ public:
         return result;
     }
 
-    static const size_t nMaxNumSize = 4;
+    static constexpr size_t nDefaultMaxNumSize = 4;
 
 private:
     static int64_t set_vch(const std::vector<unsigned char>& vch)

--- a/divi/src/script/script_error.cpp
+++ b/divi/src/script/script_error.cpp
@@ -63,6 +63,8 @@ const char* ScriptErrorString(const ScriptError serror)
             return "NOPx reserved for soft-fork upgrades";
         case SCRIPT_ERR_PUBKEYTYPE:
             return "Public key is neither compressed or uncompressed";
+        case SCRIPT_ERR_CLTV:
+            return "Invalid transaction lock time (BIP65)";
         case SCRIPT_ERR_UNKNOWN_ERROR:
         case SCRIPT_ERR_ERROR_COUNT:
         default: break;

--- a/divi/src/script/script_error.h
+++ b/divi/src/script/script_error.h
@@ -44,6 +44,9 @@ typedef enum ScriptError_t
     SCRIPT_ERR_SIG_NULLDUMMY,
     SCRIPT_ERR_PUBKEYTYPE,
 
+    /* BIP65 */
+    SCRIPT_ERR_CLTV,
+
     /* softfork safeness */
     SCRIPT_ERR_DISCOURAGE_UPGRADABLE_NOPS,
 

--- a/divi/src/script/scriptandsigflags.h
+++ b/divi/src/script/scriptandsigflags.h
@@ -55,6 +55,11 @@ enum
     // Enable NOP10: OP_REQUIRE_COINSTAKE
     //
     // Require transaction be a coinstake to be spendable
-    SCRIPT_REQUIRE_COINSTAKE  = (1U << 8)
+    SCRIPT_REQUIRE_COINSTAKE  = (1U << 8),
+
+    // Enables verification according to BIP65:  NOP2 gets replaced by
+    // OP_CHECKLOCKTIMEVERIFY, which compares a value in the script to
+    // the transaction's nLockTime field.
+    SCRIPT_VERIFY_CHECKLOCKTIMEVERIFY = (1U << 9),
 };
 #endif //SCRIPT_AND_SIG_FLAGS_H

--- a/divi/src/script/standard.h
+++ b/divi/src/script/standard.h
@@ -55,6 +55,7 @@ enum txnouttype
     TX_PUBKEYHASH,
     TX_SCRIPTHASH,
     TX_VAULT,
+    TX_HTLC,
     TX_MULTISIG,
     TX_NULL_DATA,
 };

--- a/divi/src/script/standard.h
+++ b/divi/src/script/standard.h
@@ -41,6 +41,7 @@ static const unsigned int POS_SCRIPT_VERIFY_FLAGS = MANDATORY_SCRIPT_VERIFY_FLAG
  * blocks and we must accept those blocks.
  */
 static const unsigned int STANDARD_SCRIPT_VERIFY_FLAGS = POS_SCRIPT_VERIFY_FLAGS |
+                                                         SCRIPT_VERIFY_CHECKLOCKTIMEVERIFY |
                                                          SCRIPT_VERIFY_DISCOURAGE_UPGRADABLE_NOPS;
 
 /** For convenience, standard but not mandatory verify flags. */

--- a/divi/src/test/script_CLTV_tests.cpp
+++ b/divi/src/test/script_CLTV_tests.cpp
@@ -1,0 +1,145 @@
+// Copyright (c) 2021 The DIVI developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "defaultValues.h"
+#include "primitives/transaction.h"
+#include "script/interpreter.h"
+#include "script/script.h"
+#include "script/scriptandsigflags.h"
+#include "script/script_error.h"
+#include "script/SignatureCheckers.h"
+#include "uint256.h"
+
+#include <boost/test/unit_test.hpp>
+#include "test_only.h"
+
+namespace
+{
+
+class ScriptCLTVTestFixture
+{
+
+protected:
+
+  /** A simple dummy transaction that we use with a TransactionSignatureChecker
+   *  during script verification.  It has two inputs (of which we assume
+   *  input 0 is the one we are checking), both set to sequence number 1 by
+   *  default (which means that CLTV will validate).  */
+  CMutableTransaction tx;
+
+  ScriptCLTVTestFixture()
+  {
+    tx.vin.emplace_back(uint256(), 0, CScript(), 1);
+    tx.vin.emplace_back(uint256(), 0, CScript(), 1);
+  }
+
+  /** Asserts that a given script is invalid with CLTV enabled in combination
+   *  with our dummy tx, but valid without the flag set.  */
+  void AssertInvalid(const CScript& script, const ScriptError expectedErr = SCRIPT_ERR_CLTV)
+  {
+    unsigned flags = SCRIPT_VERIFY_NONE;
+    const MutableTransactionSignatureChecker checker(&tx, 0);
+
+    ScriptError err;
+    BOOST_CHECK_MESSAGE(VerifyScript(CScript(), script, flags, checker, &err),
+                        "Script failed without CLTV enabled");
+    BOOST_CHECK_EQUAL(err, SCRIPT_ERR_OK);
+
+    flags |= SCRIPT_VERIFY_CHECKLOCKTIMEVERIFY;
+    BOOST_CHECK_MESSAGE(!VerifyScript(CScript(), script, flags, checker, &err),
+                        "Script did not fail with CLTV enabled");
+    BOOST_CHECK_EQUAL(err, expectedErr);
+  }
+
+  /** Asserts that a given script is valid with our dummy tx (which should be the
+   *  case with and without CLTV enabled).  */
+  void AssertValid(const CScript& script)
+  {
+    unsigned flags = SCRIPT_VERIFY_NONE;
+    const MutableTransactionSignatureChecker checker(&tx, 0);
+
+    ScriptError err;
+    BOOST_CHECK_MESSAGE(VerifyScript(CScript(), script, flags, checker, &err),
+                        "Valid script failed without CLTV enabled");
+    BOOST_CHECK_EQUAL(err, SCRIPT_ERR_OK);
+
+    flags |= SCRIPT_VERIFY_CHECKLOCKTIMEVERIFY;
+    BOOST_CHECK_MESSAGE(VerifyScript(CScript(), script, flags, checker, &err),
+                        "Valid script failed with CLTV enabled");
+    BOOST_CHECK_EQUAL(err, SCRIPT_ERR_OK);
+  }
+
+};
+
+BOOST_FIXTURE_TEST_SUITE(script_CLTV_tests, ScriptCLTVTestFixture)
+
+BOOST_AUTO_TEST_CASE(failsWithEmptyStack)
+{
+  AssertInvalid(CScript() << OP_CHECKLOCKTIMEVERIFY << OP_TRUE,
+                SCRIPT_ERR_INVALID_STACK_OPERATION);
+}
+
+BOOST_AUTO_TEST_CASE(failsIfArgumentTooLarge)
+{
+  AssertInvalid(CScript() << CScriptNum(1LL << 50) << OP_CHECKLOCKTIMEVERIFY << OP_TRUE,
+                SCRIPT_ERR_UNKNOWN_ERROR);
+}
+
+BOOST_AUTO_TEST_CASE(failsIfArgumentIsNegative)
+{
+  tx.nLockTime = 0;
+  AssertInvalid(CScript() << CScriptNum(-1) << OP_CHECKLOCKTIMEVERIFY << OP_TRUE);
+}
+
+BOOST_AUTO_TEST_CASE(failsIfLockTypeMismatch)
+{
+  /* Note that this case is kind of redundant, as it would fail anyway in the
+     straight comparison between the lock times.  The second case below would
+     succeed without a special check, though.  */
+  tx.nLockTime = LOCKTIME_THRESHOLD - 1;
+  AssertInvalid(CScript() << CScriptNum(LOCKTIME_THRESHOLD) << OP_CHECKLOCKTIMEVERIFY << OP_TRUE);
+
+  tx.nLockTime = LOCKTIME_THRESHOLD;
+  AssertInvalid(CScript() << CScriptNum(LOCKTIME_THRESHOLD - 1) << OP_CHECKLOCKTIMEVERIFY << OP_TRUE);
+}
+
+BOOST_AUTO_TEST_CASE(failsIfInputIsFinal)
+{
+  tx.vin[0].nSequence = 0xFFFFFFFF;
+  tx.nLockTime = 0;
+  AssertInvalid(CScript() << CScriptNum(0) << OP_CHECKLOCKTIMEVERIFY << OP_TRUE);
+}
+
+BOOST_AUTO_TEST_CASE(verifiesLockByTimeCorrectly)
+{
+  tx.nLockTime = LOCKTIME_THRESHOLD + 10;
+  AssertInvalid(CScript() << CScriptNum(LOCKTIME_THRESHOLD + 11) << OP_CHECKLOCKTIMEVERIFY << OP_TRUE);
+  AssertValid(CScript() << CScriptNum(LOCKTIME_THRESHOLD + 10) << OP_CHECKLOCKTIMEVERIFY << OP_TRUE);
+  AssertValid(CScript() << CScriptNum(LOCKTIME_THRESHOLD) << OP_CHECKLOCKTIMEVERIFY << OP_TRUE);
+}
+
+BOOST_AUTO_TEST_CASE(verifiesLockByHeightCorrectly)
+{
+  tx.nLockTime = 10;
+  AssertInvalid(CScript() << CScriptNum(11) << OP_CHECKLOCKTIMEVERIFY << OP_TRUE);
+  AssertValid(CScript() << CScriptNum(10) << OP_CHECKLOCKTIMEVERIFY << OP_TRUE);
+  AssertValid(CScript() << CScriptNum(0) << OP_CHECKLOCKTIMEVERIFY << OP_TRUE);
+}
+
+BOOST_AUTO_TEST_CASE(accepts32BitLockTimes)
+{
+  tx.nLockTime = 0xFFFFFFFF;
+  AssertValid(CScript() << CScriptNum(0xFFFFFFFF) << OP_CHECKLOCKTIMEVERIFY << OP_TRUE);
+}
+
+BOOST_AUTO_TEST_CASE(acceptsOtherInputsBeingFinal)
+{
+  tx.vin[1].nSequence = 0xFFFFFFFF;
+  tx.nLockTime = 10;
+  AssertValid(CScript() << CScriptNum(10) << OP_CHECKLOCKTIMEVERIFY << OP_TRUE);
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+} // anonymous namespace

--- a/divi/src/test/scriptnum_tests.cpp
+++ b/divi/src/test/scriptnum_tests.cpp
@@ -142,7 +142,7 @@ static void RunCreate(const long& num)
 {
     CheckCreateInt(num);
     CScriptNum scriptnum(num);
-    if (scriptnum.getvch().size() <= CScriptNum::nMaxNumSize)
+    if (scriptnum.getvch().size() <= CScriptNum::nDefaultMaxNumSize)
         CheckCreateVch(num);
     else
     {


### PR DESCRIPTION
This implements [BIP65](https://github.com/bitcoin/bips/blob/master/bip-0065.mediawiki) (`OP_CHECKLOCKTIMEVERIFY`), with behaviour the same as in Bitcoin.  This is a soft-fork, for which we define a new activation entry, with (for now) a dummy time of 2'000'000'000.

With this, it is possible to implement HTLCs and thus atomic trading on Divi.  A new regtest executes the HTLC flow, and we also add minimal support for HTLCs in the form of wallet signing.