### PR TITLE
Correctly handle standardness of P2SH inputs

### DIFF
--- a/divi/qa/rpc-tests/TxInputsStandardness.py
+++ b/divi/qa/rpc-tests/TxInputsStandardness.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+# Copyright (c) 2021 The DIVI developers
+# Distributed under the MIT/X11 software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+# Tests the standardness logic related to transaction inputs and P2SH.
+
+from test_framework import BitcoinTestFramework
+from authproxy import JSONRPCException
+from messages import *
+from util import *
+from script import *
+
+
+class TxInputStandardnessTest (BitcoinTestFramework):
+
+    def setup_network (self, split=False):
+        self.nodes = start_nodes (1, self.options.tmpdir)
+        self.node = self.nodes[0]
+        self.is_network_split = False
+
+    def generateOutput (self, addr, amount):
+        """Sends amount DIVI to the given address, and returns
+        a (txid, n) pair corresponding to the created output."""
+
+        txid = self.node.sendtoaddress (addr, amount)
+
+        tx = self.node.getrawtransaction (txid, 1)
+        for i in range (len (tx["vout"])):
+            if tx["vout"][i]["scriptPubKey"]["addresses"] == [addr]:
+                return (txid, i)
+
+        raise AssertionError ("failed to find destination address")
+
+    def buildSpend (self, outputs):
+        """Builds a transaction that spends the given outputs
+        (paying 1 sat to OP_META and otherwise spending in fees
+        for simplicity)."""
+
+        tx = CTransaction ()
+        tx.vout.append (CTxOut (1, CScript ([OP_META])))
+
+        for o in outputs:
+            (txid, n) = o
+            outpoint = COutPoint (txid=txid, n=n)
+            tx.vin.append (CTxIn (outpoint));
+
+        signed = self.node.signrawtransaction (ToHex (tx))
+        # We don't care if the transaction is completely signed yet.
+
+        return FromHex (CTransaction (), signed["hex"])
+
+    def expectNonStandard (self, tx):
+        """Expects that a given transaction is valid but non-standard."""
+        txHex = ToHex (tx)
+        assert_raises (JSONRPCException, self.node.sendrawtransaction, txHex)
+        self.node.generateblock ({"extratx": [txHex]})
+
+    def run_test (self):
+        self.nodes[0].setgenerate (True, 30)
+
+        # We generate two normal P2SH outputs.
+        addr = [
+            self.node.getnewaddress ()
+            for _ in range (2)
+        ]
+        pk = [
+            self.node.validateaddress (a)["pubkey"]
+            for a in addr
+        ]
+        p2sh = [
+            self.node.addmultisigaddress (1, [p])
+            for p in pk
+        ]
+        outputs = [
+            self.generateOutput (a, 1)
+            for a in p2sh
+        ]
+        self.node.setgenerate (True, 1)
+
+        # Also, we create a P2SH output that has an unknown form
+        # but is easy to spend.
+        eqScript = CScript ([42, OP_EQUAL])
+        eqAddr = self.node.decodescript (eqScript.hex ())["p2sh"]
+        eqOutput = self.generateOutput (eqAddr, 1)
+        self.node.setgenerate (True, 1)
+
+        # Spending a P2SH output with a non-standard script fails.
+        # This script embeds lots of extra data in the scriptSig,
+        # which is non-standard as being extra arguments.
+        tx = self.buildSpend ([outputs[0]])
+        tx.vin[0].scriptSig = CScript (
+          [b"foo"] * 50 + [x for x in CScript (tx.vin[0].scriptSig)]
+        )
+        self.expectNonStandard (tx)
+
+        # This is also true if we include a valid (considered standard)
+        # spend before the non-standard input.
+        tx = self.buildSpend ([eqOutput, outputs[1]])
+        tx.vin[0].scriptSig = CScript ([
+          42, eqScript,
+        ])
+        tx.vin[1].scriptSig = CScript (
+          [b"foo"] * 50 + [x for x in CScript (tx.vin[1].scriptSig)]
+        )
+        self.expectNonStandard (tx)
+
+
+if __name__ == '__main__':
+    TxInputStandardnessTest ().main ()

--- a/divi/qa/rpc-tests/test_runner.py
+++ b/divi/qa/rpc-tests/test_runner.py
@@ -113,6 +113,7 @@ BASE_SCRIPTS = [
     'smartfees.py',
     'sync.py',
     'txindex.py',
+    'TxInputsStandardness.py',
     'txn_doublespend.py',
     'txn_doublespend.py --mineblock',
     'VaultUtxoIndexing.py',

--- a/divi/src/main.cpp
+++ b/divi/src/main.cpp
@@ -413,7 +413,9 @@ bool AreInputsStandard(const CTransaction& tx, const CCoinsViewCache& mapInputs)
                 // Any other Script with less than 15 sigops OK:
                 unsigned int sigops = subscript.GetSigOpCount(true);
                 // ... extra data left on the stack after execution is OK, too:
-                return (sigops <= MAX_P2SH_SIGOPS);
+                if (sigops > MAX_P2SH_SIGOPS)
+                    return false;
+                continue;
             }
         }
 

--- a/divi/src/test/script_P2SH_tests.cpp
+++ b/divi/src/test/script_P2SH_tests.cpp
@@ -351,9 +351,10 @@ BOOST_AUTO_TEST_CASE(AreInputsStandard)
     BOOST_CHECK(SignSignature(keystore, txFrom, txTo, 2));
     // SignSignature doesn't know how to sign these. We're
     // not testing validating signatures, so just create
-    // dummy signatures that DO include the correct P2SH scripts:
+    // dummy signatures that DO include the correct P2SH scripts
+    // and number of expected arguments.
     txTo.vin[3].scriptSig << OP_11 << OP_11 << static_cast<vector<unsigned char> >(oneAndTwo);
-    txTo.vin[4].scriptSig << static_cast<vector<unsigned char> >(fifteenSigops);
+    txTo.vin[4].scriptSig << OP_0 << OP_11 << static_cast<vector<unsigned char> >(fifteenSigops);
 
     BOOST_CHECK(::AreInputsStandard(txTo, coins));
     // 22 P2SH sigops for all inputs (1 for vin[0], 6 for vin[3], 15 for vin[4]


### PR DESCRIPTION
The old logic for handling standardness with P2SH inputs has a loophole:  When an input is found which is of unknown type but with an acceptable number of sigops, the whole transaction is considered fine.  This fixes the logic to properly check all following inputs as well -- otherwise this opens up a venue for having inputs that should be considered non-standard accepted as standard.