### PR TITLE
Always use signature cache

### DIFF
--- a/divi/src/BlockMemoryPoolTransactionCollector.cpp
+++ b/divi/src/BlockMemoryPoolTransactionCollector.cpp
@@ -323,7 +323,7 @@ std::vector<PrioritizedTransactionData> BlockMemoryPoolTransactionCollector::Pri
         // policy here, but we still have to ensure that the block we
         // create only contains transactions that are valid in new blocks.
         CValidationState state;
-        if (!CheckInputs(tx, state, view, blockIndexMap_, true, MANDATORY_SCRIPT_VERIFY_FLAGS, true)) {
+        if (!CheckInputs(tx, state, view, blockIndexMap_, true, MANDATORY_SCRIPT_VERIFY_FLAGS)) {
             continue;
         }
 

--- a/divi/src/BlockTransactionChecker.cpp
+++ b/divi/src/BlockTransactionChecker.cpp
@@ -110,7 +110,7 @@ bool BlockTransactionChecker::CheckCoinstakeForVaults(
     return true;
 }
 
-bool BlockTransactionChecker::Check(const CBlockRewards& nExpectedMint,bool fJustCheck, IndexDatabaseUpdates& indexDatabaseUpdates)
+bool BlockTransactionChecker::Check(const CBlockRewards& nExpectedMint, IndexDatabaseUpdates& indexDatabaseUpdates)
 {
     const CAmount nMoneySupplyPrev = pindex_->pprev ? pindex_->pprev->nMoneySupply : 0;
     pindex_->nMoneySupply = nMoneySupplyPrev;
@@ -133,7 +133,7 @@ bool BlockTransactionChecker::Check(const CBlockRewards& nExpectedMint,bool fJus
         {
             return false;
         }
-        if(!txInputChecker_.CheckInputsAndUpdateCoinSupplyRecords(tx, flags, fJustCheck, pindex_))
+        if(!txInputChecker_.CheckInputsAndUpdateCoinSupplyRecords(tx, flags, pindex_))
         {
             return false;
         }

--- a/divi/src/BlockTransactionChecker.h
+++ b/divi/src/BlockTransactionChecker.h
@@ -66,7 +66,6 @@ public:
 
     bool Check(
         const CBlockRewards& nExpectedMint,
-        bool fJustCheck,
         IndexDatabaseUpdates& indexDatabaseUpdates);
     bool WaitForScriptsToBeChecked();
     CBlockUndo& getBlockUndoData();

--- a/divi/src/TransactionInputChecker.cpp
+++ b/divi/src/TransactionInputChecker.cpp
@@ -39,13 +39,12 @@ void TransactionInputChecker::ScheduleBackgroundThreadScriptChecking()
 bool TransactionInputChecker::CheckInputsAndUpdateCoinSupplyRecords(
     const CTransaction& tx,
     const unsigned flags,
-    const bool fJustCheck,
     CBlockIndex* pindex)
 {
     assert(vChecks.empty());
     CAmount txFees =0;
     CAmount txInputAmount=0;
-    if (!CheckInputs(tx, state_, view_, blockIndexMap_, txFees, txInputAmount, true, flags, fJustCheck, nScriptCheckThreads ? &vChecks : NULL, true))
+    if (!CheckInputs(tx, state_, view_, blockIndexMap_, txFees, txInputAmount, true, flags, nScriptCheckThreads ? &vChecks : NULL, true))
     {
         vChecks.clear();
         return false;

--- a/divi/src/TransactionInputChecker.h
+++ b/divi/src/TransactionInputChecker.h
@@ -31,7 +31,6 @@ public:
     bool CheckInputsAndUpdateCoinSupplyRecords(
         const CTransaction& tx,
         unsigned flags,
-        const bool fJustCheck,
         CBlockIndex* pindex);
 
     bool InputsAreValid(const CTransaction& tx) const;

--- a/divi/src/UtxoCheckingAndUpdating.cpp
+++ b/divi/src/UtxoCheckingAndUpdating.cpp
@@ -116,12 +116,11 @@ bool CheckInputs(
     const BlockMap& blockIndexMap,
     bool fScriptChecks,
     unsigned int flags,
-    bool cacheStore,
     std::vector<CScriptCheck>* pvChecks)
 {
     CAmount nFees = 0;
     CAmount nValueIn = 0;
-    return CheckInputs(tx,state,inputs,blockIndexMap,nFees,nValueIn,fScriptChecks,flags,cacheStore,pvChecks);
+    return CheckInputs(tx, state, inputs, blockIndexMap, nFees, nValueIn, fScriptChecks, flags, pvChecks);
 }
 
 
@@ -134,7 +133,6 @@ bool CheckInputs(
     CAmount& nValueIn,
     bool fScriptChecks,
     unsigned int flags,
-    bool cacheStore,
     std::vector<CScriptCheck>* pvChecks,
     bool connectBlockDoS)
 {
@@ -214,7 +212,7 @@ bool CheckInputs(
                 assert(coins);
 
                 // Verify signature
-                CScriptCheck check(*coins, tx, i, flags, cacheStore);
+                CScriptCheck check(*coins, tx, i, flags);
                 if (pvChecks) {
                     pvChecks->push_back(CScriptCheck());
                     check.swap(pvChecks->back());
@@ -227,7 +225,7 @@ bool CheckInputs(
                         // avoid splitting the network between upgraded and
                         // non-upgraded nodes.
                         CScriptCheck check(*coins, tx, i,
-                                           flags & ~STANDARD_NOT_MANDATORY_VERIFY_FLAGS, cacheStore);
+                                           flags & ~STANDARD_NOT_MANDATORY_VERIFY_FLAGS);
                         if (check())
                             return state.Invalid(false, REJECT_NONSTANDARD, strprintf("non-mandatory-script-verify-flag (%s)", ScriptErrorString(check.GetScriptError())));
                     }

--- a/divi/src/UtxoCheckingAndUpdating.h
+++ b/divi/src/UtxoCheckingAndUpdating.h
@@ -27,7 +27,6 @@ bool CheckInputs(
     const BlockMap& blockIndexMap,
     bool fScriptChecks,
     unsigned int flags,
-    bool cacheStore,
     std::vector<CScriptCheck>* pvChecks = nullptr);
 bool CheckInputs(
     const CTransaction& tx,
@@ -38,7 +37,6 @@ bool CheckInputs(
     CAmount& nValueIn,
     bool fScriptChecks,
     unsigned int flags,
-    bool cacheStore,
     std::vector<CScriptCheck>* pvChecks = nullptr,
     bool connectBlockDoS = false);
 #endif// UTXO_CHECKING_AND_UPDATING_H

--- a/divi/src/main.cpp
+++ b/divi/src/main.cpp
@@ -981,8 +981,7 @@ bool ConnectBlock(
     VerifyBestBlockIsAtPreviousBlock(pindex,view);
     if (block.GetHash() == Params().HashGenesisBlock())
     {
-        if(!fJustCheck)
-            view.SetBestBlock(pindex->GetBlockHash());
+        view.SetBestBlock(pindex->GetBlockHash());
         return true;
     }
     if(!CheckEnforcedPoSBlocksAndBIP30(chainParameters,block,state,pindex,view))
@@ -1023,21 +1022,16 @@ bool ConnectBlock(
     if (!blockTxChecker.WaitForScriptsToBeChecked())
         return state.DoS(100, false);
 
-    if (fJustCheck)
-        return true;
-
-    if(!WriteUndoDataToDisk(pindex,state,blockTxChecker.getBlockUndoData()) ||
-       !UpdateDBIndicesForNewBlock(indexDatabaseUpdates, chainstate.BlockTree(), state))
-    {
-        return false;
+    if (!fJustCheck) {
+        if(!WriteUndoDataToDisk(pindex,state,blockTxChecker.getBlockUndoData()) ||
+           !UpdateDBIndicesForNewBlock(indexDatabaseUpdates, chainstate.BlockTree(), state))
+        {
+            return false;
+        }
     }
 
     // add this block to the view's block chain
     view.SetBestBlock(pindex->GetBlockHash());
-
-    // Watch for changes to the previous coinbase transaction.
-    static uint256 hashPrevBestCoinBase;
-    hashPrevBestCoinBase = block.vtx[0].GetHash();
 
     return true;
 }

--- a/divi/src/main.h
+++ b/divi/src/main.h
@@ -139,7 +139,7 @@ bool DisconnectBlocksAndReprocess(int blocks);
 bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pindex, CCoinsViewCache& coins, bool fJustCheck, bool fAlreadyChecked = false);
 
 /** Context-independent validity checks */
-bool CheckBlock(const CBlock& block, CValidationState& state, bool fCheckMerkleRoot = true);
+bool CheckBlock(const CBlock& block, CValidationState& state);
 
 /** Context-dependent validity checks */
 bool ContextualCheckBlockHeader(const CBlockHeader& block, CValidationState& state, CBlockIndex* pindexPrev);

--- a/divi/src/script/sigcache.cpp
+++ b/divi/src/script/sigcache.cpp
@@ -85,7 +85,6 @@ bool CachingTransactionSignatureChecker::VerifySignature(const std::vector<unsig
     if (!TransactionSignatureChecker::VerifySignature(vchSig, pubkey, sighash))
         return false;
 
-    if (store)
-        signatureCache.Set(sighash, vchSig, pubkey);
+    signatureCache.Set(sighash, vchSig, pubkey);
     return true;
 }

--- a/divi/src/script/sigcache.h
+++ b/divi/src/script/sigcache.h
@@ -14,11 +14,8 @@ class CPubKey;
 
 class CachingTransactionSignatureChecker : public TransactionSignatureChecker
 {
-private:
-    bool store;
-
 public:
-    CachingTransactionSignatureChecker(const CTransaction* txToIn, unsigned int nInIn, bool storeIn=true) : TransactionSignatureChecker(txToIn, nInIn), store(storeIn) {}
+    CachingTransactionSignatureChecker(const CTransaction* txToIn, unsigned int nInIn) : TransactionSignatureChecker(txToIn, nInIn) {}
 
     bool VerifySignature(const std::vector<unsigned char>& vchSig, const CPubKey& vchPubKey, const uint256& sighash) const;
 };

--- a/divi/src/scriptCheck.cpp
+++ b/divi/src/scriptCheck.cpp
@@ -9,16 +9,16 @@
 #include <primitives/transaction.h>
 #include <coins.h>
 
-CScriptCheck::CScriptCheck() : ptxTo(0), nIn(0), nFlags(0), cacheStore(false), error(SCRIPT_ERR_UNKNOWN_ERROR) {}
+CScriptCheck::CScriptCheck() : ptxTo(0), nIn(0), nFlags(0), error(SCRIPT_ERR_UNKNOWN_ERROR) {}
 
-CScriptCheck::CScriptCheck(const CCoins& txFromIn, const CTransaction& txToIn, unsigned int nInIn, unsigned int nFlagsIn, bool cacheIn) : scriptPubKey(txFromIn.vout[txToIn.vin[nInIn].prevout.n].scriptPubKey),
-                                                                                                                                ptxTo(&txToIn), nIn(nInIn), nFlags(nFlagsIn), cacheStore(cacheIn), error(SCRIPT_ERR_UNKNOWN_ERROR) {}
+CScriptCheck::CScriptCheck(const CCoins& txFromIn, const CTransaction& txToIn, unsigned int nInIn, unsigned int nFlagsIn) : scriptPubKey(txFromIn.vout[txToIn.vin[nInIn].prevout.n].scriptPubKey),
+                                                                                                                                ptxTo(&txToIn), nIn(nInIn), nFlags(nFlagsIn), error(SCRIPT_ERR_UNKNOWN_ERROR) {}
 
     
 bool CScriptCheck::operator()()
 {
     const CScript& scriptSig = ptxTo->vin[nIn].scriptSig;
-    if (!VerifyScript(scriptSig, scriptPubKey, nFlags, CachingTransactionSignatureChecker(ptxTo, nIn, cacheStore), &error)) {
+    if (!VerifyScript(scriptSig, scriptPubKey, nFlags, CachingTransactionSignatureChecker(ptxTo, nIn), &error)) {
         return ::error("CScriptCheck(): %s:%d VerifySignature failed: %s", ptxTo->ToStringShort(), nIn, ScriptErrorString(error));
     }
     return true;
@@ -31,7 +31,6 @@ void CScriptCheck::swap(CScriptCheck& check)
     std::swap(ptxTo, check.ptxTo);
     std::swap(nIn, check.nIn);
     std::swap(nFlags, check.nFlags);
-    std::swap(cacheStore, check.cacheStore);
     std::swap(error, check.error);
 }
 

--- a/divi/src/scriptCheck.h
+++ b/divi/src/scriptCheck.h
@@ -23,13 +23,12 @@ private:
     const CTransaction* ptxTo;
     unsigned int nIn;
     unsigned int nFlags;
-    bool cacheStore;
     ScriptError error;
 
 public:
     CScriptCheck();
 
-    CScriptCheck(const CCoins& txFromIn, const CTransaction& txToIn, unsigned int nInIn, unsigned int nFlagsIn, bool cacheIn);
+    CScriptCheck(const CCoins& txFromIn, const CTransaction& txToIn, unsigned int nInIn, unsigned int nFlagsIn);
 
 
     bool operator()();

--- a/divi/src/test/checkblock_tests.cpp
+++ b/divi/src/test/checkblock_tests.cpp
@@ -63,7 +63,7 @@ BOOST_AUTO_TEST_CASE(May15)
 
         // After May 15'th, big blocks are OK:
         forkingBlock.nTime = tMay15; // Invalidates PoW
-        BOOST_CHECK(CheckBlock(forkingBlock, state, false));
+        BOOST_CHECK(CheckBlock(forkingBlock, state));
     }
 
     SetMockTime(0);

--- a/divi/src/test/script_P2SH_tests.cpp
+++ b/divi/src/test/script_P2SH_tests.cpp
@@ -125,7 +125,7 @@ BOOST_AUTO_TEST_CASE(sign)
         {
             CScript sigSave = txTo[i].vin[0].scriptSig;
             txTo[i].vin[0].scriptSig = txTo[j].vin[0].scriptSig;
-            bool sigOK = CScriptCheck(CCoins(txFrom, 0), txTo[i], 0, SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_STRICTENC, false)();
+            bool sigOK = CScriptCheck(CCoins(txFrom, 0), txTo[i], 0, SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_STRICTENC)();
             if (i == j)
                 BOOST_CHECK_MESSAGE(sigOK, strprintf("VerifySignature %d %d", i, j));
             else

--- a/divi/src/txmempool.cpp
+++ b/divi/src/txmempool.cpp
@@ -247,7 +247,7 @@ void CTxMemPool::check(const CCoinsViewCache* pcoins, const BlockMap& blockIndex
         else {
             CValidationState state;
             CTxUndo undo;
-            assert(CheckInputs(tx, state, mempoolDuplicate, blockIndexMap, false, 0, false, NULL));
+            assert(CheckInputs(tx, state, mempoolDuplicate, blockIndexMap, false, 0, nullptr));
             UpdateCoinsWithTransaction(tx, mempoolDuplicate, undo, 1000000);
         }
     }
@@ -261,7 +261,7 @@ void CTxMemPool::check(const CCoinsViewCache* pcoins, const BlockMap& blockIndex
             stepsSinceLastRemove++;
             assert(stepsSinceLastRemove < waitingOnDependants.size());
         } else {
-            assert(CheckInputs(entry->GetTx(), state, mempoolDuplicate, blockIndexMap, false, 0, false, NULL));
+            assert(CheckInputs(entry->GetTx(), state, mempoolDuplicate, blockIndexMap, false, 0, nullptr));
             CTxUndo undo;
             UpdateCoinsWithTransaction(entry->GetTx(), mempoolDuplicate, undo, 1000000);
             stepsSinceLastRemove = 0;

--- a/divi/src/verifyDb.cpp
+++ b/divi/src/verifyDb.cpp
@@ -22,7 +22,7 @@
 
 /** Apply the effects of this block (with given index) on the UTXO set represented by coins */
 bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pindex, CCoinsViewCache& coins, bool fJustCheck, bool fAlreadyChecked = false);
-bool CheckBlock(const CBlock& block, CValidationState& state, bool fCheckMerkleRoot = true);
+bool CheckBlock(const CBlock& block, CValidationState& state);
 
 CVerifyDB::CVerifyDB(
     const ActiveChainManager& chainManager,

--- a/divi/src/verifyDb.cpp
+++ b/divi/src/verifyDb.cpp
@@ -122,7 +122,7 @@ bool CVerifyDB::VerifyDB(const CCoinsView* coinsview, unsigned coinsTipCacheSize
             CBlock block;
             if (!ReadBlockFromDisk(block, pindex))
                 return error("VerifyDB() : *** ReadBlockFromDisk failed at %d, hash=%s", pindex->nHeight, pindex->GetBlockHash());
-            if (!ConnectBlock(block, state, pindex, coins, false))
+            if (!ConnectBlock(block, state, pindex, coins, true))
                 return error("VerifyDB() : *** found unconnectable block at %d, hash=%s", pindex->nHeight, pindex->GetBlockHash());
         }
     }


### PR DESCRIPTION
The code of the caching signature checker has a flag to actually disable the cache, which is however never really used in production (and there is no real harm in always using the cache anyway).  This change removes this flag, which can then also be used to simplify a lot of upstream calling code (where the flag is currently passed through).

The second commit cleans up `fJustCheck` in `ConnectBlock`, which is currently not used at all and also not very useful; the semantics are changed, so that the flag can now be used to disable writes to undo data and on-disk indices from `VerifyDB`.