### PR TITLE
Introduce fJustCheck flag for DisconnectBlock

### DIFF
--- a/divi/src/ActiveChainManager.h
+++ b/divi/src/ActiveChainManager.h
@@ -34,11 +34,14 @@ public:
         CBlockTreeDB* blocktree,
         const I_BlockDataReader& blockDataReader);
     bool DisconnectBlock(
-        CBlock& block,
+        const CBlock& block,
         CValidationState& state,
         const CBlockIndex* pindex,
         CCoinsViewCache& coins,
-        bool* pfClean = nullptr) const;
+        bool fJustCheck) const;
+    /** Disconnects a block given by pindex, which is also first loaded from
+     *  disk and returned as part of disconnectedBlockAndStatus.
+     *  This method always fully disconnects (i.e. fJustCheck=false).  */
     void DisconnectBlock(
         std::pair<CBlock,bool>& disconnectedBlockAndStatus,
         CValidationState& state,


### PR DESCRIPTION
Unlike `ConnectBlock`, `DisconnectBlock` does not have a direct flag for disabling on-disk index updates (`fJustCheck`).  It has `pfClean`, which acts in a similar way (when the flag isn't passed as null, then index updates are disabled).  But this behaviour is hard to understand and perhaps unexpected for callers.

This commit refactors the way the method works, by changing `pfClean` into a clear and direct `fJustCheck` flag.  The previous "result" returned in `pfClean` is now returned from `DisconnectBlock` directly.  The new flag is used from `VerifyDB` similarly to how `fJustCheck` for `ConnectBlock` is used from this place.