### PR TITLE
Avoid undefined global initialisation order issues

### DIFF
--- a/divi/src/init.cpp
+++ b/divi/src/init.cpp
@@ -120,12 +120,18 @@ BlockMap mapBlockIndex;
 CBlockTreeDB* pblocktree = nullptr;
 CCoinsViewCache* pcoinsTip = nullptr;
 
+namespace
+{
+
 //! -paytxfee will warn if called with a higher fee than this amount (in satoshis) per KB
-static const CAmount nHighTransactionFeeWarning = 0.1 * COIN;
+const CAmount nHighTransactionFeeWarning = 0.1 * COIN;
 //! -maxtxfee will warn if called with a higher fee than this amount (in satoshis)
-static const CAmount nHighTransactionMaxFeeWarning = 100 * nHighTransactionFeeWarning;
+const CAmount nHighTransactionMaxFeeWarning = 100 * nHighTransactionFeeWarning;
 
 constexpr char FEE_ESTIMATES_FILENAME[] = "fee_estimates.dat";
+
+} // anonymous namespace
+
 CClientUIInterface uiInterface;
 
 bool fAddressIndex = false;
@@ -147,7 +153,10 @@ void InitializeWallet(std::string strWalletFile)
 #endif
 }
 
-static CCriticalSection vaultAllocationLock;
+namespace
+{
+
+CCriticalSection vaultAllocationLock;
 void ThreadSyncVaultDatabase()
 {
 #ifdef ENABLE_WALLET
@@ -192,6 +201,20 @@ void DeallocateVault()
 #endif
 }
 
+bool InitError(const std::string& str)
+{
+    uiInterface.ThreadSafeMessageBox(str, "", CClientUIInterface::MSG_ERROR);
+    return false;
+}
+
+bool InitWarning(const std::string& str)
+{
+    uiInterface.ThreadSafeMessageBox(str, "", CClientUIInterface::MSG_WARNING);
+    return true;
+}
+
+} // anonymous namespace
+
 void DeallocateWallet()
 {
 #ifdef ENABLE_WALLET
@@ -199,18 +222,6 @@ void DeallocateWallet()
     pwalletMain = nullptr;
     confirmationsCalculator.reset();
 #endif
-}
-
-bool static InitError(const std::string& str)
-{
-    uiInterface.ThreadSafeMessageBox(str, "", CClientUIInterface::MSG_ERROR);
-    return false;
-}
-
-bool static InitWarning(const std::string& str)
-{
-    uiInterface.ThreadSafeMessageBox(str, "", CClientUIInterface::MSG_WARNING);
-    return true;
 }
 
 //////////////////////////////////////////////////////////////////////////////
@@ -243,6 +254,8 @@ bool static InitWarning(const std::string& str)
 // shutdown thing.
 //
 
+namespace
+{
 
 volatile bool fRequestShutdown = false;
 volatile bool fRestartRequested = false; // if true then restart, else shutdown
@@ -279,9 +292,6 @@ public:
 #ifdef ENABLE_WALLET
 inline void FlushWallet(bool shutdown = false) { if(pwalletMain) BerkleyDBEnvWrapper().Flush(shutdown);}
 #endif
-
-namespace
-{
 
 /** Helper class for constructing and destructing the shallow databases.  */
 class ShallowDatabases
@@ -348,8 +358,6 @@ public:
 };
 
 std::unique_ptr<ShallowDatabases> ShallowDatabases::instance;
-
-} // anonymous namespace
 
 /** Preparing steps before shutting down or restarting the wallet */
 void PrepareShutdown()
@@ -432,7 +440,9 @@ bool UnitTestShutdownRequested()
   return false;
 }
 
-static StartAndShutdownSignals& startAndShutdownSignals = StartAndShutdownSignals::instance();
+StartAndShutdownSignals& startAndShutdownSignals = StartAndShutdownSignals::instance();
+
+} // anonymous namespace
 
 void EnableMainSignals()
 {
@@ -472,6 +482,8 @@ void Shutdown()
     UnloadBlockIndex();
 }
 
+namespace
+{
 
 /**
  * Signal handlers are very limited in what they are allowed to do, so:
@@ -486,7 +498,7 @@ void HandleSIGHUP(int)
     fReopenDebugLog = true;
 }
 
-static void BlockNotifyCallback(const uint256& hashNewTip)
+void BlockNotifyCallback(const uint256& hashNewTip)
 {
     std::string strCmd = settings.GetArg("-blocknotify", "");
 
@@ -1192,6 +1204,8 @@ void SubmitUnconfirmedWalletTransactionsToMempool(const CWallet& wallet)
         }
     }
 }
+
+} // anonymous namespace
 
 bool InitializeDivi(boost::thread_group& threadGroup)
 {

--- a/divi/src/spork.cpp
+++ b/divi/src/spork.cpp
@@ -41,7 +41,6 @@ extern bool ActivateBestChain(CValidationState& state, const CBlock* pblock = nu
 CAmount nTransactionValueMultiplier = 10000; // 1 / 0.0001 = 10000;
 unsigned int nTransactionSizeMultiplier = 300;
 std::map<uint256, CSporkMessage> mapSporks;
-CSporkManager sporkManager;
 
 bool ShareSporkDataWithPeer(CNode* peer, const uint256& inventoryHash)
 {
@@ -60,10 +59,11 @@ bool SporkDataIsKnown(const uint256& inventoryHash)
 }
 void ProcessSpork(CNode* pfrom, const std::string& strCommand, CDataStream& vRecv)
 {
-    sporkManager.ProcessSpork(pfrom, strCommand, vRecv);
+    GetSporkManager().ProcessSpork(pfrom, strCommand, vRecv);
 }
 CSporkManager& GetSporkManager()
 {
+    static CSporkManager sporkManager;
     return sporkManager;
 }
 


### PR DESCRIPTION
The order in which global instances are initialised is undefined in C++, so it is generally considered good practice to avoid having globals of complex types with non-trivial constructors.  This set of changes refactors two globals (the spork manager and the masternode module) into `static` variables inside an accessor function - this is quite similar, but has well-defined behaviour (namely initialisation when that function gets first called).

The main reason why this particular change is important is that those two globals depend on the `ChainstateManager`, and we are working on a well-defined life cycle of the chainstate manager during setup and shutdown.  But of course the refactorings in this PR lead even by themselves to cleaner code in general.