### PR TITLE
Refactor of CFlatDB

### DIFF
--- a/divi/src/Makefile.am
+++ b/divi/src/Makefile.am
@@ -598,6 +598,7 @@ libbitcoin_common_a_SOURCES = \
   core_io.cpp \
   eccryptoverify.cpp \
   ecwrapper.cpp \
+  flat-database.cpp \
   hash.cpp \
   hdchain.cpp \
   key.cpp \

--- a/divi/src/flat-database.cpp
+++ b/divi/src/flat-database.cpp
@@ -1,0 +1,62 @@
+// Copyright (c) 2014-2017 The Dash Core developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "flat-database.h"
+
+std::unique_ptr<FlatDataFile::Reader> FlatDataFile::Read() const
+{
+    std::unique_ptr<Reader> reader(new Reader(Path()));
+    if (reader->GetFile().IsNull())
+    {
+        error("%s: Failed to open file %s", __func__, Path().string());
+        return nullptr;
+    }
+    return reader;
+}
+
+FlatDataFile::ReadResult FlatDataFile::Reader::NextChunk(const size_t dataSize)
+{
+    std::vector<unsigned char> vchData(dataSize);
+    uint256 hashIn;
+
+    // read data and checksum from file
+    try {
+        file.read((char *)&vchData[0], vchData.size());
+        file >> hashIn;
+    } catch (const std::exception& e) {
+        error("%s: Deserialize or I/O error - %s", __func__, e.what());
+        return HashReadError;
+    }
+
+    chunk.reset(new CDataStream(vchData, SER_DISK, CLIENT_VERSION));
+
+    // verify stored checksum matches input data
+    const uint256 hashTmp = Hash(chunk->begin(), chunk->end());
+    if (hashIn != hashTmp)
+    {
+        error("%s: Checksum mismatch, data corrupted", __func__);
+        return IncorrectHash;
+    }
+
+    try {
+        // de-serialize file header (file specific magic message) and ..
+        *chunk >> magic;
+
+        // de-serialize file header (network specific magic number) and ..
+        unsigned char pchMsgTmp[4];
+        *chunk >> FLATDATA(pchMsgTmp);
+
+        // ... verify the network matches ours
+        if (memcmp(pchMsgTmp, Params().MessageStart(), sizeof(pchMsgTmp)))
+        {
+            error("%s: Invalid network magic number", __func__);
+            return IncorrectMagicNumber;
+        }
+    } catch (const std::exception& e) {
+        error("%s: Deserialize or I/O error - %s", __func__, e.what());
+        return IncorrectFormat;
+    }
+
+    return Ok;
+}

--- a/divi/src/flat-database.h
+++ b/divi/src/flat-database.h
@@ -39,18 +39,18 @@ private:
     std::string strFilename;
     std::string strMagicMessage;
 
-    bool Write(const T& objToSave)
+    bool Write(const T& objToSave) const
     {
         // LOCK(objToSave.cs);
 
-        int64_t nStart = GetTimeMillis();
+        const int64_t nStart = GetTimeMillis();
 
         // serialize, checksum data up to that point, then append checksum
         CDataStream ssObj(SER_DISK, CLIENT_VERSION);
         ssObj << strMagicMessage; // specific magic message for this type of object
         ssObj << FLATDATA(Params().MessageStart()); // network specific magic number
         ssObj << objToSave;
-        uint256 hash = Hash(ssObj.begin(), ssObj.end());
+        const uint256 hash = Hash(ssObj.begin(), ssObj.end());
         ssObj << hash;
 
         // open output file, and associate with CAutoFile
@@ -62,8 +62,7 @@ private:
         // Write and commit header, data
         try {
             fileout << ssObj;
-        }
-        catch (std::exception &e) {
+        } catch (const std::exception& e) {
             return error("%s: Serialize or I/O error - %s", __func__, e.what());
         }
         fileout.fclose();
@@ -74,11 +73,11 @@ private:
         return true;
     }
 
-    ReadResult Read(T& objToLoad, bool fDryRun = false)
+    ReadResult Read(T& objToLoad, const bool fDryRun = false) const
     {
         //LOCK(objToLoad.cs);
 
-        int64_t nStart = GetTimeMillis();
+        const int64_t nStart = GetTimeMillis();
         // open input file, and associate with CAutoFile
         FILE *file = fopen(pathDB.string().c_str(), "rb");
         CAutoFile filein(file, SER_DISK, CLIENT_VERSION);
@@ -89,7 +88,7 @@ private:
         }
 
         // use file size to size memory buffer
-        int fileSize = boost::filesystem::file_size(pathDB);
+        const int fileSize = boost::filesystem::file_size(pathDB);
         int dataSize = fileSize - sizeof(uint256);
         // Don't try to resize to a negative number if file is small
         if (dataSize < 0)
@@ -102,8 +101,7 @@ private:
         try {
             filein.read((char *)&vchData[0], dataSize);
             filein >> hashIn;
-        }
-        catch (std::exception &e) {
+        } catch (const std::exception& e) {
             error("%s: Deserialize or I/O error - %s", __func__, e.what());
             return HashReadError;
         }
@@ -112,7 +110,7 @@ private:
         CDataStream ssObj(vchData, SER_DISK, CLIENT_VERSION);
 
         // verify stored checksum matches input data
-        uint256 hashTmp = Hash(ssObj.begin(), ssObj.end());
+        const uint256 hashTmp = Hash(ssObj.begin(), ssObj.end());
         if (hashIn != hashTmp)
         {
             error("%s: Checksum mismatch, data corrupted", __func__);
@@ -146,8 +144,7 @@ private:
 
             // de-serialize data into T object
             ssObj >> objToLoad;
-        }
-        catch (std::exception &e) {
+        } catch (const std::exception& e) {
             objToLoad.Clear();
             error("%s: Deserialize or I/O error - %s", __func__, e.what());
             return IncorrectFormat;
@@ -166,14 +163,14 @@ private:
 
 
 public:
-    CFlatDB(std::string strFilenameIn, std::string strMagicMessageIn)
+    explicit CFlatDB(const std::string& strFilenameIn, const std::string& strMagicMessageIn)
     {
         pathDB = GetDataDir() / strFilenameIn;
         strFilename = strFilenameIn;
         strMagicMessage = strMagicMessageIn;
     }
 
-    bool Load(T& objToLoad)
+    bool Load(T& objToLoad) const
     {
         LogPrintf("Reading info from %s...\n", strFilename);
         ReadResult readResult = Read(objToLoad);
@@ -195,9 +192,9 @@ public:
         return true;
     }
 
-    bool Dump(T& objToSave)
+    bool Dump(T& objToSave) const
     {
-        int64_t nStart = GetTimeMillis();
+        const int64_t nStart = GetTimeMillis();
 
         LogPrintf("Verifying %s format...\n", strFilename);
         T tmpObjToLoad;


### PR DESCRIPTION
This is a refactor of `CFlatDB`, which has been split out of #102 and is in preparation of reusing some parts of the code to implement an append-only data file (in contrast to the current logic which supports just raw files with a single "chunk" of data).