### PR TITLE
Constness fixes for CBlock(Index)

### DIFF
--- a/divi/src/ActiveChainManager.cpp
+++ b/divi/src/ActiveChainManager.cpp
@@ -66,7 +66,7 @@ static bool CheckTxReversalStatus(const TxReversalStatus status, bool& fClean)
 bool ActiveChainManager::DisconnectBlock(
     CBlock& block,
     CValidationState& state,
-    CBlockIndex* pindex,
+    const CBlockIndex* pindex,
     CCoinsViewCache& view,
     bool* pfClean) const
 {
@@ -124,7 +124,7 @@ bool ActiveChainManager::DisconnectBlock(
 void ActiveChainManager::DisconnectBlock(
     std::pair<CBlock,bool>& disconnectedBlockAndStatus,
     CValidationState& state,
-    CBlockIndex* pindex,
+    const CBlockIndex* pindex,
     CCoinsViewCache& coins) const
 {
     CBlock& block = disconnectedBlockAndStatus.first;

--- a/divi/src/ActiveChainManager.h
+++ b/divi/src/ActiveChainManager.h
@@ -34,13 +34,13 @@ public:
     bool DisconnectBlock(
         CBlock& block,
         CValidationState& state,
-        CBlockIndex* pindex,
+        const CBlockIndex* pindex,
         CCoinsViewCache& coins,
         bool* pfClean = nullptr) const;
     void DisconnectBlock(
         std::pair<CBlock,bool>& disconnectedBlockAndStatus,
         CValidationState& state,
-        CBlockIndex* pindex,
+        const CBlockIndex* pindex,
         CCoinsViewCache& coins) const;
 };
 #endif// ACTIVE_CHAIN_MANAGER_H

--- a/divi/src/BlockDiskAccessor.cpp
+++ b/divi/src/BlockDiskAccessor.cpp
@@ -25,7 +25,7 @@ bool CheckDiskSpace(uint64_t nAdditionalBytes)
     return true;
 }
 
-bool WriteBlockToDisk(CBlock& block, CDiskBlockPos& pos)
+bool WriteBlockToDisk(const CBlock& block, CDiskBlockPos& pos)
 {
     // Open history file to append
     CAutoFile fileout(OpenBlockFile(pos), SER_DISK, CLIENT_VERSION);

--- a/divi/src/BlockDiskAccessor.h
+++ b/divi/src/BlockDiskAccessor.h
@@ -8,7 +8,7 @@ class CBlockIndex;
 
 /** Functions for disk access for blocks */
 bool CheckDiskSpace(uint64_t nAdditionalBytes = 0);
-bool WriteBlockToDisk(CBlock& block, CDiskBlockPos& pos);
+bool WriteBlockToDisk(const CBlock& block, CDiskBlockPos& pos);
 bool ReadBlockFromDisk(CBlock& block, const CDiskBlockPos& pos);
 bool ReadBlockFromDisk(CBlock& block, const CBlockIndex* pindex);
 

--- a/divi/src/BlocksInFlightRegistry.cpp
+++ b/divi/src/BlocksInFlightRegistry.cpp
@@ -36,7 +36,7 @@ void BlocksInFlightRegistry::MarkBlockAsReceived(const uint256& hash)
 }
 
 // Requires cs_main.
-void BlocksInFlightRegistry::MarkBlockAsInFlight(NodeId nodeId, const uint256& hash, CBlockIndex* pindex)
+void BlocksInFlightRegistry::MarkBlockAsInFlight(NodeId nodeId, const uint256& hash, const CBlockIndex* pindex)
 {
     assert(nodeSyncByNodeId_.count(nodeId)>0);
     // Make sure it's not listed somewhere already.

--- a/divi/src/BlocksInFlightRegistry.h
+++ b/divi/src/BlocksInFlightRegistry.h
@@ -43,7 +43,7 @@ public:
     void RegisterNodedId(NodeId nodeId);
     void UnregisterNodeId(NodeId nodeId);
     void MarkBlockAsReceived(const uint256& hash);
-    void MarkBlockAsInFlight(NodeId nodeId, const uint256& hash, CBlockIndex* pindex = nullptr);
+    void MarkBlockAsInFlight(NodeId nodeId, const uint256& hash, const CBlockIndex* pindex = nullptr);
     bool BlockIsInFlight(const uint256& hash);
     NodeId GetSourceOfInFlightBlock(const uint256& hash);
 

--- a/divi/src/CoinMinter.cpp
+++ b/divi/src/CoinMinter.cpp
@@ -84,7 +84,7 @@ bool CoinMinter::satisfiesMintingRequirements() const
     const unsigned oneReorgWorthOfTimestampDrift = 60*chainParameters_.MaxReorganizationDepth();
     const unsigned minimumChainTipTimestampForMinting = GetTime() - oneReorgWorthOfTimestampDrift;
 
-    CBlockIndex* chainTip = chain_.Tip();
+    const CBlockIndex* chainTip = chain_.Tip();
     bool chainTipIsSyncedEnough = !(chainTip? chainTip->nTime < minimumChainTipTimestampForMinting: IsBlockchainSynced());
     bool stakingRequirementsAreMet =
         chainTipIsSyncedEnough &&
@@ -95,7 +95,7 @@ bool CoinMinter::satisfiesMintingRequirements() const
 }
 bool CoinMinter::limitStakingSpeed() const
 {
-    CBlockIndex* chainTip = chain_.Tip();
+    const CBlockIndex* chainTip = chain_.Tip();
     if (chainTip && mapHashedBlocks_.count(chainTip->nHeight)) //search our map of hashed blocks, see if bestblock has been hashed yet
     {
         if (GetTime() - mapHashedBlocks_[chainTip->nHeight] < static_cast<int64_t>(hashingDelay)/2 )

--- a/divi/src/LegacyPoSStakeModifierService.cpp
+++ b/divi/src/LegacyPoSStakeModifierService.cpp
@@ -32,7 +32,7 @@ uint64_t LegacyPoSStakeModifierService::GetKernelStakeModifier(const uint256& ha
     int64_t timeStampOfSelectedBlock = stakeTransactionBlockIndex.GetBlockTime();
     const int64_t timeWindowForSelectingStakeModifier = GetStakeModifierSelectionInterval();
     const CBlockIndex* pindex = &stakeTransactionBlockIndex;
-    CBlockIndex* pindexNext = activeChain_[stakeTransactionBlockIndex.nHeight + 1];
+    const CBlockIndex* pindexNext = activeChain_[stakeTransactionBlockIndex.nHeight + 1];
 
     // loop to find the stake modifier later by a selection interval
     while (timeStampOfSelectedBlock < stakeTransactionBlockIndex.GetBlockTime() + timeWindowForSelectingStakeModifier) {

--- a/divi/src/LotteryWinnersCalculator.cpp
+++ b/divi/src/LotteryWinnersCalculator.cpp
@@ -60,7 +60,7 @@ bool LotteryWinnersCalculator::IsCoinstakeValidForLottery(const CTransaction &tx
     return nAmount > minimumCoinstakeForTicket(nHeight); // only if stake is more than 10k
 }
 
-CBlockIndex* LotteryWinnersCalculator::GetLastLotteryBlockIndexBeforeHeight(int blockHeight) const
+const CBlockIndex* LotteryWinnersCalculator::GetLastLotteryBlockIndexBeforeHeight(int blockHeight) const
 {
     const int lotteryBlockPaymentCycle = superblockHeightValidator_.GetLotteryBlockPaymentCycle(blockHeight);
     const int nLastLotteryHeight = std::max(startOfLotteryBlocks_,  lotteryBlockPaymentCycle* ((blockHeight - 1) / lotteryBlockPaymentCycle) );
@@ -74,7 +74,7 @@ bool LotteryWinnersCalculator::IsPaymentScriptVetoed(const CScript& paymentScrip
     constexpr int numberOfLotteryCyclesToVetoFor = 3;
     for (int lotteryCycleCount = 0; lotteryCycleCount < numberOfLotteryCyclesToVetoFor; ++lotteryCycleCount)
     {
-        CBlockIndex* blockIndexPreceedingPriorLotteryBlock = activeChain_[ nLastLotteryHeight-lotteryBlockPaymentCycle*lotteryCycleCount-1];
+        const CBlockIndex* blockIndexPreceedingPriorLotteryBlock = activeChain_[ nLastLotteryHeight-lotteryBlockPaymentCycle*lotteryCycleCount-1];
         if(!blockIndexPreceedingPriorLotteryBlock)
         {
             return false;
@@ -153,7 +153,7 @@ RankedScoreAwareCoinstakes LotteryWinnersCalculator::computeRankedScoreAwareCoin
 
 bool LotteryWinnersCalculator::UpdateCoinstakes(int nextBlockHeight, LotteryCoinstakes& updatedCoinstakes) const
 {
-    CBlockIndex* lastLotteryBlockIndex = GetLastLotteryBlockIndexBeforeHeight(nextBlockHeight);
+    const CBlockIndex* lastLotteryBlockIndex = GetLastLotteryBlockIndexBeforeHeight(nextBlockHeight);
     ActivationState activations(lastLotteryBlockIndex);
     if(activations.IsActive(Fork::UniformLotteryWinners) &&
         IsPaymentScriptVetoed(updatedCoinstakes.back().second,nextBlockHeight))

--- a/divi/src/LotteryWinnersCalculator.h
+++ b/divi/src/LotteryWinnersCalculator.h
@@ -39,7 +39,7 @@ public:
     static RankedScoreAwareCoinstakes computeRankedScoreAwareCoinstakes(
         const uint256& lastLotteryBlockHash, const LotteryCoinstakes& updatedCoinstakes);
     bool IsCoinstakeValidForLottery(const CTransaction &tx, int nHeight) const;
-    CBlockIndex* GetLastLotteryBlockIndexBeforeHeight(int blockHeight) const;
+    const CBlockIndex* GetLastLotteryBlockIndexBeforeHeight(int blockHeight) const;
     bool UpdateCoinstakes(int nextBlockHeight, LotteryCoinstakes& updatedCoinstakes) const;
     LotteryCoinstakeData CalculateUpdatedLotteryWinners(const CTransaction& coinMintTransaction, const LotteryCoinstakeData& previousBlockLotteryCoinstakeData, int nHeight) const;
 };

--- a/divi/src/NodeState.h
+++ b/divi/src/NodeState.h
@@ -37,11 +37,11 @@ public:
     //! String name of this peer (debugging/logging purposes).
     std::string name;
     //! The best known block we know this peer has announced.
-    CBlockIndex* pindexBestKnownBlock;
+    const CBlockIndex* pindexBestKnownBlock;
     //! The hash of the last unknown block this peer has announced.
     uint256 hashLastUnknownBlock;
     //! The last full block we both have.
-    CBlockIndex* pindexLastCommonBlock;
+    const CBlockIndex* pindexLastCommonBlock;
     //! Whether we consider this a preferred download peer.
     bool fPreferredDownload;
 

--- a/divi/src/NodeStateRegistry.cpp
+++ b/divi/src/NodeStateRegistry.cpp
@@ -71,7 +71,7 @@ void MarkBlockAsReceived(const uint256& hash)
 }
 
 // Requires cs_main.
-void MarkBlockAsInFlight(NodeId nodeid, const uint256& hash, CBlockIndex* pindex)
+void MarkBlockAsInFlight(NodeId nodeid, const uint256& hash, const CBlockIndex* pindex)
 {
     AssertLockHeld(cs_main);
     blocksInFlightRegistry.MarkBlockAsInFlight(nodeid,hash,pindex);
@@ -148,7 +148,7 @@ void FindNextBlocksToDownload(
     const CChain& activeChain,
     CNodeState* state,
     unsigned int count,
-    std::vector<CBlockIndex*>& vBlocks,
+    std::vector<const CBlockIndex*>& vBlocks,
     NodeId& nodeStaller)
 {
     if (count == 0)
@@ -177,8 +177,8 @@ void FindNextBlocksToDownload(
     if (state->pindexLastCommonBlock == state->pindexBestKnownBlock)
         return;
 
-    std::vector<CBlockIndex*> vToFetch;
-    CBlockIndex* pindexWalk = state->pindexLastCommonBlock;
+    std::vector<const CBlockIndex*> vToFetch;
+    const CBlockIndex* pindexWalk = state->pindexLastCommonBlock;
     // Never fetch further than the best block we know the peer has, or more than BLOCK_DOWNLOAD_WINDOW + 1 beyond the last
     // linked block we have in common with this peer. The +1 is so we can detect stalling, namely if we would be able to
     // download that next block if the window were 1 larger.
@@ -201,7 +201,7 @@ void FindNextBlocksToDownload(
         // Iterate over those blocks in vToFetch (in forward direction), adding the ones that
         // are not yet downloaded and not in flight to vBlocks. In the mean time, update
         // pindexLastCommonBlock as long as all ancestors are already downloaded.
-        for(CBlockIndex* pindex: vToFetch) {
+        for(const auto* pindex: vToFetch) {
             if (!pindex->IsValid(BLOCK_VALID_TREE)) {
                 // We consider the chain that this peer is on invalid.
                 return;

--- a/divi/src/NodeStateRegistry.h
+++ b/divi/src/NodeStateRegistry.h
@@ -18,7 +18,7 @@ class CBlockReject;
 void InitializeNode(CNodeState& nodeState);
 void FinalizeNode(NodeId nodeId);
 void MarkBlockAsReceived(const uint256& hash);
-void MarkBlockAsInFlight(NodeId nodeid, const uint256& hash, CBlockIndex* pindex = nullptr);
+void MarkBlockAsInFlight(NodeId nodeid, const uint256& hash, const CBlockIndex* pindex = nullptr);
 bool BlockIsInFlight(const uint256& hash);
 void UpdateBlockAvailability(const BlockMap& blockIndicesByHash, CNodeState* state, const uint256& hash);
 void FindNextBlocksToDownload(
@@ -26,7 +26,7 @@ void FindNextBlocksToDownload(
     const CChain& activeChain,
     CNodeState* state,
     unsigned int count,
-    std::vector<CBlockIndex*>& vBlocks,
+    std::vector<const CBlockIndex*>& vBlocks,
     NodeId& nodeStaller);
 
 bool BlockDownloadHasTimedOut(NodeId nodeId, int64_t nNow, int64_t targetSpacing);

--- a/divi/src/QueuedBlock.h
+++ b/divi/src/QueuedBlock.h
@@ -6,7 +6,7 @@ class CBlockIndex;
 /** Blocks that are in flight, and that are in the queue to be downloaded. Protected by cs_main. */
 struct QueuedBlock {
     uint256 hash;
-    CBlockIndex* pindex;        //! Optional.
+    const CBlockIndex* pindex;        //! Optional.
     int64_t nTime;              //! Time of "getdata" request in microseconds.
     int nValidatedQueuedBefore; //! Number of blocks queued with validated headers (globally) at the time this one is requested.
     bool fValidatedHeaders;     //! Whether this block has validated headers at the time of request.

--- a/divi/src/RpcMasternodeFeatures.cpp
+++ b/divi/src/RpcMasternodeFeatures.cpp
@@ -241,7 +241,7 @@ ActiveMasternodeStatus GetActiveMasternodeStatus()
     }
 }
 
-unsigned FindLastPayeePaymentTime(CBlockIndex* chainTip, const MasternodePaymentData& paymentData, const CMasternode& masternode, const unsigned maxBlockDepth)
+unsigned FindLastPayeePaymentTime(const CBlockIndex* chainTip, const MasternodePaymentData& paymentData, const CMasternode& masternode, const unsigned maxBlockDepth)
 {
     assert(chainTip);
     CScript mnPayee = GetScriptForDestination(masternode.pubKeyCollateralAddress.GetID());
@@ -276,7 +276,7 @@ unsigned FindLastPayeePaymentTime(CBlockIndex* chainTip, const MasternodePayment
     return 0u;
 }
 
-std::vector<MasternodeListEntry> GetMasternodeList(std::string strFilter, CBlockIndex* chainTip)
+std::vector<MasternodeListEntry> GetMasternodeList(std::string strFilter, const CBlockIndex* chainTip)
 {
     const auto& mnModule = GetMasternodeModule();
     auto& networkMessageManager = mnModule.getNetworkMessageManager();

--- a/divi/src/RpcMasternodeFeatures.h
+++ b/divi/src/RpcMasternodeFeatures.h
@@ -59,6 +59,6 @@ MasternodeStartResult RelayMasternodeBroadcast(const std::string& hexData, const
 bool SignMasternodeBroadcast(const CKeyStore& keystore, std::string& hexData);
 MasternodeStartResult StartMasternode(const CKeyStore& keyStore, const StoredMasternodeBroadcasts& stored, std::string alias, bool deferRelay);
 ActiveMasternodeStatus GetActiveMasternodeStatus();
-std::vector<MasternodeListEntry> GetMasternodeList(std::string strFilter, CBlockIndex* chainTip);
+std::vector<MasternodeListEntry> GetMasternodeList(std::string strFilter, const CBlockIndex* chainTip);
 MasternodeCountData GetMasternodeCounts(const CBlockIndex* chainTip);
 #endif// RPC_MASTERNODE_FEATURES_H

--- a/divi/src/TransactionDiskAccessor.cpp
+++ b/divi/src/TransactionDiskAccessor.cpp
@@ -20,7 +20,7 @@ extern CChain chainActive;
 /** Return transaction in tx, and if it was found inside a block, its hash is placed in hashBlock */
 bool GetTransaction(const uint256& hash, CTransaction& txOut, uint256& hashBlock, bool fAllowSlow)
 {
-    CBlockIndex* pindexSlow = NULL;
+    const CBlockIndex* pindexSlow = NULL;
     {
         LOCK(cs_main);
         {

--- a/divi/src/WalletRescanner.cpp
+++ b/divi/src/WalletRescanner.cpp
@@ -20,14 +20,14 @@ WalletRescanner::WalletRescanner(
 {
 }
 
-int WalletRescanner::scanForWalletTransactions(CWallet& wallet, CBlockIndex* pindexStart, bool fUpdate)
+int WalletRescanner::scanForWalletTransactions(CWallet& wallet, const CBlockIndex* pindexStart, bool fUpdate)
 {
     static const CCheckpointServices checkpointsVerifier(GetCurrentChainCheckpoints);
 
     int ret = 0;
     int64_t nNow = GetTime();
 
-    CBlockIndex* pindex = pindexStart;
+    const CBlockIndex* pindex = pindexStart;
     {
         LOCK2(mainCS_, wallet.cs_wallet);
         // no need to read and scan block, if block was created before

--- a/divi/src/WalletRescanner.h
+++ b/divi/src/WalletRescanner.h
@@ -13,6 +13,6 @@ class WalletRescanner
     CCriticalSection& mainCS_;
 public:
     WalletRescanner(const I_BlockDataReader& blockReader, const CChain& activeChain, CCriticalSection& mainCS);
-    int scanForWalletTransactions(CWallet& wallet, CBlockIndex* pindexStart, bool fUpdate);
+    int scanForWalletTransactions(CWallet& wallet, const CBlockIndex* pindexStart, bool fUpdate);
 };
 #endif// WALLET_RESCANNER_H

--- a/divi/src/chain.cpp
+++ b/divi/src/chain.cpp
@@ -134,7 +134,7 @@ void CBlockIndex::BuildSkip()
         pskip = pprev->GetAncestor(GetSkipHeight(nHeight));
 }
 
-CBlockIndex* LastCommonAncestor(CBlockIndex* pa, CBlockIndex* pb)
+const CBlockIndex* LastCommonAncestor(const CBlockIndex* pa, const CBlockIndex* pb)
 {
     if (pa->nHeight > pb->nHeight) {
         pa = pa->GetAncestor(pb->nHeight);

--- a/divi/src/chain.h
+++ b/divi/src/chain.h
@@ -553,5 +553,5 @@ public:
 
 /** Find the last common ancestor two blocks have.
  *  Both pa and pb must be non-NULL. */
-CBlockIndex* LastCommonAncestor(CBlockIndex* pa, CBlockIndex* pb);
+const CBlockIndex* LastCommonAncestor(const CBlockIndex* pa, const CBlockIndex* pb);
 #endif // BITCOIN_CHAIN_H

--- a/divi/src/checkpoints.cpp
+++ b/divi/src/checkpoints.cpp
@@ -51,7 +51,7 @@ bool CCheckpointServices::CheckBlock(int nHeight, const uint256& hash, bool fMat
 }
 
 //! Guess how far we are in the verification process at the given block index
-double CCheckpointServices::GuessVerificationProgress(CBlockIndex* pindex, bool useConservativeEstimate) const
+double CCheckpointServices::GuessVerificationProgress(const CBlockIndex* pindex, bool useConservativeEstimate) const
 {
     static const double CONSERVATIVE_VERIFICATION_FACTOR = 5.0;
     if (pindex == NULL)

--- a/divi/src/checkpoints.h
+++ b/divi/src/checkpoints.h
@@ -39,7 +39,7 @@ public:
     //! Returns last CBlockIndex* in mapBlockIndex that is a checkpoint
     CBlockIndex* GetLastCheckpoint(const BlockMap& mapBlockIndex) const;
 
-    double GuessVerificationProgress(CBlockIndex* pindex, bool fSigchecks = true) const;
+    double GuessVerificationProgress(const CBlockIndex* pindex, bool fSigchecks = true) const;
 
     static bool fEnabled;
 }; //class CCheckpoints

--- a/divi/src/init.cpp
+++ b/divi/src/init.cpp
@@ -1043,7 +1043,7 @@ bool CreateNewWalletIfOneIsNotAvailable(std::string strWalletFile, std::ostrings
     return true;
 }
 
-int ScanForWalletTransactions(CWallet& walletToRescan, CBlockIndex* scanStartIndex, bool updateWallet)
+int ScanForWalletTransactions(CWallet& walletToRescan, const CBlockIndex* scanStartIndex, bool updateWallet)
 {
     static BlockDiskDataReader blockReader;
     static WalletRescanner rescanner(blockReader,chainActive,cs_main);
@@ -1053,7 +1053,7 @@ int ScanForWalletTransactions(CWallet& walletToRescan, CBlockIndex* scanStartInd
 void ScanBlockchainForWalletUpdates(std::string strWalletFile, int64_t& nStart)
 {
     BlockDiskDataReader blockReader;
-    CBlockIndex* pindexRescan = chainActive.Tip();
+    const CBlockIndex* pindexRescan = chainActive.Tip();
     if (settings.GetBoolArg("-rescan", false))
         pindexRescan = chainActive.Genesis();
     else {

--- a/divi/src/init.h
+++ b/divi/src/init.h
@@ -24,7 +24,7 @@ void Shutdown();
 void EnableMainSignals();
 void EnableUnitTestSignals();
 bool InitializeDivi(boost::thread_group& threadGroup);
-int ScanForWalletTransactions(CWallet& walletToRescan, CBlockIndex* scanStartIndex, bool updateWallet = false);
+int ScanForWalletTransactions(CWallet& walletToRescan, const CBlockIndex* scanStartIndex, bool updateWallet = false);
 void InitializeWallet(std::string strWalletFile);
 void DeallocateWallet();
 #endif // BITCOIN_INIT_H

--- a/divi/src/main.cpp
+++ b/divi/src/main.cpp
@@ -1222,7 +1222,7 @@ static int64_t nTimePostConnect = 0;
  * Connect a new block to chainActive. pblock is either NULL or a pointer to a CBlock
  * corresponding to pindexNew, to bypass loading it again from disk.
  */
-bool static ConnectTip(CValidationState& state, CBlockIndex* pindexNew, CBlock* pblock, bool fAlreadyChecked)
+bool static ConnectTip(CValidationState& state, CBlockIndex* pindexNew, const CBlock* pblock, bool fAlreadyChecked)
 {
     AssertLockHeld(cs_main);
     assert(pindexNew->pprev == chainActive.Tip());
@@ -1386,7 +1386,7 @@ static void PruneBlockIndexCandidates()
  * Try to make some progress towards making pindexMostWork the active block.
  * pblock is either NULL or a pointer to a CBlock corresponding to pindexMostWork.
  */
-static bool ActivateBestChainStep(CValidationState& state, CBlockIndex* pindexMostWork, CBlock* pblock, bool fAlreadyChecked)
+static bool ActivateBestChainStep(CValidationState& state, CBlockIndex* pindexMostWork, const CBlock* pblock, bool fAlreadyChecked)
 {
     AssertLockHeld(cs_main);
     if (pblock == NULL)
@@ -1458,7 +1458,7 @@ static bool ActivateBestChainStep(CValidationState& state, CBlockIndex* pindexMo
  * or an activated best chain. pblock is either NULL or a pointer to a block
  * that is already loaded (to avoid loading it again from disk).
  */
-bool ActivateBestChain(CValidationState& state, CBlock* pblock, bool fAlreadyChecked)
+bool ActivateBestChain(CValidationState& state, const CBlock* pblock, bool fAlreadyChecked)
 {
     CBlockIndex* pindexNewTip = NULL;
     CBlockIndex* pindexMostWork = NULL;
@@ -2340,7 +2340,7 @@ bool InitBlockIndex()
     // Only add the genesis block if not reindexing (in which case we reuse the one already on disk)
     if (!fReindex) {
         try {
-            CBlock& block = const_cast<CBlock&>(Params().GenesisBlock());
+            const CBlock& block = Params().GenesisBlock();
             // Start new block file
             unsigned int nBlockSize = ::GetSerializeSize(block, SER_DISK, CLIENT_VERSION);
             CDiskBlockPos blockPos;

--- a/divi/src/main.h
+++ b/divi/src/main.h
@@ -145,7 +145,7 @@ bool AcceptBlock(CBlock& block, CValidationState& state, CBlockIndex** pindex, C
 bool AcceptBlockHeader(const CBlockHeader& block, CValidationState& state, CBlockIndex** ppindex = NULL);
 
 /** Find the last common block between the parameter chain and a locator. */
-CBlockIndex* FindForkInGlobalIndex(const CChain& chain, const CBlockLocator& locator);
+const CBlockIndex* FindForkInGlobalIndex(const CChain& chain, const CBlockLocator& locator);
 
 /** Mark a block as invalid. */
 bool InvalidateBlock(CValidationState& state, CBlockIndex* pindex);

--- a/divi/src/main.h
+++ b/divi/src/main.h
@@ -92,7 +92,7 @@ std::string GetWarnings(std::string strFor);
 bool DisconnectBlocksAndReprocess(int blocks);
 
 // ***TODO***
-bool ActivateBestChain(CValidationState& state, CBlock* pblock = NULL, bool fAlreadyChecked = false);
+bool ActivateBestChain(CValidationState& state, const CBlock* pblock = nullptr, bool fAlreadyChecked = false);
 
 /** (try to) add transaction to memory pool **/
 bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState& state, const CTransaction& tx, bool fLimitFree, bool* pfMissingInputs = nullptr, bool ignoreFees = false);

--- a/divi/src/masternode-payments.cpp
+++ b/divi/src/masternode-payments.cpp
@@ -334,7 +334,7 @@ bool CMasternodePayments::IsScheduled(const CScript mnpayee, int nNotBlockHeight
 {
     LOCK(cs_mapMasternodeBlocks);
 
-    CBlockIndex* tip = activeChain_.Tip();
+    const CBlockIndex* tip = activeChain_.Tip();
     if (tip == nullptr)
         return false;
 

--- a/divi/src/rpcblockchain.cpp
+++ b/divi/src/rpcblockchain.cpp
@@ -40,7 +40,7 @@ extern bool fAddressIndex;
 extern BlockMap mapBlockIndex;
 extern CCriticalSection cs_main;
 extern CTxMemPool mempool;
-extern CBlockIndex* pindexBestHeader;
+extern const CBlockIndex* pindexBestHeader;
 extern CChain chainActive;
 
 double GetDifficulty(const CBlockIndex* blockindex)
@@ -104,7 +104,7 @@ Object blockToJSON(const CBlock& block, const CBlockIndex* blockindex, bool txDe
 
     if (blockindex->pprev)
         result.push_back(Pair("previousblockhash", blockindex->pprev->GetBlockHash().GetHex()));
-    CBlockIndex* pnext = chainActive.Next(blockindex);
+    const CBlockIndex* pnext = chainActive.Next(blockindex);
     if (pnext)
         result.push_back(Pair("nextblockhash", pnext->GetBlockHash().GetHex()));
 
@@ -259,7 +259,7 @@ Value getblockhash(const Array& params, bool fHelp)
     if (nHeight < 0 || nHeight > chainActive.Height())
         throw JSONRPCError(RPC_INVALID_PARAMETER, "Block height out of range");
 
-    CBlockIndex* pblockindex = chainActive[nHeight];
+    const CBlockIndex* pblockindex = chainActive[nHeight];
     return pblockindex->GetBlockHash().GetHex();
 }
 

--- a/divi/src/rpcdump.cpp
+++ b/divi/src/rpcdump.cpp
@@ -295,7 +295,7 @@ Value importwallet(const Array& params, bool fHelp)
     file.close();
     pwalletMain->ShowProgress("", 100); // hide progress dialog in GUI
 
-    CBlockIndex* pindex = chainActive.Tip();
+    const CBlockIndex* pindex = chainActive.Tip();
     while (pindex && pindex->pprev && pindex->GetBlockTime() > nTimeBegin - 7200)
         pindex = pindex->pprev;
 

--- a/divi/src/rpcmasternode.cpp
+++ b/divi/src/rpcmasternode.cpp
@@ -386,7 +386,7 @@ Value listmasternodes(const Array& params, bool fHelp)
             HelpExampleCli("masternodelist", "") + HelpExampleRpc("masternodelist", ""));
 
     Array ret;
-    CBlockIndex* pindex;
+    const CBlockIndex* pindex;
     {
         LOCK(cs_main);
         pindex = chainActive.Tip();
@@ -638,7 +638,7 @@ Value getmasternodewinners (const Array& params, bool fHelp)
             HelpExampleCli("getmasternodewinners", "") + HelpExampleRpc("getmasternodewinners", ""));
 
     int nHeight;
-    CBlockIndex* pindex = nullptr;
+    const CBlockIndex* pindex = nullptr;
     {
         LOCK(cs_main);
         pindex = chainActive.Tip();

--- a/divi/src/rpcmisc.cpp
+++ b/divi/src/rpcmisc.cpp
@@ -799,8 +799,8 @@ Value getaddressdeltas(const Array& params, bool fHelp)
             throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Start or end is outside chain range");
         }
 
-        CBlockIndex* startIndex = chainActive[start];
-        CBlockIndex* endIndex = chainActive[end];
+        const CBlockIndex* startIndex = chainActive[start];
+        const CBlockIndex* endIndex = chainActive[end];
 
         Object startInfo;
         Object endInfo;

--- a/divi/src/rpcwallet.cpp
+++ b/divi/src/rpcwallet.cpp
@@ -2188,7 +2188,7 @@ Value listsinceblock(const Array& params, bool fHelp)
             ParseTransactionDetails(*pwalletMain, tx, "*", 0, true, transactions, filter);
     }
 
-    CBlockIndex* pblockLast = chainActive[chainActive.Height() + 1 - target_confirms];
+    const CBlockIndex* pblockLast = chainActive[chainActive.Height() + 1 - target_confirms];
     uint256 lastblock = pblockLast ? pblockLast->GetBlockHash() : 0;
 
     Object ret;

--- a/divi/src/spork.cpp
+++ b/divi/src/spork.cpp
@@ -38,7 +38,7 @@ extern std::map<uint256, int64_t> mapRejectedBlocks;
 
 extern bool ReconsiderBlock(CValidationState& state, CBlockIndex* pindex);
 extern bool DisconnectBlocksAndReprocess(int blocks);
-extern bool ActivateBestChain(CValidationState& state, CBlock* pblock = NULL, bool fAlreadyChecked = false);
+extern bool ActivateBestChain(CValidationState& state, const CBlock* pblock = nullptr, bool fAlreadyChecked = false);
 
 CAmount nTransactionValueMultiplier = 10000; // 1 / 0.0001 = 10000;
 unsigned int nTransactionSizeMultiplier = 300;

--- a/divi/src/test/PoSStakeModifierService_tests.cpp
+++ b/divi/src/test/PoSStakeModifierService_tests.cpp
@@ -57,7 +57,7 @@ public:
     {
         return *(fakeBlockIndexWithHashes_->activeChain);
     }
-    uint64_t getLastStakeModifier(CBlockIndex* currentIndex) const
+    uint64_t getLastStakeModifier(const CBlockIndex* currentIndex) const
     {
         assert(currentIndex);
         while(currentIndex && currentIndex->pprev && !currentIndex->GeneratedStakeModifier())
@@ -67,7 +67,7 @@ public:
         assert(currentIndex->GeneratedStakeModifier());
         return currentIndex->nStakeModifier;
     }
-    uint64_t getExpectedStakeModifier(CBlockIndex* currentIndex) const
+    uint64_t getExpectedStakeModifier(const CBlockIndex* currentIndex) const
     {
         assert(currentIndex);
         CHashWriter hasher(SER_GETHASH,0);
@@ -125,7 +125,7 @@ BOOST_AUTO_TEST_CASE(willDelegateToDecoradtedStakeModifierServiceBefore2021)
     Init(100, unixTimestampDecember31st2020Midnight - 3600);
     ON_CALL(*mockStakeModifierService_,getStakeModifier(_)).WillByDefault(Return(defaultStakeModifierQueryResult));
     StakingData stakingData;
-    CBlockIndex* currentBlockIndex = getActiveChain().Tip();
+    const CBlockIndex* currentBlockIndex = getActiveChain().Tip();
     while(currentBlockIndex)
     {
         if(currentBlockIndex->GetBlockTime() < unixTimestampDecember31st2020Midnight)

--- a/divi/src/verifyDb.cpp
+++ b/divi/src/verifyDb.cpp
@@ -58,10 +58,10 @@ bool CVerifyDB::VerifyDB(const CCoinsView* coinsview, unsigned coinsTipCacheSize
     LogPrintf("Verifying last %i blocks at level %i\n", nCheckDepth, nCheckLevel);
     CCoinsViewCache coins(coinsview);
     CBlockIndex* pindexState = activeChain_.Tip();
-    CBlockIndex* pindexFailure = NULL;
+    const CBlockIndex* pindexFailure = nullptr;
     int nGoodTransactions = 0;
     CValidationState state;
-    for (CBlockIndex* pindex = activeChain_.Tip(); pindex && pindex->pprev; pindex = pindex->pprev) {
+    for (const CBlockIndex* pindex = activeChain_.Tip(); pindex && pindex->pprev; pindex = pindex->pprev) {
         boost::this_thread::interruption_point();
         const double fractionOfBlocksChecked = (double)(activeChain_.Height() - pindex->nHeight) / (double)nCheckDepth;
         const int fractionAsProgressPercentage = static_cast<int>(fractionOfBlocksChecked * (nCheckLevel >= 4 ? 50 : 100));


### PR DESCRIPTION
This is a set of straight-forward changes that mark `CBlock` and `CBlockIndex` usages in the code `const` where that can/should be done.  It is not meant to be exhaustive, there are still many more places that use incorrect constness.

Note that `CBlockIndex` in particular is often referenced non-const in the current code, while most `CBlockIndex` instances are actually read-only once validated and attached to a chain.