### PR TITLE
Better const-ness for coins views

### DIFF
--- a/divi/src/coins.h
+++ b/divi/src/coins.h
@@ -307,15 +307,22 @@ public:
 class CCoinsViewBacked : public CCoinsView
 {
 private:
-    CCoinsView* base;
+    /** The base view used for read-only operations.  */
+    const CCoinsView* roBase;
+    /** The base view used for writing (BatchWrite).  May be null, in which
+     *  case this method must not be called.  */
+    CCoinsView* writeBase;
 
 public:
     CCoinsViewBacked();
-    CCoinsViewBacked(CCoinsView* viewIn);
+    explicit CCoinsViewBacked(CCoinsView* viewIn);
+    explicit CCoinsViewBacked(const CCoinsView* viewIn);
+
     bool GetCoins(const uint256& txid, CCoins& coins) const override;
     bool HaveCoins(const uint256& txid) const override;
     uint256 GetBestBlock() const override;
     void SetBackend(CCoinsView& viewIn);
+    void SetBackend(const CCoinsView& viewIn);
     void DettachBackend();
     bool BatchWrite(CCoinsMap& mapCoins, const uint256& hashBlock) override;
     bool GetStats(CCoinsStats& stats) const override;
@@ -371,7 +378,8 @@ protected:
 
 public:
     CCoinsViewCache();
-    CCoinsViewCache(CCoinsView* baseIn);
+    explicit CCoinsViewCache(CCoinsView* baseIn);
+    explicit CCoinsViewCache(const CCoinsView* baseIn);
     ~CCoinsViewCache();
 
     // Standard CCoinsView methods

--- a/divi/src/init.cpp
+++ b/divi/src/init.cpp
@@ -853,7 +853,7 @@ BlockLoadingStatus TryToLoadBlocks(std::string& strLoadError)
 
             LOCK(cs_main);
             const ActiveChainManager& chainManager = GetActiveChainManager();
-            CVerifyDB dbVerifier(
+            const CVerifyDB dbVerifier(
                 chainManager,
                 chainActive,
                 uiInterface,

--- a/divi/src/main.cpp
+++ b/divi/src/main.cpp
@@ -605,7 +605,7 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState& state, const CTransa
         CAmount nValueIn = 0;
         {
             LOCK(pool.cs);
-            CCoinsViewMemPool viewMemPool(pcoinsTip, pool);
+            const CCoinsViewMemPool viewMemPool(pcoinsTip, pool);
             view.SetBackend(viewMemPool);
 
             // do we already have it?

--- a/divi/src/rpcblockchain.cpp
+++ b/divi/src/rpcblockchain.cpp
@@ -501,7 +501,7 @@ Value verifychain(const Array& params, bool fHelp)
 
     LOCK(cs_main);
     const ActiveChainManager& chainManager = GetActiveChainManager();
-    CVerifyDB dbVerifier(
+    const CVerifyDB dbVerifier(
         chainManager,
         chainActive,
         uiInterface,

--- a/divi/src/rpcrawtransaction.cpp
+++ b/divi/src/rpcrawtransaction.cpp
@@ -708,8 +708,8 @@ Value signrawtransaction(const Array& params, bool fHelp)
     CCoinsViewCache view;
     {
         LOCK(mempool.cs);
-        CCoinsViewCache& viewChain = *pcoinsTip;
-        CCoinsViewMemPool viewMempool(&viewChain, mempool);
+        const CCoinsViewCache& viewChain = *pcoinsTip;
+        const CCoinsViewMemPool viewMempool(&viewChain, mempool);
         view.SetBackend(viewMempool); // temporarily switch cache backend to db+mempool view
 
         BOOST_FOREACH (const CTxIn& txin, mergedTx.vin) {
@@ -842,9 +842,8 @@ Value signrawtransaction(const Array& params, bool fHelp)
 static std::pair<CAmount,bool> ComputeFeeTotalsAndIfInputsAreKnown(const CTransaction& tx)
 {
     LOCK(mempool.cs);
-    CCoinsViewCache view;
-    CCoinsViewMemPool viewMemPool(pcoinsTip, mempool);
-    view.SetBackend(viewMemPool);
+    const CCoinsViewMemPool viewMemPool(pcoinsTip, mempool);
+    const CCoinsViewCache view(&viewMemPool);
 
     if(!view.HaveInputs(tx))
     {

--- a/divi/src/test/kernel_tests.cpp
+++ b/divi/src/test/kernel_tests.cpp
@@ -38,7 +38,7 @@ protected:
   std::vector<COutPoint> nonVaultCoins;
 
   CheckCoinstakeForVaultsTestFixture()
-    : coins(nullptr), rewards(CENT, 0, 0, 0, 0, 0)
+    : rewards(CENT, 0, 0, 0, 0, 0)
   {
     const std::vector<unsigned char> key1(20, 'x');
     const std::vector<unsigned char> key2(20, 'y');

--- a/divi/src/txmempool.cpp
+++ b/divi/src/txmempool.cpp
@@ -56,7 +56,7 @@ CTxMemPool::~CTxMemPool()
     feePolicyEstimator.reset();
 }
 
-void CTxMemPool::pruneSpent(const uint256& hashTx, CCoins& coins)
+void CTxMemPool::pruneSpent(const uint256& hashTx, CCoins& coins) const
 {
     LOCK(cs);
 
@@ -568,7 +568,7 @@ void CTxMemPool::ClearPrioritisation(const uint256 hash)
 }
 
 
-CCoinsViewMemPool::CCoinsViewMemPool(CCoinsView* baseIn, CTxMemPool& mempoolIn) : CCoinsViewBacked(baseIn), mempool(mempoolIn) {}
+CCoinsViewMemPool::CCoinsViewMemPool(const CCoinsView* baseIn, const CTxMemPool& mempoolIn) : CCoinsViewBacked(baseIn), mempool(mempoolIn) {}
 
 bool CCoinsViewMemPool::GetCoins(const uint256& txid, CCoins& coins) const
 {

--- a/divi/src/txmempool.h
+++ b/divi/src/txmempool.h
@@ -121,7 +121,7 @@ public:
     void removeConfirmedTransactions(const std::vector<CTransaction>& vtx, unsigned int nBlockHeight, std::list<CTransaction>& conflicts);
     void clear();
     void queryHashes(std::vector<uint256>& vtxid);
-    void pruneSpent(const uint256& hash, CCoins& coins);
+    void pruneSpent(const uint256& hash, CCoins& coins) const;
     unsigned int GetTransactionsUpdated() const;
     void AddTransactionsUpdated(unsigned int n);
 
@@ -184,10 +184,10 @@ public:
 class CCoinsViewMemPool : public CCoinsViewBacked
 {
 protected:
-    CTxMemPool& mempool;
+    const CTxMemPool& mempool;
 
 public:
-    CCoinsViewMemPool(CCoinsView* baseIn, CTxMemPool& mempoolIn);
+    CCoinsViewMemPool(const CCoinsView* baseIn, const CTxMemPool& mempoolIn);
     bool GetCoins(const uint256& txid, CCoins& coins) const override;
     bool HaveCoins(const uint256& txid) const override;
     bool GetCoinsAndPruneSpent(const uint256& txid,CCoins& coins) const;

--- a/divi/src/verifyDb.cpp
+++ b/divi/src/verifyDb.cpp
@@ -26,7 +26,7 @@ bool CheckBlock(const CBlock& block, CValidationState& state, bool fCheckMerkleR
 
 CVerifyDB::CVerifyDB(
     const ActiveChainManager& chainManager,
-    CChain& activeChain,
+    const CChain& activeChain,
     CClientUIInterface& clientInterface,
     const unsigned& coinsCacheSize,
     ShutdownListener shutdownListener
@@ -44,7 +44,7 @@ CVerifyDB::~CVerifyDB()
     clientInterface_.ShowProgress("", 100);
 }
 
-bool CVerifyDB::VerifyDB(CCoinsView* coinsview, unsigned coinsTipCacheSize, int nCheckLevel, int nCheckDepth)
+bool CVerifyDB::VerifyDB(const CCoinsView* coinsview, unsigned coinsTipCacheSize, int nCheckLevel, int nCheckDepth) const
 {
     if (activeChain_.Tip() == NULL || activeChain_.Tip()->pprev == NULL)
         return true;

--- a/divi/src/verifyDb.h
+++ b/divi/src/verifyDb.h
@@ -20,19 +20,19 @@ public:
     typedef bool (*ShutdownListener)();
 private:
     const ActiveChainManager& chainManager_;
-    CChain& activeChain_;
+    const CChain& activeChain_;
     CClientUIInterface& clientInterface_;
     const unsigned coinsCacheSize_;
     ShutdownListener shutdownListener_;
 public:
     CVerifyDB(
         const ActiveChainManager& chainManager,
-        CChain& activeChain,
+        const CChain& activeChain,
         CClientUIInterface& clientInterface,
         const unsigned& coinsCacheSize,
         ShutdownListener shutdownListener);
     ~CVerifyDB();
-    bool VerifyDB(CCoinsView* coinsview, unsigned coinsTipCacheSize, int nCheckLevel, int nCheckDepth);
+    bool VerifyDB(const CCoinsView* coinsview, unsigned coinsTipCacheSize, int nCheckLevel, int nCheckDepth) const;
 };
 
 #endif


### PR DESCRIPTION
This is a collection of changes which improves `const`-ness for code related to coins views.  The main change is that a `CCoinsViewBacked` (and derived classes like `CCoinsViewCache` or `CCoinsViewMemPool`) now also accept a `const` base view, which will still work completely except for `WriteBatch` (which is the only method with write semantics).

Many places in the code actually use `CCoinsViewCache` precisely for the reason of doing temporary write operations on top of an assumed const base UTXO set.  With this change, we can properly declare and enforce this at compile time by making the base coins actually `const`.