### PR TITLE
Make CBlockIndex instances in CChain const

### DIFF
--- a/divi/src/BlockFileHelpers.cpp
+++ b/divi/src/BlockFileHelpers.cpp
@@ -16,7 +16,7 @@ CCriticalSection cs_LastBlockFile;
 /** Dirty block file entries. */
 std::set<int> setDirtyFileInfo;
 /** Dirty block index entries. */
-std::set<CBlockIndex*> setDirtyBlockIndex;
+std::set<const CBlockIndex*> setDirtyBlockIndex;
 int nLastBlockFile = 0;
 std::vector<CBlockFileInfo> vinfoBlockFile;
 
@@ -164,7 +164,7 @@ bool BlockFileHelpers::WriteBlockFileToBlockTreeDatabase(
         return state.Abort("Failed to write to block index");
     }
 
-    for (CBlockIndex* blockIndex: setDirtyBlockIndex)
+    for (const auto* blockIndex: setDirtyBlockIndex)
     {
         if (!blockTreeDB.WriteBlockIndex(CDiskBlockIndex(blockIndex)))
         {
@@ -175,7 +175,7 @@ bool BlockFileHelpers::WriteBlockFileToBlockTreeDatabase(
     return true;
 }
 
-void BlockFileHelpers::RecordDirtyBlockIndex(CBlockIndex* blockIndexToRecord)
+void BlockFileHelpers::RecordDirtyBlockIndex(const CBlockIndex* blockIndexToRecord)
 {
     setDirtyBlockIndex.insert(blockIndexToRecord);
 }

--- a/divi/src/BlockFileHelpers.h
+++ b/divi/src/BlockFileHelpers.h
@@ -30,7 +30,7 @@ namespace BlockFileHelpers
     bool WriteBlockFileToBlockTreeDatabase(
         CValidationState& state,
         CBlockTreeDB& blockTreeDB);
-    void RecordDirtyBlockIndex(CBlockIndex* blockIndexToRecord);
+    void RecordDirtyBlockIndex(const CBlockIndex* blockIndexToRecord);
     void ReadBlockFiles(
         const CBlockTreeDB& blockTreeDB);
     int GetLastBlockHeightWrittenIntoLastBlockFile();

--- a/divi/src/chain.cpp
+++ b/divi/src/chain.cpp
@@ -11,7 +11,7 @@ using namespace std;
 /**
  * CChain implementation
  */
-void CChain::SetTip(CBlockIndex* pindex)
+void CChain::SetTip(const CBlockIndex* pindex)
 {
     if (pindex == NULL) {
         vChain.clear();

--- a/divi/src/chain.h
+++ b/divi/src/chain.h
@@ -207,6 +207,7 @@ public:
         vLotteryWinnersCoinstakes.clear();
     }
 
+    CBlockIndex (const CBlockIndex& index) = default;
 
     CDiskBlockPos GetBlockPos() const
     {

--- a/divi/src/chain.h
+++ b/divi/src/chain.h
@@ -72,7 +72,7 @@ public:
     CBlockIndex* pprev;
 
     //! pointer to the index of the next block
-    CBlockIndex* pnext;
+    const CBlockIndex* pnext;
 
     //! pointer to the index of some further predecessor of this block
     CBlockIndex* pskip;
@@ -441,22 +441,22 @@ public:
 class CChain
 {
 private:
-    std::vector<CBlockIndex*> vChain;
+    std::vector<const CBlockIndex*> vChain;
 
 public:
     /** Returns the index entry for the genesis block of this chain, or NULL if none. */
-    CBlockIndex* Genesis() const
+    const CBlockIndex* Genesis() const
     {
         return vChain.size() > 0 ? vChain[0] : NULL;
     }
 
     /** Returns the index entry for the tip of this chain, or NULL if none. */
-    CBlockIndex* Tip(bool fProofOfStake = false) const
+    const CBlockIndex* Tip(bool fProofOfStake = false) const
     {
         if (vChain.size() < 1)
             return NULL;
 
-        CBlockIndex* pindex = vChain[vChain.size() - 1];
+        const CBlockIndex* pindex = vChain[vChain.size() - 1];
 
         if (fProofOfStake) {
             while (pindex && pindex->pprev && !pindex->IsProofOfStake())
@@ -466,7 +466,7 @@ public:
     }
 
     /** Returns the index entry at a particular height in this chain, or NULL if no such height exists. */
-    CBlockIndex* operator[](int nHeight) const
+    const CBlockIndex* operator[](int nHeight) const
     {
         if (nHeight < 0 || nHeight >= (int)vChain.size())
             return NULL;
@@ -487,7 +487,7 @@ public:
     }
 
     /** Find the successor of a block in this chain, or NULL if the given index is not found or is the tip. */
-    CBlockIndex* Next(const CBlockIndex* pindex) const
+    const CBlockIndex* Next(const CBlockIndex* pindex) const
     {
         if (Contains(pindex))
             return (*this)[pindex->nHeight + 1];
@@ -502,7 +502,7 @@ public:
     }
 
     /** Set/initialize a chain with a given tip. */
-    void SetTip(CBlockIndex* pindex);
+    void SetTip(const CBlockIndex* pindex);
 
     /** Return a CBlockLocator that refers to a block in this chain (by default the tip). */
     CBlockLocator GetLocator(const CBlockIndex* pindex = NULL) const;

--- a/divi/src/chain.h
+++ b/divi/src/chain.h
@@ -357,7 +357,7 @@ public:
         hashNext = uint256();
     }
 
-    explicit CDiskBlockIndex(CBlockIndex* pindex) : CBlockIndex(*pindex)
+    explicit CDiskBlockIndex(const CBlockIndex* pindex) : CBlockIndex(*pindex)
     {
         hashPrev = (pprev ? pprev->GetBlockHash() : uint256());
     }

--- a/divi/src/main.cpp
+++ b/divi/src/main.cpp
@@ -1093,7 +1093,7 @@ void FlushStateToDisk(FlushStateMode mode)
 }
 
 /** Update chainActive and related internal data structures. */
-void static UpdateTip(CBlockIndex* pindexNew)
+void static UpdateTip(const CBlockIndex* pindexNew)
 {
     ChainstateManager chainstate;
     auto& chain = chainstate.ActiveChain();

--- a/divi/src/test/FakeBlockIndexChain.h
+++ b/divi/src/test/FakeBlockIndexChain.h
@@ -42,7 +42,7 @@ private:
     uint256 randomBlockHashSeed_;
 
     void extendChainBlocks(
-        CBlockIndex* chainToExtend,
+        const CBlockIndex* chainToExtend,
         unsigned numberOfBlocks,
         unsigned versionNumber,
         unsigned blockStartTime);

--- a/divi/src/test/LegacyPoSStakeModifierService_tests.cpp
+++ b/divi/src/test/LegacyPoSStakeModifierService_tests.cpp
@@ -70,7 +70,7 @@ BOOST_AUTO_TEST_CASE(willFailToGetValidStakeModifierForAnUnknownHash)
 BOOST_AUTO_TEST_CASE(willReturnStakeModifierOfZeroWhenAskedForTheChainTipsStakeModifierIfNotSet)
 {
     Init(200); // Initialize to 200 blocks;
-    CBlockIndex* chainTip = getActiveChain().Tip();
+    const CBlockIndex* chainTip = getActiveChain().Tip();
     assert(chainTip);
     {
         std::pair<uint64_t,bool> stakeModifierQuery = stakeModifierService_->getStakeModifier(fromBlockHash(chainTip->GetBlockHash()));
@@ -81,7 +81,7 @@ BOOST_AUTO_TEST_CASE(willReturnStakeModifierOfZeroWhenAskedForTheChainTipsStakeM
 BOOST_AUTO_TEST_CASE(willReturnStakeModifierForTheChainTipsStakeModifierWhenItsSet)
 {
     Init(200); // Initialize to 200 blocks;
-    CBlockIndex* chainTip = getActiveChain().Tip();
+    CBlockIndex* chainTip = const_cast<CBlockIndex*>(getActiveChain().Tip());
     assert(chainTip);
     {
         uint64_t stakeModifier = 0x26929c2;
@@ -100,10 +100,10 @@ BOOST_AUTO_TEST_CASE(willVerifyLengthOfSearchIntervalIs2087seconds)
 BOOST_AUTO_TEST_CASE(willReturnStakeModifierForLastStakeModifierSetOrDefaultToZero)
 {
     Init(200); // Initialize to 200 blocks;
-    CBlockIndex* chainTip = getActiveChain().Tip();
-    CBlockIndex* blockIndexOnePastStakeModifierSet = chainTip->GetAncestor(151);
+    const CBlockIndex* chainTip = getActiveChain().Tip();
+    const CBlockIndex* blockIndexOnePastStakeModifierSet = chainTip->GetAncestor(151);
     CBlockIndex* blockIndexWithStakeModifierSet = blockIndexOnePastStakeModifierSet->pprev;
-    CBlockIndex* oldBlockIndex = blockIndexWithStakeModifierSet->GetAncestor(101);
+    const CBlockIndex* oldBlockIndex = blockIndexWithStakeModifierSet->GetAncestor(101);
     assert(chainTip);
     assert(blockIndexOnePastStakeModifierSet);
     assert(blockIndexWithStakeModifierSet);
@@ -125,8 +125,8 @@ BOOST_AUTO_TEST_CASE(willReturnStakeModifierForLastStakeModifierSetOrDefaultToZe
 BOOST_AUTO_TEST_CASE(willGetEarliestStakeModifierSetThatIsOutsideTheSelectionIntervalOrDefaultToTheChainTipIfSetAndZeroOtherwise)
 {
     Init(200); // Initialize to 200 blocks;
-    CBlockIndex* chainTip = getActiveChain().Tip();
-    CBlockIndex* blockIndexWithStakeModifierSet = chainTip->GetAncestor(185);
+    CBlockIndex* chainTip = const_cast<CBlockIndex*>(getActiveChain().Tip());
+    CBlockIndex* blockIndexWithStakeModifierSet = const_cast<CBlockIndex*>(chainTip->GetAncestor(185));
     blockIndexWithStakeModifierSet->SetStakeModifier(blockIndexWithStakeModifierSet->nHeight,true);
     CBlockIndex* predecesor = blockIndexWithStakeModifierSet->pprev;
     while(blockIndexWithStakeModifierSet->GetBlockTime() -  predecesor->GetBlockTime() < GetStakeModifierSelectionInterval())
@@ -138,7 +138,7 @@ BOOST_AUTO_TEST_CASE(willGetEarliestStakeModifierSetThatIsOutsideTheSelectionInt
     assert(chainTip);
     assert(blockIndexWithStakeModifierSet);
     assert(predecesor);
-    CBlockIndex* onePastPredecesor = chainTip->GetAncestor(predecesor->nHeight+1);
+    const CBlockIndex* onePastPredecesor = chainTip->GetAncestor(predecesor->nHeight+1);
 
     {
         std::pair<uint64_t,bool> stakeModifierQuery = stakeModifierService_->getStakeModifier(fromBlockHash(predecesor->GetBlockHash()));

--- a/divi/src/test/LotteryWinnersCalculatorTests.cpp
+++ b/divi/src/test/LotteryWinnersCalculatorTests.cpp
@@ -89,7 +89,7 @@ public:
     {
         CMutableTransaction tx;
 
-        CBlockIndex* currentBlockIndex = fakeBlockIndexWithHashes_->activeChain->operator[](blockHeight);
+        CBlockIndex* currentBlockIndex = const_cast<CBlockIndex*>(fakeBlockIndexWithHashes_->activeChain->operator[](blockHeight));
         LotteryCoinstakeData previousCoinstakesData;
 
 

--- a/divi/src/test/PoSStakeModifierService_tests.cpp
+++ b/divi/src/test/PoSStakeModifierService_tests.cpp
@@ -49,8 +49,8 @@ public:
                 *mockStakeModifierService_,
                 *(fakeBlockIndexWithHashes_->blockIndexByHash) ));
 
-        if(numberOfBlocks>0) getActiveChain()[0]->SetStakeModifier(genesisStakeModifier, true);
-        if(numberOfBlocks>1) getActiveChain()[1]->SetStakeModifier(firstBlockStakeModifier, true);
+        if(numberOfBlocks>0) const_cast<CBlockIndex*>(getActiveChain()[0])->SetStakeModifier(genesisStakeModifier, true);
+        if(numberOfBlocks>1) const_cast<CBlockIndex*>(getActiveChain()[1])->SetStakeModifier(firstBlockStakeModifier, true);
     }
 
     const CChain& getActiveChain() const


### PR DESCRIPTION
Once blocks (or `CBlockIndex` instances) have been added already to the active chain, they are effectively read-only from that point on (as they have been validated and updated already prior to being connected to the chain).  There are only a few exceptions, like the `invalidateblock` RPC method or unit tests.

This change enforces this assumption in code, by making `CChain` store and expose the contained `CBlockIndex`'es only as `const`.