### PR TITLE
Remove redundant wallet flush

### DIFF
--- a/divi/src/init.cpp
+++ b/divi/src/init.cpp
@@ -351,9 +351,6 @@ void PrepareShutdown()
     /// module was initialized.
     RenameThread("divi-shutoff");
     StopRPCThreads();
-#ifdef ENABLE_WALLET
-    FlushWallet(true);
-#endif
     StopNode();
     InterruptTorControl();
     StopTorControl();


### PR DESCRIPTION
Remove a redundant (and out-of-order) `FlushWallet` call in the shutdown sequence; there is another one a bit later down already.  The removed call was already closing down the BDB environment (due to `fShutdown` being set to `true`), whereas the later `ShallowDatabases::FlushStateAndCleanup` (through `FlushStateToDisk`) could still invoke the `SetBestChain` signal, which would then try to access / recreate the BDB environment for setting the best block in the wallet.  That in turn caused a segfault during the shutdown sequence, preventing a clean shutdown.

This issue was introduced in f4fd2bbff54c27bdc8c2743411e6e7bfdc20ded1:  Before that change, there were still two `FlushWallet` calls, but the first of them was with `fShutdown=false`.  That flag got accidentally flipped to `true` in the refactor.