### PR TITLE
Introduce ChainstateManager

### DIFF
--- a/divi/src/BlockMemoryPoolTransactionCollector.cpp
+++ b/divi/src/BlockMemoryPoolTransactionCollector.cpp
@@ -89,7 +89,7 @@ public:
 
 BlockMemoryPoolTransactionCollector::BlockMemoryPoolTransactionCollector(
     const Settings& settings,
-    CCoinsViewCache* baseCoinsViewCache,
+    const CCoinsViewCache* baseCoinsViewCache,
     const CChain& activeChain,
     const BlockMap& blockIndexMap,
     CTxMemPool& mempool,
@@ -193,7 +193,7 @@ void BlockMemoryPoolTransactionCollector::AddTransactionToBlock(
 std::vector<TxPriority> BlockMemoryPoolTransactionCollector::ComputeMempoolTransactionPriorities(
     const int& nHeight,
     DependingTransactionsMap& dependentTransactions,
-    CCoinsViewCache& view) const
+    const CCoinsViewCache& view) const
 {
     std::vector<TxPriority> vecPriority;
     vecPriority.reserve(mempool_.mapTx.size());

--- a/divi/src/BlockMemoryPoolTransactionCollector.h
+++ b/divi/src/BlockMemoryPoolTransactionCollector.h
@@ -76,7 +76,7 @@ class BlockMemoryPoolTransactionCollector: public I_BlockTransactionCollector
 private:
     using DependingTransactionsMap = std::map<uint256, std::vector<std::shared_ptr<COrphan>>>;
 
-    CCoinsViewCache* baseCoinsViewCache_;
+    const CCoinsViewCache* baseCoinsViewCache_;
     const CChain& activeChain_;
     const BlockMap& blockIndexMap_;
     CTxMemPool& mempool_;
@@ -117,7 +117,7 @@ private:
     std::vector<TxPriority> ComputeMempoolTransactionPriorities(
         const int& nHeight,
         DependingTransactionsMap& mapDependers,
-        CCoinsViewCache& view) const;
+        const CCoinsViewCache& view) const;
 
     bool ShouldSwitchToPriotizationByFee(
         const uint64_t& currentBlockSize,
@@ -135,7 +135,7 @@ private:
 public:
     BlockMemoryPoolTransactionCollector(
         const Settings& settings,
-        CCoinsViewCache* baseCoinsViewCache,
+        const CCoinsViewCache* baseCoinsViewCache,
         const CChain& activeChain,
         const BlockMap& blockIndexMap,
         CTxMemPool& mempool,

--- a/divi/src/ChainstateManager.cpp
+++ b/divi/src/ChainstateManager.cpp
@@ -1,0 +1,11 @@
+#include "ChainstateManager.h"
+
+extern BlockMap mapBlockIndex;
+extern CChain chainActive;
+extern CBlockTreeDB* pblocktree;
+extern CCoinsViewCache* pcoinsTip;
+
+ChainstateManager::ChainstateManager ()
+  : blockMap(mapBlockIndex), activeChain(chainActive),
+    blockTree(*pblocktree), coinsTip(*pcoinsTip)
+{}

--- a/divi/src/ChainstateManager.h
+++ b/divi/src/ChainstateManager.h
@@ -1,0 +1,80 @@
+#ifndef CHAINSTATE_MANAGER_H
+#define CHAINSTATE_MANAGER_H
+
+class BlockMap;
+class CBlockTreeDB;
+class CChain;
+class CCoinsViewCache;
+
+/** The main class that encapsulates the blockchain state (including active
+ *  chain and the block-index map).  All code that modifies or reads the
+ *  blockchain state should do it through an instance of this class.  */
+class ChainstateManager
+{
+
+private:
+
+  BlockMap& blockMap;
+  CChain& activeChain;
+  CBlockTreeDB& blockTree;
+  CCoinsViewCache& coinsTip;
+
+public:
+
+  /** Constructs a fresh instance that refers to the globals.
+   *
+   *  TODO: Remove the globals and instead make the instances held
+   *  by the ChainstateManager instance.  */
+  ChainstateManager ();
+
+  inline BlockMap&
+  GetBlockMap ()
+  {
+    return blockMap;
+  }
+
+  inline const BlockMap&
+  GetBlockMap () const
+  {
+    return blockMap;
+  }
+
+  inline CChain&
+  ActiveChain ()
+  {
+    return activeChain;
+  }
+
+  inline const CChain&
+  ActiveChain () const
+  {
+    return activeChain;
+  }
+
+  inline CBlockTreeDB&
+  BlockTree ()
+  {
+    return blockTree;
+  }
+
+  inline const CBlockTreeDB&
+  BlockTree () const
+  {
+    return blockTree;
+  }
+
+  inline CCoinsViewCache&
+  CoinsTip ()
+  {
+    return coinsTip;
+  }
+
+  inline const CCoinsViewCache&
+  CoinsTip () const
+  {
+    return coinsTip;
+  }
+
+};
+
+#endif // CHAINSTATE_MANAGER_H

--- a/divi/src/CoinMintingModule.h
+++ b/divi/src/CoinMintingModule.h
@@ -5,21 +5,19 @@
 #include <vector>
 #include <boost/thread/recursive_mutex.hpp>
 class I_StakingWallet;
-class CChain;
 class CChainParams;
+class ChainstateManager;
 class CNode;
 class CMasternodeSync;
 typedef std::map<unsigned int, unsigned int> BlockTimestampsByHeight;
 class I_BlockFactory;
 class CTxMemPool;
 class CCriticalSection;
-class BlockMap;
 class I_CoinMinter;
 class I_BlockTransactionCollector;
 class I_PoSTransactionCreator;
 class SuperblockSubsidyContainer;
 class BlockIncentivesPopulator;
-class BlockMap;
 class CMasternodePayments;
 class ProofOfStakeModule;
 class CSporkManager;
@@ -43,11 +41,9 @@ public:
         const Settings& settings,
         CCriticalSection& mainCS,
         const CChainParams& chainParameters,
-        const CChain& activeChain,
-        const BlockMap& blockIndexByHash,
+        const ChainstateManager& chainstate,
         const MasternodeModule& masternodeModule,
         const CFeeRate& relayTxFeeCalculator,
-        CCoinsViewCache* baseCoinsViewCache,
         CTxMemPool& mempool,
         const I_PeerBlockNotifyService& peers,
         I_StakingWallet& wallet,

--- a/divi/src/Makefile.am
+++ b/divi/src/Makefile.am
@@ -209,6 +209,7 @@ BITCOIN_CORE_H = \
   BlockUndo.h \
   ValidationState.h \
   ActiveChainManager.h \
+  ChainstateManager.h \
   IndexDatabaseUpdateCollector.h \
   NodeState.h \
   NodeStateRegistry.h \
@@ -410,6 +411,7 @@ libbitcoin_server_a_SOURCES = \
   TransactionInputChecker.cpp \
   UtxoCheckingAndUpdating.cpp\
   ActiveChainManager.cpp \
+  ChainstateManager.cpp \
   IndexDatabaseUpdateCollector.cpp \
   NodeState.cpp \
   BlocksInFlightRegistry.cpp \

--- a/divi/src/MasternodeHelpers.cpp
+++ b/divi/src/MasternodeHelpers.cpp
@@ -2,6 +2,7 @@
 
 #include <sync.h>
 #include <chain.h>
+#include <ChainstateManager.h>
 #include <utiltime.h>
 #include <timedata.h>
 #include <masternode.h>
@@ -13,8 +14,6 @@
 extern CCriticalSection cs_main;
 extern bool fImporting;
 extern bool fReindex;
-extern CChain chainActive;
-extern BlockMap mapBlockIndex;
 
 static bool mnResyncRequested  = false;
 bool MasternodeResyncIsRequested()
@@ -50,7 +49,8 @@ bool IsBlockchainSynced()
     TRY_LOCK(cs_main, lockMain);
     if (!lockMain) return false;
 
-    CBlockIndex* pindex = chainActive.Tip();
+    const ChainstateManager chainstate;
+    const CBlockIndex* pindex = chainstate.ActiveChain().Tip();
     if (pindex == NULL) return false;
 
 
@@ -65,7 +65,8 @@ bool IsBlockchainSynced()
 
 bool GetBlockHashForScoring(uint256& hash, int nBlockHeight)
 {
-    const auto* tip = chainActive.Tip();
+    const ChainstateManager chainstate;
+    const auto* tip = chainstate.ActiveChain().Tip();
     if (tip == nullptr)
         return false;
     return GetBlockHashForScoring(hash, tip, nBlockHeight - tip->nHeight);
@@ -87,11 +88,12 @@ bool GetBlockHashForScoring(uint256& hash, const CBlockIndex* pindex, const int 
 const CBlockIndex* ComputeCollateralBlockIndex(const CMasternode& masternode)
 {
     static std::map<COutPoint,const CBlockIndex*> cachedCollateralBlockIndices;
+    const ChainstateManager chainstate;
 
     const CBlockIndex* collateralBlockIndex = cachedCollateralBlockIndices[masternode.vin.prevout];
     if (collateralBlockIndex)
     {
-        if(chainActive.Contains(collateralBlockIndex))
+        if(chainstate.ActiveChain().Contains(collateralBlockIndex))
         {
             return collateralBlockIndex;
         }
@@ -104,13 +106,14 @@ const CBlockIndex* ComputeCollateralBlockIndex(const CMasternode& masternode)
         return collateralBlockIndex;
     }
 
-    const auto mi = mapBlockIndex.find(hashBlock);
-    if (mi == mapBlockIndex.end() || mi->second == nullptr) {
+    const auto& blockMap = chainstate.GetBlockMap();
+    const auto mi = blockMap.find(hashBlock);
+    if (mi == blockMap.end() || mi->second == nullptr) {
         collateralBlockIndex = nullptr;
         return collateralBlockIndex;
     }
 
-    if (!chainActive.Contains(mi->second)) {
+    if (!chainstate.ActiveChain().Contains(mi->second)) {
         collateralBlockIndex = nullptr;
         return collateralBlockIndex;
     }
@@ -123,12 +126,13 @@ const CBlockIndex* ComputeMasternodeConfirmationBlockIndex(const CMasternode& ma
     const CBlockIndex* pindexConf = nullptr;
     {
         LOCK(cs_main);
+        const ChainstateManager chainstate;
         const auto* pindexCollateral = ComputeCollateralBlockIndex(masternode);
         if (pindexCollateral == nullptr)
             pindexConf = nullptr;
         else {
-            assert(chainActive.Contains(pindexCollateral));
-            pindexConf = chainActive[pindexCollateral->nHeight + MASTERNODE_MIN_CONFIRMATIONS - 1];
+            assert(chainstate.ActiveChain().Contains(pindexCollateral));
+            pindexConf = chainstate.ActiveChain()[pindexCollateral->nHeight + MASTERNODE_MIN_CONFIRMATIONS - 1];
             assert(pindexConf == nullptr || pindexConf->GetAncestor(pindexCollateral->nHeight) == pindexCollateral);
         }
     }
@@ -138,14 +142,15 @@ const CBlockIndex* ComputeMasternodeConfirmationBlockIndex(const CMasternode& ma
 int ComputeMasternodeInputAge(const CMasternode& masternode)
 {
     LOCK(cs_main);
+    const ChainstateManager chainstate;
 
     const auto* pindex = ComputeCollateralBlockIndex(masternode);
     if (pindex == nullptr)
         return 0;
 
-    assert(chainActive.Contains(pindex));
+    assert(chainstate.ActiveChain().Contains(pindex));
 
-    const unsigned tipHeight = chainActive.Height();
+    const unsigned tipHeight = chainstate.ActiveChain().Height();
     assert(tipHeight >= pindex->nHeight);
 
     return tipHeight - pindex->nHeight + 1;
@@ -153,9 +158,12 @@ int ComputeMasternodeInputAge(const CMasternode& masternode)
 
 CMasternodePing createCurrentPing(const CTxIn& newVin)
 {
+    const ChainstateManager chainstate;
+    const auto& activeChain = chainstate.ActiveChain();
+
     CMasternodePing ping;
     ping.vin = newVin;
-    ping.blockHash = chainActive[chainActive.Height() - 12]->GetBlockHash();
+    ping.blockHash = activeChain[activeChain.Height() - 12]->GetBlockHash();
     ping.sigTime = GetAdjustedTime();
     ping.signature = std::vector<unsigned char>();
     return ping;
@@ -186,12 +194,15 @@ bool ReindexingOrImportingIsActive()
 }
 CMasternodePing createDelayedMasternodePing(const CMasternode& mn)
 {
+    const ChainstateManager chainstate;
+    const auto& activeChain = chainstate.ActiveChain();
+
     CMasternodePing ping;
     const int64_t offsetTimeBy45BlocksInSeconds = 60 * 45;
     ping.vin = mn.vin;
     const int depthOfTx = ComputeMasternodeInputAge(mn);
     const int offset = std::min( std::max(0, depthOfTx), 12 );
-    const auto* block = chainActive[chainActive.Height() - offset];
+    const auto* block = activeChain[activeChain.Height() - offset];
     ping.blockHash = block->GetBlockHash();
     ping.sigTime = std::max(block->GetBlockTime() + offsetTimeBy45BlocksInSeconds, GetAdjustedTime());
     ping.signature = std::vector<unsigned char>();

--- a/divi/src/MasternodeModule.h
+++ b/divi/src/MasternodeModule.h
@@ -16,8 +16,7 @@ class UIMessenger;
 class CMasternodePayments;
 class CKeyStore;
 
-class CChain;
-class BlockMap;
+class ChainstateManager;
 class MasternodeNetworkMessageManager;
 class MasternodePaymentData;
 class CMasternodeConfig;
@@ -33,8 +32,6 @@ class MasternodeModule
 {
 private:
     bool fMasterNode_;
-    const CChain& activeChain_;
-    const BlockMap& blockIndexByHash_;
     std::unique_ptr<CNetFulfilledRequestManager> networkFulfilledRequestManager_;
     std::unique_ptr<MasternodeNetworkMessageManager> networkMessageManager_;
     std::unique_ptr<MasternodePaymentData> masternodePaymentData_;
@@ -48,8 +45,7 @@ public:
     MasternodeModule(
         const I_Clock& clock,
         const I_PeerSyncQueryService& peerSyncQueryService,
-        const CChain& activeChain,
-        const BlockMap& blockIndexByHash,
+        const ChainstateManager& chainstate,
         CAddrMan& addressManager);
     ~MasternodeModule();
 

--- a/divi/src/TransactionSearchIndexes.cpp
+++ b/divi/src/TransactionSearchIndexes.cpp
@@ -5,7 +5,7 @@
 
 bool TransactionSearchIndexes::GetAddressIndex(
     bool addresIndexEnabled,
-    CBlockTreeDB* pblocktree,
+    const CBlockTreeDB* pblocktree,
     uint160 addressHash,
     int type,
     std::vector<std::pair<CAddressIndexKey, CAmount> > &addressIndex,
@@ -23,7 +23,7 @@ bool TransactionSearchIndexes::GetAddressIndex(
 
 bool TransactionSearchIndexes::GetAddressUnspent(
     bool addresIndexEnabled,
-    CBlockTreeDB* pblocktree,
+    const CBlockTreeDB* pblocktree,
     uint160 addressHash,
     int type,
     std::vector<std::pair<CAddressUnspentKey,CAddressUnspentValue> > &unspentOutputs)
@@ -39,7 +39,7 @@ bool TransactionSearchIndexes::GetAddressUnspent(
 
 bool TransactionSearchIndexes::GetSpentIndex(
     bool spentIndexEnabled,
-    CBlockTreeDB* pblocktree,
+    const CBlockTreeDB* pblocktree,
     const CSpentIndexKey &key,
     CSpentIndexValue &value)
 {

--- a/divi/src/TransactionSearchIndexes.h
+++ b/divi/src/TransactionSearchIndexes.h
@@ -8,7 +8,7 @@ namespace TransactionSearchIndexes
 {
     bool GetAddressIndex(
         bool addresIndexEnabled,
-        CBlockTreeDB* pblocktree,
+        const CBlockTreeDB* pblocktree,
         uint160 addressHash,
         int type,
         std::vector<std::pair<CAddressIndexKey, CAmount> > &addressIndex,
@@ -16,13 +16,13 @@ namespace TransactionSearchIndexes
         int end = 0);
     bool GetAddressUnspent(
         bool addresIndexEnabled,
-        CBlockTreeDB* pblocktree,
+        const CBlockTreeDB* pblocktree,
         uint160 addressHash,
         int type,
         std::vector<std::pair<CAddressUnspentKey,CAddressUnspentValue> > &unspentOutputs);
     bool GetSpentIndex(
         bool spentIndexEnabled,
-        CBlockTreeDB* pblocktree,
+        const CBlockTreeDB* pblocktree,
         const CSpentIndexKey &key,
         CSpentIndexValue &value);
 }

--- a/divi/src/init.cpp
+++ b/divi/src/init.cpp
@@ -80,7 +80,6 @@
 #include <verifyDb.h>
 
 extern CCriticalSection cs_main;
-extern CChain chainActive;
 extern Settings& settings;
 extern bool fReindex;
 extern bool fImporting;
@@ -90,7 +89,6 @@ extern int nCoinCacheSize;
 extern bool fTxIndex;
 extern bool fVerifyingBlocks;
 extern bool fLiteMode;
-extern BlockMap mapBlockIndex;
 extern Settings& settings;
 #if ENABLE_ZMQ
 static CZMQNotificationInterface* pzmqNotificationInterface = NULL;
@@ -108,6 +106,8 @@ constexpr int nWalletBackups = 20;
 #endif
 
 
+CChain chainActive;
+BlockMap mapBlockIndex;
 CBlockTreeDB* pblocktree = nullptr;
 CCoinsViewCache* pcoinsTip = nullptr;
 

--- a/divi/src/rpcdump.cpp
+++ b/divi/src/rpcdump.cpp
@@ -38,7 +38,6 @@
 using namespace json_spirit;
 using namespace std;
 extern CWallet* pwalletMain;
-extern CChain chainActive;
 
 void EnsureWalletIsUnlocked();
 

--- a/divi/src/rpclottery.cpp
+++ b/divi/src/rpclottery.cpp
@@ -1,4 +1,5 @@
 #include <chain.h>
+#include <ChainstateManager.h>
 #include <spork.h>
 #include <LotteryWinnersCalculator.h>
 #include <SuperblockSubsidyContainer.h>
@@ -9,7 +10,6 @@
 #include <rpcprotocol.h>
 #include <sync.h>
 
-extern CChain chainActive;
 extern CCriticalSection cs_main;
 using namespace json_spirit;
 
@@ -42,12 +42,13 @@ Value getlotteryblockwinners(const Array& params, bool fHelp)
 
     static const CChainParams& chainParameters = Params();
     static SuperblockSubsidyContainer subsidyCointainer(chainParameters);
+    static const ChainstateManager chainstate;
     static LotteryWinnersCalculator calculator(
-        chainParameters.GetLotteryBlockStartBlock(),chainActive, GetSporkManager(),subsidyCointainer.superblockHeightValidator());
+        chainParameters.GetLotteryBlockStartBlock(), chainstate.ActiveChain(), GetSporkManager(),subsidyCointainer.superblockHeightValidator());
     const CBlockIndex* chainTip = nullptr;
     {
         LOCK(cs_main);
-        chainTip = chainActive.Tip();
+        chainTip = chainstate.ActiveChain().Tip();
         if(!chainTip) throw JSONRPCError(RPC_MISC_ERROR,"Could not acquire lock on chain tip.");
     }
     int blockHeight = (params.size()>0)? std::min(params[0].get_int(),chainTip->nHeight): chainTip->nHeight;

--- a/divi/src/rpcmasternode.cpp
+++ b/divi/src/rpcmasternode.cpp
@@ -4,6 +4,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include "activemasternode.h"
+#include <ChainstateManager.h>
 #include "init.h"
 #include "main.h"
 #include <chain.h>
@@ -33,7 +34,6 @@
 using namespace json_spirit;
 
 extern CWallet* pwalletMain;
-extern CChain chainActive;
 extern CCriticalSection cs_main;
 extern std::string SendMoneyToAddress(const CTxDestination& address, CAmount nValue);
 extern CBitcoinAddress GetAccountAddress(CWallet& wallet, std::string strAccount, bool forceNewKey, bool isWalletDerivedKey);
@@ -388,8 +388,9 @@ Value listmasternodes(const Array& params, bool fHelp)
     Array ret;
     const CBlockIndex* pindex;
     {
+        const ChainstateManager chainstate;
         LOCK(cs_main);
-        pindex = chainActive.Tip();
+        pindex = chainstate.ActiveChain().Tip();
         if(!pindex) return 0;
     }
 
@@ -434,7 +435,8 @@ Value getmasternodecount (const Array& params, bool fHelp)
             "\nExamples:\n" +
             HelpExampleCli("getmasternodecount", "") + HelpExampleRpc("getmasternodecount", ""));
 
-    const CBlockIndex* tip = chainActive.Tip();
+    const ChainstateManager chainstate;
+    const CBlockIndex* tip = chainstate.ActiveChain().Tip();
     MasternodeCountData data = GetMasternodeCounts(tip);
 
     Object obj;
@@ -640,8 +642,9 @@ Value getmasternodewinners (const Array& params, bool fHelp)
     int nHeight;
     const CBlockIndex* pindex = nullptr;
     {
+        const ChainstateManager chainstate;
         LOCK(cs_main);
-        pindex = chainActive.Tip();
+        pindex = chainstate.ActiveChain().Tip();
         if(!pindex) return 0;
         nHeight = pindex->nHeight;
     }

--- a/divi/src/rpcmining.cpp
+++ b/divi/src/rpcmining.cpp
@@ -47,7 +47,6 @@ using namespace boost;
 using namespace boost::assign;
 extern Settings& settings;
 extern CWallet* pwalletMain;
-extern CCoinsViewCache* pcoinsTip;
 extern CCriticalSection cs_main;
 extern CTxMemPool mempool;
 

--- a/divi/src/spork.h
+++ b/divi/src/spork.h
@@ -7,6 +7,7 @@
 #define SPORK_H
 
 #include "key.h"
+#include <ChainstateManager.h>
 #include "pubkey.h"
 #include <amount.h>
 
@@ -165,6 +166,7 @@ struct TxFeeSporkValue : public SporkMultiValue {
 class CSporkManager
 {
 private:
+    const ChainstateManager chainstate_;
     std::unique_ptr<CSporkDB> pSporkDB_;
     std::vector<unsigned char> vchSig;
     // Some sporks require to have history, we will use sorted vector for this approach.
@@ -173,11 +175,11 @@ private:
     CPubKey sporkPubKey;
     CKey sporkPrivKey;
 
-private:
     bool AddActiveSpork(const CSporkMessage &spork);
     bool IsNewerSpork(const CSporkMessage &spork) const;
     void ExecuteSpork(int nSporkID);
     void ExecuteMultiValueSpork(int nSporkID);
+    int64_t GetBlockTime(int nHeight) const;
 
 public:
 

--- a/divi/src/test/test_divi.cpp
+++ b/divi/src/test/test_divi.cpp
@@ -34,7 +34,6 @@ extern CCoinsViewCache* pcoinsTip;
 extern bool fCheckBlockIndex;
 extern BlockMap mapBlockIndex;
 extern int nScriptCheckThreads;
-extern CChain chainActive;
 
 struct TestingSetup {
     CCoinsViewDB *pcoinsdbview;


### PR DESCRIPTION
This introduces the `ChainstateManager` helper class.  This class provides an interface to access the global state related to the blockchain, i.e. `chainActive`, `pcoinsTip`, `pblocktree` and `mapBlockIndex`.  Almost all code is updated to access these globals not directly, but through `ChainstateManager` instances (the only exception are code in `init` and the unit tests where the chainstate is *set up* rather than *accessed*).

For now, this is purely cosmetic, as the `ChainstateManager` still uses the globals under the hood.  But this is a first step towards actually moving the state into instances of `ChainstateManager`, and passing them through to function calls instead of directly accessing global state.