### PR TITLE
Singleton ChainstateManager

### DIFF
--- a/divi/src/ChainstateManager.cpp
+++ b/divi/src/ChainstateManager.cpp
@@ -1,11 +1,42 @@
 #include "ChainstateManager.h"
 
+#include <sync.h>
+
 extern BlockMap mapBlockIndex;
 extern CChain chainActive;
 extern CBlockTreeDB* pblocktree;
 extern CCoinsViewCache* pcoinsTip;
 
+namespace
+{
+
+/** The singleton instance or null if none exists.  */
+ChainstateManager* instance = nullptr;
+
+/** Lock for accessing the instance global.  */
+CCriticalSection instanceLock;
+
+} // anonymous namespace
+
 ChainstateManager::ChainstateManager ()
   : blockMap(mapBlockIndex), activeChain(chainActive),
     blockTree(*pblocktree), coinsTip(*pcoinsTip)
-{}
+{
+  LOCK (instanceLock);
+  assert (instance == nullptr);
+  instance = this;
+}
+
+ChainstateManager::~ChainstateManager ()
+{
+  LOCK (instanceLock);
+  assert (instance == this);
+  instance = nullptr;
+}
+
+ChainstateManager& ChainstateManager::Get ()
+{
+  LOCK (instanceLock);
+  assert (instance != nullptr);
+  return *instance;
+}

--- a/divi/src/ChainstateManager.h
+++ b/divi/src/ChainstateManager.h
@@ -24,8 +24,11 @@ public:
   /** Constructs a fresh instance that refers to the globals.
    *
    *  TODO: Remove the globals and instead make the instances held
-   *  by the ChainstateManager instance.  */
+   *  by the ChainstateManager instance.  Until then, the ChainstateManager
+   *  is a singleton, and only one instance must be created at a time.  */
   ChainstateManager ();
+
+  ~ChainstateManager ();
 
   inline BlockMap&
   GetBlockMap ()
@@ -74,6 +77,10 @@ public:
   {
     return coinsTip;
   }
+
+  /** Returns the singleton instance of the ChainstateManager that exists
+   *  at the moment.  It must be constructed at the moment.  */
+  static ChainstateManager& Get ();
 
 };
 

--- a/divi/src/MasternodeHelpers.cpp
+++ b/divi/src/MasternodeHelpers.cpp
@@ -49,7 +49,7 @@ bool IsBlockchainSynced()
     TRY_LOCK(cs_main, lockMain);
     if (!lockMain) return false;
 
-    const ChainstateManager chainstate;
+    const auto& chainstate = ChainstateManager::Get();
     const CBlockIndex* pindex = chainstate.ActiveChain().Tip();
     if (pindex == NULL) return false;
 
@@ -65,7 +65,7 @@ bool IsBlockchainSynced()
 
 bool GetBlockHashForScoring(uint256& hash, int nBlockHeight)
 {
-    const ChainstateManager chainstate;
+    const auto& chainstate = ChainstateManager::Get();
     const auto* tip = chainstate.ActiveChain().Tip();
     if (tip == nullptr)
         return false;
@@ -88,7 +88,7 @@ bool GetBlockHashForScoring(uint256& hash, const CBlockIndex* pindex, const int 
 const CBlockIndex* ComputeCollateralBlockIndex(const CMasternode& masternode)
 {
     static std::map<COutPoint,const CBlockIndex*> cachedCollateralBlockIndices;
-    const ChainstateManager chainstate;
+    const auto& chainstate = ChainstateManager::Get();
 
     const CBlockIndex* collateralBlockIndex = cachedCollateralBlockIndices[masternode.vin.prevout];
     if (collateralBlockIndex)
@@ -126,7 +126,7 @@ const CBlockIndex* ComputeMasternodeConfirmationBlockIndex(const CMasternode& ma
     const CBlockIndex* pindexConf = nullptr;
     {
         LOCK(cs_main);
-        const ChainstateManager chainstate;
+        const auto& chainstate = ChainstateManager::Get();
         const auto* pindexCollateral = ComputeCollateralBlockIndex(masternode);
         if (pindexCollateral == nullptr)
             pindexConf = nullptr;
@@ -142,7 +142,7 @@ const CBlockIndex* ComputeMasternodeConfirmationBlockIndex(const CMasternode& ma
 int ComputeMasternodeInputAge(const CMasternode& masternode)
 {
     LOCK(cs_main);
-    const ChainstateManager chainstate;
+    const auto& chainstate = ChainstateManager::Get();
 
     const auto* pindex = ComputeCollateralBlockIndex(masternode);
     if (pindex == nullptr)
@@ -158,7 +158,7 @@ int ComputeMasternodeInputAge(const CMasternode& masternode)
 
 CMasternodePing createCurrentPing(const CTxIn& newVin)
 {
-    const ChainstateManager chainstate;
+    const auto& chainstate = ChainstateManager::Get();
     const auto& activeChain = chainstate.ActiveChain();
 
     CMasternodePing ping;
@@ -194,7 +194,7 @@ bool ReindexingOrImportingIsActive()
 }
 CMasternodePing createDelayedMasternodePing(const CMasternode& mn)
 {
-    const ChainstateManager chainstate;
+    const auto& chainstate = ChainstateManager::Get();
     const auto& activeChain = chainstate.ActiveChain();
 
     CMasternodePing ping;

--- a/divi/src/MasternodeModule.cpp
+++ b/divi/src/MasternodeModule.cpp
@@ -149,8 +149,7 @@ namespace
 MasternodeModule& GetMutableModule()
 {
   static LocalClock localClock;
-  static ChainstateManager localChainstate;
-  static MasternodeModule mnModule(localClock, GetPeerSyncQueryService(), localChainstate, GetNetworkAddressManager());
+  static MasternodeModule mnModule(localClock, GetPeerSyncQueryService(), ChainstateManager::Get(), GetNetworkAddressManager());
   return mnModule;
 }
 

--- a/divi/src/TransactionDiskAccessor.cpp
+++ b/divi/src/TransactionDiskAccessor.cpp
@@ -18,7 +18,7 @@ extern bool fTxIndex;
 /** Return transaction in tx, and if it was found inside a block, its hash is placed in hashBlock */
 bool GetTransaction(const uint256& hash, CTransaction& txOut, uint256& hashBlock, bool fAllowSlow)
 {
-    const ChainstateManager chainstate;
+    const auto& chainstate = ChainstateManager::Get();
 
     const CBlockIndex* pindexSlow = NULL;
     {
@@ -86,7 +86,7 @@ bool CollateralIsExpectedAmount(const COutPoint &outpoint, int64_t expectedAmoun
 {
     CCoins coins;
     LOCK(cs_main);
-    const ChainstateManager chainstate;
+    const auto& chainstate = ChainstateManager::Get();
     if (!chainstate.CoinsTip().GetCoins(outpoint.hash, coins))
         return false;
 

--- a/divi/src/init.cpp
+++ b/divi/src/init.cpp
@@ -902,11 +902,8 @@ BlockLoadingStatus TryToLoadBlocks(std::string& strLoadError)
 {
     if(fReindex) uiInterface.InitMessage(translate("Reindexing requested. Skip loading block index..."));
     try {
-        uiInterface.InitMessage(translate("Preparing databases..."));
         ChainstateManager chainstate;
         UnloadBlockIndex(&chainstate);
-        ShallowDatabases::Setup(CalculateDBCacheSizes());
-        GetSporkManager().AllocateDatabase();
 
         if (fReindex)
             pblocktree->WriteReindexing(true);
@@ -1336,10 +1333,6 @@ bool InitializeDivi(boost::thread_group& threadGroup)
     PrintInitialLogHeader(fDisableWallet,numberOfFileDescriptors,strDataDir);
     StartScriptVerificationThreads(threadGroup);
 
-    if(!SetSporkKey())
-    {
-        return false;
-    }
     WarmUpRPCAndStartRPCThreads();
 
 
@@ -1368,6 +1361,14 @@ bool InitializeDivi(boost::thread_group& threadGroup)
 
     // ********************************************************* Step 7: load block chain
     CreateHardlinksForBlocks();
+
+    uiInterface.InitMessage(translate("Preparing databases..."));
+    ShallowDatabases::Setup(CalculateDBCacheSizes());
+    GetSporkManager().AllocateDatabase();
+
+    if(!SetSporkKey())
+        return false;
+
     bool fLoaded = false;
     int64_t nStart;
     while (!fLoaded) {

--- a/divi/src/init.cpp
+++ b/divi/src/init.cpp
@@ -475,7 +475,9 @@ void Shutdown()
 {
     assert(!startAndShutdownSignals.shutdown.empty());
     startAndShutdownSignals.shutdown();
-    UnloadBlockIndex();
+    /* At this point, the ChainstateManager doesn't exist anymore (and thus
+       there is also no need to free any of its contents).  */
+    UnloadBlockIndex(nullptr);
 }
 
 namespace
@@ -901,7 +903,8 @@ BlockLoadingStatus TryToLoadBlocks(std::string& strLoadError)
     if(fReindex) uiInterface.InitMessage(translate("Reindexing requested. Skip loading block index..."));
     try {
         uiInterface.InitMessage(translate("Preparing databases..."));
-        UnloadBlockIndex();
+        ChainstateManager chainstate;
+        UnloadBlockIndex(&chainstate);
         ShallowDatabases::Setup(CalculateDBCacheSizes());
         GetSporkManager().AllocateDatabase();
 

--- a/divi/src/init.cpp
+++ b/divi/src/init.cpp
@@ -907,8 +907,7 @@ BlockLoadingStatus TryToLoadBlocks(std::string& strLoadError)
 {
     if(fReindex) uiInterface.InitMessage(translate("Reindexing requested. Skip loading block index..."));
     try {
-        ChainstateManager chainstate;
-        UnloadBlockIndex(&chainstate);
+        UnloadBlockIndex(&ChainstateManager::Get());
 
         if (fReindex)
             pblocktree->WriteReindexing(true);

--- a/divi/src/init.cpp
+++ b/divi/src/init.cpp
@@ -293,6 +293,10 @@ public:
 inline void FlushWallet(bool shutdown = false) { if(pwalletMain) BerkleyDBEnvWrapper().Flush(shutdown);}
 #endif
 
+/** Global instance of the ChainstateManager.  The lifetime is managed through
+ *  the startup/shutdown cycle.  */
+std::unique_ptr<ChainstateManager> chainstateInstance;
+
 /** Helper class for constructing and destructing the shallow databases.  */
 class ShallowDatabases
 {
@@ -375,6 +379,7 @@ void PrepareShutdown()
             //record that client took the proper shutdown procedure
             pblocktree->WriteFlag("shutdown", true);
         }
+        chainstateInstance.reset ();
         GetSporkManager().DeallocateDatabase();
         ShallowDatabases::Cleanup();
     }
@@ -1364,6 +1369,7 @@ bool InitializeDivi(boost::thread_group& threadGroup)
 
     uiInterface.InitMessage(translate("Preparing databases..."));
     ShallowDatabases::Setup(CalculateDBCacheSizes());
+    chainstateInstance.reset(new ChainstateManager ());
     GetSporkManager().AllocateDatabase();
 
     if(!SetSporkKey())

--- a/divi/src/main.cpp
+++ b/divi/src/main.cpp
@@ -2255,19 +2255,22 @@ bool static LoadBlockIndexState(string& strError)
     return true;
 }
 
-void UnloadBlockIndex()
+void UnloadBlockIndex(ChainstateManager* chainstate)
 {
-    ChainstateManager chainstate;
-    auto& blockMap = chainstate.GetBlockMap();
-
-    for(auto& blockHashAndBlockIndex: blockMap)
-    {
-        delete blockHashAndBlockIndex.second;
-    }
-    blockMap.clear();
     setBlockIndexCandidates.clear();
-    chainstate.ActiveChain().SetTip(nullptr);
-    pindexBestInvalid = NULL;
+    pindexBestInvalid = nullptr;
+
+    if (chainstate != nullptr)
+    {
+        auto& blockMap = chainstate->GetBlockMap();
+
+        for(auto& blockHashAndBlockIndex: blockMap)
+        {
+            delete blockHashAndBlockIndex.second;
+        }
+        blockMap.clear();
+        chainstate->ActiveChain().SetTip(nullptr);
+    }
 }
 
 bool LoadBlockIndex(string& strError)

--- a/divi/src/main.cpp
+++ b/divi/src/main.cpp
@@ -222,7 +222,7 @@ void UnregisterAllValidationInterfaces()
 //
 int GetHeight()
 {
-    const ChainstateManager chainstate;
+    const auto& chainstate = ChainstateManager::Get();
     while (true) {
         TRY_LOCK(cs_main, lockMain);
         if (!lockMain) {
@@ -235,7 +235,7 @@ int GetHeight()
 
 const CBlockIndex* FindForkInGlobalIndex(const CChain& chain, const CBlockLocator& locator)
 {
-    const ChainstateManager chainstate;
+    const auto& chainstate = ChainstateManager::Get();
     const auto& blockMap = chainstate.GetBlockMap();
 
     // Find the first block the caller has in the main chain
@@ -262,7 +262,7 @@ bool IsStandardTx(const CTransaction& tx, string& reason)
         return false;
     }
 
-    const ChainstateManager chainstate;
+    const auto& chainstate = ChainstateManager::Get();
     const auto& chain = chainstate.ActiveChain();
 
     // Treat non-final transactions as non-standard to prevent a specific type
@@ -594,7 +594,7 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState& state, const CTransa
 
 
     {
-        const ChainstateManager chainstate;
+        const auto& chainstate = ChainstateManager::Get();
         CCoinsViewCache view;
 
         CAmount nValueIn = 0;
@@ -708,7 +708,7 @@ bool IsInitialBlockDownload()	//2446
 {
     LOCK(cs_main);
 
-    const ChainstateManager chainstate;
+    const auto& chainstate = ChainstateManager::Get();
     const int64_t height = chainstate.ActiveChain().Height();
 
     if (fImporting || fReindex || fVerifyingBlocks || height < checkpointsVerifier.GetTotalBlocksEstimate())
@@ -741,7 +741,7 @@ void CheckForkWarningConditions()
     if (IsInitialBlockDownload())
         return;
 
-    const ChainstateManager chainstate;
+    const auto& chainstate = ChainstateManager::Get();
     const auto& chain = chainstate.ActiveChain();
 
     // If our best fork is no longer within 72 blocks (+/- 3 hours if no one mines it)
@@ -778,7 +778,7 @@ static void CheckForkWarningConditionsOnNewFork(const CBlockIndex* pindexNewFork
 {
     AssertLockHeld(cs_main);
 
-    const ChainstateManager chainstate;
+    const auto& chainstate = ChainstateManager::Get();
     const auto& chain = chainstate.ActiveChain();
 
     // If we are on a fork that is sufficiently large, set a warning flag
@@ -817,7 +817,7 @@ void InvalidChainFound(CBlockIndex* pindexNew)
     if (!pindexBestInvalid || pindexNew->nChainWork > pindexBestInvalid->nChainWork)
         pindexBestInvalid = pindexNew;
 
-    const ChainstateManager chainstate;
+    const auto& chainstate = ChainstateManager::Get();
     const auto& chain = chainstate.ActiveChain();
 
     LogPrintf("InvalidChainFound: invalid block=%s  height=%d  log2_work=%.8g  date=%s\n",
@@ -957,7 +957,7 @@ bool CheckMintTotalsAndBlockPayees(
 const ActiveChainManager& GetActiveChainManager()
 {
     static const BlockDiskDataReader blockDiskReader;
-    static ChainstateManager chainstate;
+    static auto& chainstate = ChainstateManager::Get();
     static ActiveChainManager chainManager(fAddressIndex,fSpentIndex, &chainstate.BlockTree(), blockDiskReader);
     return chainManager;
 }
@@ -971,7 +971,7 @@ bool ConnectBlock(
     bool fAlreadyChecked)
 {
     AssertLockHeld(cs_main);
-    ChainstateManager chainstate;
+    auto& chainstate = ChainstateManager::Get();
 
     // Check it again in case a previous version let a bad block in
     if (!fAlreadyChecked && !CheckBlock(block, state))
@@ -1045,7 +1045,7 @@ bool static FlushStateToDisk(CValidationState& state, FlushStateMode mode)
 {
     LOCK(cs_main);
 
-    ChainstateManager chainstate;
+    auto& chainstate = ChainstateManager::Get();
     auto& coinsTip = chainstate.CoinsTip();
     auto& blockTreeDB = chainstate.BlockTree();
 
@@ -1095,7 +1095,7 @@ void FlushStateToDisk(FlushStateMode mode)
 /** Update chainActive and related internal data structures. */
 void static UpdateTip(const CBlockIndex* pindexNew)
 {
-    ChainstateManager chainstate;
+    auto& chainstate = ChainstateManager::Get();
     auto& chain = chainstate.ActiveChain();
     chain.SetTip(pindexNew);
 
@@ -1133,7 +1133,7 @@ bool static DisconnectTip(CValidationState& state)
 {
     AssertLockHeld(cs_main);
 
-    ChainstateManager chainstate;
+    auto& chainstate = ChainstateManager::Get();
     auto& coinsTip = chainstate.CoinsTip();
     const auto& blockMap = chainstate.GetBlockMap();
     const auto& chain = chainstate.ActiveChain();
@@ -1188,7 +1188,7 @@ bool static ConnectTip(CValidationState& state, CBlockIndex* pindexNew, const CB
 {
     AssertLockHeld(cs_main);
 
-    ChainstateManager chainstate;
+    auto& chainstate = ChainstateManager::Get();
     auto& coinsTip = chainstate.CoinsTip();
     const auto& blockMap = chainstate.GetBlockMap();
 
@@ -1280,7 +1280,7 @@ bool DisconnectBlocksAndReprocess(int blocks)
  */
 static CBlockIndex* FindMostWorkChain()
 {
-    const ChainstateManager chainstate;
+    const auto& chainstate = ChainstateManager::Get();
     const auto& chain = chainstate.ActiveChain();
 
     do {
@@ -1339,7 +1339,7 @@ static CBlockIndex* FindMostWorkChain()
 /** Delete all entries in setBlockIndexCandidates that are worse than the current tip. */
 static void PruneBlockIndexCandidates()
 {
-    const ChainstateManager chainstate;
+    const auto& chainstate = ChainstateManager::Get();
     const auto& chain = chainstate.ActiveChain();
 
     // Note that we can't delete the current block itself, as we may need to return to it later in case a
@@ -1360,7 +1360,7 @@ static bool ActivateBestChainStep(CValidationState& state, CBlockIndex* pindexMo
 {
     AssertLockHeld(cs_main);
 
-    const ChainstateManager chainstate;
+    const auto& chainstate = ChainstateManager::Get();
     const auto& chain = chainstate.ActiveChain();
 
     if (pblock == NULL)
@@ -1434,7 +1434,7 @@ static bool ActivateBestChainStep(CValidationState& state, CBlockIndex* pindexMo
  */
 bool ActivateBestChain(CValidationState& state, const CBlock* pblock, bool fAlreadyChecked)
 {
-    const ChainstateManager chainstate;
+    const auto& chainstate = ChainstateManager::Get();
     const auto& chain = chainstate.ActiveChain();
 
     const CBlockIndex* pindexNewTip = NULL;
@@ -1491,7 +1491,7 @@ bool InvalidateBlock(CValidationState& state, CBlockIndex* pindex)
 {
     AssertLockHeld(cs_main);
 
-    ChainstateManager chainstate;
+    auto& chainstate = ChainstateManager::Get();
     const auto& chain = chainstate.ActiveChain();
     auto& blockMap = chainstate.GetBlockMap();
 
@@ -1528,7 +1528,7 @@ bool ReconsiderBlock(CValidationState& state, CBlockIndex* pindex)
 {
     AssertLockHeld(cs_main);
 
-    ChainstateManager chainstate;
+    auto& chainstate = ChainstateManager::Get();
     const auto& chain = chainstate.ActiveChain();
 
     int nHeight = pindex->nHeight;
@@ -1562,7 +1562,7 @@ bool ReconsiderBlock(CValidationState& state, CBlockIndex* pindex)
 
 CBlockIndex* AddToBlockIndex(const CBlock& block)
 {
-    ChainstateManager chainstate;
+    auto& chainstate = ChainstateManager::Get();
     auto& blockMap = chainstate.GetBlockMap();
 
     static const CSporkManager& sporkManager = GetSporkManager();
@@ -1640,7 +1640,7 @@ bool ReceivedBlockTransactions(const CBlock& block, CValidationState& state, CBl
     BlockFileHelpers::RecordDirtyBlockIndex(pindexNew);
 
     if (pindexNew->pprev == NULL || pindexNew->pprev->nChainTx) {
-        const ChainstateManager chainstate;
+        const auto& chainstate = ChainstateManager::Get();
         const auto& chain = chainstate.ActiveChain();
 
         // If pindexNew is the genesis block or all parents are BLOCK_VALID_TRANSACTIONS.
@@ -1768,7 +1768,7 @@ bool ContextualCheckBlockHeader(const CBlockHeader& block, CValidationState& sta
 
     assert(pindexPrev);
 
-    const ChainstateManager chainstate;
+    const auto& chainstate = ChainstateManager::Get();
     int nHeight = pindexPrev->nHeight + 1;
 
     //If this is a reorg, check that it is not too deep
@@ -1805,7 +1805,7 @@ bool ContextualCheckBlockHeader(const CBlockHeader& block, CValidationState& sta
 
 bool ContextualCheckBlock(const CBlock& block, CValidationState& state, CBlockIndex* const pindexPrev)
 {
-    const ChainstateManager chainstate;
+    const auto& chainstate = ChainstateManager::Get();
     const auto& chain = chainstate.ActiveChain();
 
     const int nHeight = pindexPrev == NULL ? 0 : pindexPrev->nHeight + 1;
@@ -1833,7 +1833,7 @@ bool AcceptBlockHeader(const CBlock& block, CValidationState& state, CBlockIndex
 {
     AssertLockHeld(cs_main);
 
-    const ChainstateManager chainstate;
+    const auto& chainstate = ChainstateManager::Get();
     const auto& blockMap = chainstate.GetBlockMap();
 
     // Check for duplicate
@@ -1893,7 +1893,7 @@ bool AcceptBlock(CBlock& block, CValidationState& state, CBlockIndex** ppindex, 
 {
     AssertLockHeld(cs_main);
 
-    const ChainstateManager chainstate;
+    const auto& chainstate = ChainstateManager::Get();
     const auto& blockMap = chainstate.GetBlockMap();
 
     CBlockIndex*& pindex = *ppindex;
@@ -1983,7 +1983,7 @@ bool ProcessNewBlock(CValidationState& state, CNode* pfrom, CBlock* pblock, CDis
     if (!CheckBlockSignature(*pblock))
         return error("%s : bad proof-of-stake block signature",__func__);
 
-    const ChainstateManager chainstate;
+    const auto& chainstate = ChainstateManager::Get();
     const auto& blockMap = chainstate.GetBlockMap();
 
     if (pblock->GetHash() != Params().HashGenesisBlock() && pfrom != NULL) {
@@ -2028,7 +2028,7 @@ bool IsBlockValidChainExtension(CBlock* pblock)
 {
     {
         LOCK(cs_main);
-        const ChainstateManager chainstate;
+        const auto& chainstate = ChainstateManager::Get();
         if (pblock->hashPrevBlock != chainstate.ActiveChain().Tip()->GetBlockHash())
             return error("%s : generated block is stale",__func__);
     }
@@ -2112,7 +2112,7 @@ static bool VerifyAllBlockFilesArePresent(const BlockMap& blockIndicesByHash)
 
 bool static LoadBlockIndexState(string& strError)
 {
-    ChainstateManager chainstate;
+    auto& chainstate = ChainstateManager::Get();
     auto& chain = chainstate.ActiveChain();
     auto& coinsTip = chainstate.CoinsTip();
     auto& blockMap = chainstate.GetBlockMap();
@@ -2286,7 +2286,7 @@ bool InitBlockIndex()
 {
     LOCK(cs_main);
 
-    ChainstateManager chainstate;
+    auto& chainstate = ChainstateManager::Get();
     auto& blockTree = chainstate.BlockTree();
 
     // Check whether we're already initialized
@@ -2339,7 +2339,7 @@ bool LoadExternalBlockFile(FILE* fileIn, CDiskBlockPos* dbp)
     static std::multimap<uint256, CDiskBlockPos> mapBlocksUnknownParent;
     int64_t nStart = GetTimeMillis();
 
-    const ChainstateManager chainstate;
+    const auto& chainstate = ChainstateManager::Get();
     const auto& blockMap = chainstate.GetBlockMap();
 
     int nLoaded = 0;
@@ -2444,7 +2444,7 @@ void static CheckBlockIndex()
 
     LOCK(cs_main);
 
-    const ChainstateManager chainstate;
+    const auto& chainstate = ChainstateManager::Get();
     const auto& blockMap = chainstate.GetBlockMap();
     const auto& chain = chainstate.ActiveChain();
 
@@ -2642,7 +2642,7 @@ bool static AlreadyHave(const CInv& inv)
     }
 
     case MSG_BLOCK: {
-        const ChainstateManager chainstate;
+        const auto& chainstate = ChainstateManager::Get();
         return chainstate.GetBlockMap().count(inv.GetHash()) > 0;
     }
     case MSG_TXLOCK_REQUEST:
@@ -2714,7 +2714,7 @@ static std::pair<const CBlockIndex*, bool> GetBlockIndexOfRequestedBlock(NodeId 
     {
         LOCK(cs_main);
 
-        const ChainstateManager chainstate;
+        const auto& chainstate = ChainstateManager::Get();
         const auto& blockMap = chainstate.GetBlockMap();
         const auto& chain = chainstate.ActiveChain();
 
@@ -2775,7 +2775,7 @@ static void PushCorrespondingBlockToPeer(CNode* pfrom, const CBlockIndex* blockT
 
 void static ProcessGetData(CNode* pfrom, std::deque<CInv>& requestsForData)
 {
-    const ChainstateManager chainstate;
+    const auto& chainstate = ChainstateManager::Get();
 
     auto it = requestsForData.begin();
 
@@ -2966,7 +2966,7 @@ bool static ProcessMessage(CNode* pfrom, std::string strCommand, CDataStream& vR
         return true;
     }
 
-    const ChainstateManager chainstate;
+    const auto& chainstate = ChainstateManager::Get();
     const auto& coinsTip = chainstate.CoinsTip();
     const auto& blockMap = chainstate.GetBlockMap();
     const auto& chain = chainstate.ActiveChain();
@@ -3690,7 +3690,7 @@ static void BeginSyncingWithPeer(CNode* pto)
 {
     CNodeState* state = pto->GetNodeState();
     if (!state->Syncing() && !pto->fClient && !fReindex) {
-        const ChainstateManager chainstate;
+        const auto& chainstate = ChainstateManager::Get();
         const auto& chain = chainstate.ActiveChain();
 
         // Only actively request headers from a single peer, unless we're close to end of initial download.
@@ -3763,7 +3763,7 @@ static void RequestDisconnectionFromNodeIfStalling(int64_t nNow, CNode* pto)
 }
 static void CollectBlockDataToRequest(int64_t nNow, CNode* pto, std::vector<CInv>& vGetData)
 {
-    const ChainstateManager chainstate;
+    const auto& chainstate = ChainstateManager::Get();
     const auto& chain = chainstate.ActiveChain();
     const auto& blockMap = chainstate.GetBlockMap();
 
@@ -3852,7 +3852,7 @@ void PeriodicallyRebroadcastMempoolTxs()
 
 bool SendMessages(CNode* pto, bool fSendTrickle)
 {
-    const ChainstateManager chainstate;
+    const auto& chainstate = ChainstateManager::Get();
 
     {
         if (fSendTrickle) {

--- a/divi/src/main.h
+++ b/divi/src/main.h
@@ -22,6 +22,7 @@ struct CBlockLocator;
 class CBlockHeader;
 class CBlockIndex;
 class CBlockTreeDB;
+class ChainstateManager;
 class CSporkDB;
 class CInv;
 class CScriptCheck;
@@ -73,8 +74,11 @@ bool LoadExternalBlockFile(FILE* fileIn, CDiskBlockPos* dbp = NULL);
 bool InitBlockIndex();
 /** Load the block tree and coins database from disk */
 bool LoadBlockIndex(std::string& strError);
-/** Unload database information */
-void UnloadBlockIndex();
+/** Unload database information.  If a ChainstateManager is present,
+ *  the block map inside (and all other in-memory information) is unloaded.
+ *  Otherwise just local data (e.g. validated but not yet attached
+ *  CBlockIndex instances) is removed.  */
+void UnloadBlockIndex(ChainstateManager* chainstate);
 /** Process protocol messages received from a given node */
 bool ProcessReceivedMessages(CNode* pfrom);
 /**

--- a/divi/src/miner.cpp
+++ b/divi/src/miner.cpp
@@ -46,7 +46,7 @@ void InitializeCoinMintingModule(I_StakingWallet* pwallet)
     static const CChainParams& chainParameters = Params();
     static const MasternodeModule& masternodeModule = GetMasternodeModule();
     static const I_PeerBlockNotifyService& peerNotification = GetPeerBlockNotifyService();
-    static const ChainstateManager chainstate;
+    static const auto& chainstate = ChainstateManager::Get();
     coinMintingModule.reset(
         new CoinMintingModule(
             settings,
@@ -122,7 +122,7 @@ void MinterThread(I_CoinMinter& minter)
 bool HasRecentlyAttemptedToGenerateProofOfStake()
 {
     static const LastExtensionTimestampByBlockHeight& mapHashedBlocks = getLastExtensionTimestampByBlockHeight();
-    const ChainstateManager chainstate;
+    const auto& chainstate = ChainstateManager::Get();
     bool recentlyAttemptedPoS = false;
     if (mapHashedBlocks.count(chainstate.ActiveChain().Tip()->nHeight))
         recentlyAttemptedPoS = true;

--- a/divi/src/rest.cpp
+++ b/divi/src/rest.cpp
@@ -114,7 +114,7 @@ static bool rest_block(AcceptedConnection* conn,
     CBlockIndex* pblockindex = NULL;
     {
         LOCK(cs_main);
-        const ChainstateManager chainstate;
+        const auto& chainstate = ChainstateManager::Get();
         const auto& blockMap = chainstate.GetBlockMap();
 
         const auto mit = blockMap.find(hash);

--- a/divi/src/rpcblockchain.cpp
+++ b/divi/src/rpcblockchain.cpp
@@ -42,7 +42,7 @@ extern const CBlockIndex* pindexBestHeader;
 
 double GetDifficulty(const CBlockIndex* blockindex)
 {
-    const ChainstateManager chainstate;
+    const auto& chainstate = ChainstateManager::Get();
 
     // Floating point number that is a multiple of the minimum difficulty,
     // minimum difficulty = 1.0.
@@ -72,7 +72,7 @@ double GetDifficulty(const CBlockIndex* blockindex)
 
 Object blockToJSON(const CBlock& block, const CBlockIndex* blockindex, bool txDetails = false)
 {
-    const ChainstateManager chainstate;
+    const auto& chainstate = ChainstateManager::Get();
 
     Object result;
     result.push_back(Pair("hash", block.GetHash().GetHex()));
@@ -139,7 +139,7 @@ Value getblockcount(const Array& params, bool fHelp)
             "\nExamples:\n" +
             HelpExampleCli("getblockcount", "") + HelpExampleRpc("getblockcount", ""));
 
-    return ChainstateManager().ActiveChain().Height();
+    return ChainstateManager::Get().ActiveChain().Height();
 }
 
 Value getbestblockhash(const Array& params, bool fHelp)
@@ -153,7 +153,7 @@ Value getbestblockhash(const Array& params, bool fHelp)
             "\nExamples\n" +
             HelpExampleCli("getbestblockhash", "") + HelpExampleRpc("getbestblockhash", ""));
 
-    return ChainstateManager().ActiveChain().Tip()->GetBlockHash().GetHex();
+    return ChainstateManager::Get().ActiveChain().Tip()->GetBlockHash().GetHex();
 }
 
 Value getdifficulty(const Array& params, bool fHelp)
@@ -206,7 +206,7 @@ Value getrawmempool(const Array& params, bool fHelp)
         fVerbose = params[0].get_bool();
 
     if (fVerbose) {
-        const ChainstateManager chainstate;
+        const auto& chainstate = ChainstateManager::Get();
         LOCK(mempool.cs);
         Object o;
         BOOST_FOREACH (const PAIRTYPE(uint256, CTxMemPoolEntry) & entry, mempool.mapTx) {
@@ -256,7 +256,7 @@ Value getblockhash(const Array& params, bool fHelp)
             "\nExamples:\n" +
             HelpExampleCli("getblockhash", "1000") + HelpExampleRpc("getblockhash", "1000"));
 
-    const ChainstateManager chainstate;
+    const auto& chainstate = ChainstateManager::Get();
 
     int nHeight = params[0].get_int();
     if (nHeight < 0 || nHeight > chainstate.ActiveChain().Height())
@@ -308,7 +308,7 @@ Value getblock(const Array& params, bool fHelp)
     if (params.size() > 1)
         fVerbose = params[1].get_bool();
 
-    const ChainstateManager chainstate;
+    const auto& chainstate = ChainstateManager::Get();
     const auto& blockMap = chainstate.GetBlockMap();
     const auto mit = blockMap.find(hash);
     if (mit == blockMap.end())
@@ -361,7 +361,7 @@ Value getblockheader(const Array& params, bool fHelp)
     if (params.size() > 1)
         fVerbose = params[1].get_bool();
 
-    const ChainstateManager chainstate;
+    const auto& chainstate = ChainstateManager::Get();
     const auto& blockMap = chainstate.GetBlockMap();
     const auto mit = blockMap.find(hash);
     if (mit == blockMap.end())
@@ -405,7 +405,7 @@ Value gettxoutsetinfo(const Array& params, bool fHelp)
 
     Object ret;
 
-    const ChainstateManager chainstate;
+    const auto& chainstate = ChainstateManager::Get();
 
     CCoinsStats stats;
     FlushStateToDisk();
@@ -466,7 +466,7 @@ Value gettxout(const Array& params, bool fHelp)
         fMempool = params[2].get_bool();
 
     /* FIXME: mark const */
-    ChainstateManager chainstate;
+    auto& chainstate = ChainstateManager::Get();
 
     CCoins coins;
     if (fMempool) {
@@ -516,7 +516,7 @@ Value verifychain(const Array& params, bool fHelp)
 
     LOCK(cs_main);
     const ActiveChainManager& chainManager = GetActiveChainManager();
-    const ChainstateManager chainstate;
+    const auto& chainstate = ChainstateManager::Get();
     const CVerifyDB dbVerifier(
         chainManager,
         chainstate.ActiveChain(),
@@ -546,7 +546,7 @@ Value getblockchaininfo(const Array& params, bool fHelp)
             "\nExamples:\n" +
             HelpExampleCli("getblockchaininfo", "") + HelpExampleRpc("getblockchaininfo", ""));
 
-    const ChainstateManager chainstate;
+    const auto& chainstate = ChainstateManager::Get();
 
     Object obj;
     obj.push_back(Pair("chain", Params().NetworkIDString()));
@@ -604,7 +604,7 @@ Value getchaintips(const Array& params, bool fHelp)
             "\nExamples:\n" +
             HelpExampleCli("getchaintips", "") + HelpExampleRpc("getchaintips", ""));
 
-    const ChainstateManager chainstate;
+    const auto& chainstate = ChainstateManager::Get();
 
     /* Build up a list of chain tips.  We start with the list of all
        known blocks, and successively remove blocks that appear as pprev
@@ -697,7 +697,7 @@ Value invalidateblock(const Array& params, bool fHelp)
     CValidationState state;
 
     {
-        ChainstateManager chainstate;
+        auto& chainstate = ChainstateManager::Get();
         LOCK(cs_main);
         auto& blockMap = chainstate.GetBlockMap();
         const auto mit = blockMap.find(hash);
@@ -737,7 +737,7 @@ Value reconsiderblock(const Array& params, bool fHelp)
     CValidationState state;
 
     {
-        ChainstateManager chainstate;
+        auto& chainstate = ChainstateManager::Get();
         LOCK(cs_main);
         auto& blockMap = chainstate.GetBlockMap();
         const auto mit = blockMap.find(hash);

--- a/divi/src/rpclottery.cpp
+++ b/divi/src/rpclottery.cpp
@@ -42,7 +42,7 @@ Value getlotteryblockwinners(const Array& params, bool fHelp)
 
     static const CChainParams& chainParameters = Params();
     static SuperblockSubsidyContainer subsidyCointainer(chainParameters);
-    static const ChainstateManager chainstate;
+    static const auto& chainstate = ChainstateManager::Get();
     static LotteryWinnersCalculator calculator(
         chainParameters.GetLotteryBlockStartBlock(), chainstate.ActiveChain(), GetSporkManager(),subsidyCointainer.superblockHeightValidator());
     const CBlockIndex* chainTip = nullptr;

--- a/divi/src/rpcmasternode.cpp
+++ b/divi/src/rpcmasternode.cpp
@@ -388,7 +388,7 @@ Value listmasternodes(const Array& params, bool fHelp)
     Array ret;
     const CBlockIndex* pindex;
     {
-        const ChainstateManager chainstate;
+        const auto& chainstate = ChainstateManager::Get();
         LOCK(cs_main);
         pindex = chainstate.ActiveChain().Tip();
         if(!pindex) return 0;
@@ -435,7 +435,7 @@ Value getmasternodecount (const Array& params, bool fHelp)
             "\nExamples:\n" +
             HelpExampleCli("getmasternodecount", "") + HelpExampleRpc("getmasternodecount", ""));
 
-    const ChainstateManager chainstate;
+    const auto& chainstate = ChainstateManager::Get();
     const CBlockIndex* tip = chainstate.ActiveChain().Tip();
     MasternodeCountData data = GetMasternodeCounts(tip);
 
@@ -642,7 +642,7 @@ Value getmasternodewinners (const Array& params, bool fHelp)
     int nHeight;
     const CBlockIndex* pindex = nullptr;
     {
-        const ChainstateManager chainstate;
+        const auto& chainstate = ChainstateManager::Get();
         LOCK(cs_main);
         pindex = chainstate.ActiveChain().Tip();
         if(!pindex) return 0;

--- a/divi/src/rpcmining.cpp
+++ b/divi/src/rpcmining.cpp
@@ -90,7 +90,7 @@ Value setgenerate(const Array& params, bool fHelp)
     int nHeightEnd = 0;
     int nHeight = 0;
 
-    const ChainstateManager chainstate;
+    const auto& chainstate = ChainstateManager::Get();
     const auto& chain = chainstate.ActiveChain();
 
     { // Don't keep cs_main locked
@@ -151,7 +151,7 @@ Value generateblock(const Array& params, bool fHelp)
 
     int nHeight = 0;
 
-    const ChainstateManager chainstate;
+    const auto& chainstate = ChainstateManager::Get();
     const auto& chain = chainstate.ActiveChain();
 
     { // Don't keep cs_main locked
@@ -235,7 +235,7 @@ Value getmininginfo(const Array& params, bool fHelp)
             "\nExamples:\n" +
             HelpExampleCli("getmininginfo", "") + HelpExampleRpc("getmininginfo", ""));
 
-    const ChainstateManager chainstate;
+    const auto& chainstate = ChainstateManager::Get();
 
     Object obj;
     obj.push_back(Pair("blocks", (int)chainstate.ActiveChain().Height()));

--- a/divi/src/rpcmisc.cpp
+++ b/divi/src/rpcmisc.cpp
@@ -137,7 +137,7 @@ Value getinfo(const Array& params, bool fHelp)
     proxyType proxy;
     GetProxy(NET_IPV4, proxy);
 
-    const ChainstateManager chainstate;
+    const auto& chainstate = ChainstateManager::Get();
     const auto& chain = chainstate.ActiveChain();
 
     Object obj;
@@ -663,7 +663,7 @@ Value getaddresstxids(const Array& params, bool fHelp)
 
     std::vector<std::pair<CAddressIndexKey, CAmount> > addressIndex;
 
-    const ChainstateManager chainstate;
+    const auto& chainstate = ChainstateManager::Get();
     const auto& blockTree = chainstate.BlockTree();
 
     for (std::vector<std::pair<uint160, int> >::iterator it = addresses.begin(); it != addresses.end(); it++) {
@@ -764,7 +764,7 @@ Value getaddressdeltas(const Array& params, bool fHelp)
 
     std::vector<std::pair<CAddressIndexKey, CAmount> > addressIndex;
 
-    const ChainstateManager chainstate;
+    const auto& chainstate = ChainstateManager::Get();
     const auto& blockTree = chainstate.BlockTree();
 
     for (std::vector<std::pair<uint160, int> >::iterator it = addresses.begin(); it != addresses.end(); it++) {
@@ -802,7 +802,7 @@ Value getaddressdeltas(const Array& params, bool fHelp)
     if (includeChainInfo && start > 0 && end > 0) {
         LOCK(cs_main);
 
-        const ChainstateManager chainstate;
+        const auto& chainstate = ChainstateManager::Get();
         const auto& chain = chainstate.ActiveChain();
 
         if (start > chain.Height() || end > chain.Height()) {
@@ -861,7 +861,7 @@ Value getaddressbalance(const Array& params, bool fHelp)
 
     std::vector<std::pair<CAddressIndexKey, CAmount> > addressIndex;
 
-    const ChainstateManager chainstate;
+    const auto& chainstate = ChainstateManager::Get();
 
     for (std::vector<std::pair<uint160, int> >::iterator it = addresses.begin(); it != addresses.end(); it++) {
         if (!TransactionSearchIndexes::GetAddressIndex(fAddressIndex, &chainstate.BlockTree(), (*it).first, (*it).second, addressIndex)) {
@@ -933,7 +933,7 @@ Value getspentinfo(const Array& params, bool fHelp)
     const CSpentIndexKey key(txid, outputIndex);
     CSpentIndexValue value;
 
-    const ChainstateManager chainstate;
+    const auto& chainstate = ChainstateManager::Get();
 
     if (!TransactionSearchIndexes::GetSpentIndex(fSpentIndex, &chainstate.BlockTree(), key, value)) {
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Unable to get spent info");
@@ -990,7 +990,7 @@ Value getaddressutxos(const Array& params, bool fHelp)
 
     std::vector<std::pair<CAddressUnspentKey, CAddressUnspentValue>> unspentOutputs;
 
-    const ChainstateManager chainstate;
+    const auto& chainstate = ChainstateManager::Get();
 
     for (std::vector<std::pair<uint160, int> >::iterator it = addresses.begin(); it != addresses.end(); it++) {
         if (!TransactionSearchIndexes::GetAddressUnspent(fAddressIndex, &chainstate.BlockTree(), (*it).first, (*it).second, unspentOutputs)) {
@@ -1023,7 +1023,7 @@ Value getaddressutxos(const Array& params, bool fHelp)
         result.push_back(Pair("utxos", utxos));
 
         LOCK(cs_main);
-        const ChainstateManager chainstate;
+        const auto& chainstate = ChainstateManager::Get();
         const auto& chain = chainstate.ActiveChain();
         result.push_back(Pair("hash", chain.Tip()->GetBlockHash().GetHex()));
         result.push_back(Pair("height", (int)chain.Height()));
@@ -1077,7 +1077,7 @@ Value getstakingstatus(const Array& params, bool fHelp)
             "\nExamples:\n" +
             HelpExampleCli("getstakingstatus", "") + HelpExampleRpc("getstakingstatus", ""));
 
-    const ChainstateManager chainstate;
+    const auto& chainstate = ChainstateManager::Get();
 
     Object obj;
     obj.push_back(Pair("validtime", chainstate.ActiveChain().Tip()->nTime > 1471482000));

--- a/divi/src/rpcrawtransaction.cpp
+++ b/divi/src/rpcrawtransaction.cpp
@@ -76,7 +76,7 @@ void TxToJSONExpanded(const CTransaction& tx, const uint256 hashBlock, Object& e
                       int nHeight = 0, int nConfirmations = 0, int nBlockTime = 0)
 {
 
-    const ChainstateManager chainstate;
+    const auto& chainstate = ChainstateManager::Get();
     const auto& blockTree = chainstate.BlockTree();
 
     uint256 txid = tx.GetHash();
@@ -199,7 +199,7 @@ void TxToJSON(const CTransaction& tx, const uint256 hashBlock, Object& entry)
     entry.push_back(Pair("vout", vout));
 
     if (hashBlock != 0) {
-        const ChainstateManager chainstate;
+        const auto& chainstate = ChainstateManager::Get();
         const auto& chain = chainstate.ActiveChain();
         const auto& blockMap = chainstate.GetBlockMap();
 
@@ -298,7 +298,7 @@ Value getrawtransaction(const Array& params, bool fHelp)
         if (!GetTransaction(hash, tx, hashBlock, true))
             throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "No information available about transaction");
 
-        const ChainstateManager chainstate;
+        const auto& chainstate = ChainstateManager::Get();
         const auto& chain = chainstate.ActiveChain();
         const auto& blockMap = chainstate.GetBlockMap();
 
@@ -716,7 +716,7 @@ Value signrawtransaction(const Array& params, bool fHelp)
     CCoinsViewCache view;
     {
         LOCK(mempool.cs);
-        const ChainstateManager chainstate;
+        const auto& chainstate = ChainstateManager::Get();
         const CCoinsViewCache& viewChain = chainstate.CoinsTip();
         const CCoinsViewMemPool viewMempool(&viewChain, mempool);
         view.SetBackend(viewMempool); // temporarily switch cache backend to db+mempool view
@@ -851,7 +851,7 @@ Value signrawtransaction(const Array& params, bool fHelp)
 static std::pair<CAmount,bool> ComputeFeeTotalsAndIfInputsAreKnown(const CTransaction& tx)
 {
     LOCK(mempool.cs);
-    const ChainstateManager chainstate;
+    const auto& chainstate = ChainstateManager::Get();
     const CCoinsViewMemPool viewMemPool(&chainstate.CoinsTip(), mempool);
     const CCoinsViewCache view(&viewMemPool);
 
@@ -896,7 +896,7 @@ Value sendrawtransaction(const Array& params, bool fHelp)
     if (params.size() > 1)
         fOverrideFees = params[1].get_bool();
 
-    const ChainstateManager chainstate;
+    const auto& chainstate = ChainstateManager::Get();
     const auto& view = chainstate.CoinsTip();
     const bool fHaveMempool = mempool.exists(hashTx);
 

--- a/divi/src/rpcwallet.cpp
+++ b/divi/src/rpcwallet.cpp
@@ -248,7 +248,7 @@ void WalletTxToJSON(const CWallet& wallet, const CWalletTx& wtx, Object& entry)
     if (wtx.IsCoinBase() || wtx.IsCoinStake())
         entry.push_back(Pair("generated", true));
     if (confirms > 0) {
-        const ChainstateManager chainstate;
+        const auto& chainstate = ChainstateManager::Get();
         entry.push_back(Pair("blockhash", wtx.hashBlock.GetHex()));
         entry.push_back(Pair("blockindex", wtx.merkleBranchIndex));
         entry.push_back(Pair("blocktime", chainstate.GetBlockMap().at(wtx.hashBlock)->GetBlockTime()));
@@ -381,7 +381,7 @@ CBitcoinAddress GetAccountAddress(CWallet& wallet, string strAccount, bool bForc
 
 CAmount GetAccountBalance(const string& strAccount, int nMinDepth, const UtxoOwnershipFilter& filter)
 {
-    const ChainstateManager chainstate;
+    const auto& chainstate = ChainstateManager::Get();
     const auto& chain = chainstate.ActiveChain();
 
     CAmount nBalance = 0;
@@ -1031,7 +1031,7 @@ Value addvault(const Array& params, bool fHelp)
         return result;
     }
 
-    const ChainstateManager chainstate;
+    const auto& chainstate = ChainstateManager::Get();
     const CBlockIndex* blockSearchStart = chainstate.ActiveChain().Tip();
     while (blockSearchStart->pprev)
     {
@@ -1215,7 +1215,7 @@ Value getreceivedbyaddress(const Array& params, bool fHelp)
     if (params.size() > 1)
         nMinDepth = params[1].get_int();
 
-    const ChainstateManager chainstate;
+    const auto& chainstate = ChainstateManager::Get();
     const auto& chain = chainstate.ActiveChain();
 
     // Tally
@@ -1281,7 +1281,7 @@ Value getreceivedbyaccount(const Array& params, bool fHelp)
         setAddress = GetAccountAddresses(pwalletMain->GetAddressBookManager().GetAddressBook(),strAccount);
     }
 
-    const ChainstateManager chainstate;
+    const auto& chainstate = ChainstateManager::Get();
     const auto& chain = chainstate.ActiveChain();
 
     // Tally
@@ -1548,7 +1548,7 @@ Value ListReceived(const Array& params, bool fByAccounts)
         if (params[2].get_bool())
             filter.addOwnershipType(isminetype::ISMINE_WATCH_ONLY);
 
-    const ChainstateManager chainstate;
+    const auto& chainstate = ChainstateManager::Get();
     const auto& chain = chainstate.ActiveChain();
 
     // Tally
@@ -1733,7 +1733,7 @@ static std::string GetAccountAddressName(const CWallet& wallet, const CTxDestina
 static int ComputeBlockHeightOfFirstConfirmation(const uint256 blockHash)
 {
     LOCK(cs_main);
-    const ChainstateManager chainstate;
+    const auto& chainstate = ChainstateManager::Get();
     const auto& blockMap = chainstate.GetBlockMap();
     const auto it = blockMap.find(blockHash);
     return (it==blockMap.end() || it->second==nullptr)? 0 : it->second->nHeight;
@@ -2163,7 +2163,7 @@ Value listsinceblock(const Array& params, bool fHelp)
     UtxoOwnershipFilter filter;
     filter.addOwnershipType(isminetype::ISMINE_SPENDABLE);
 
-    const ChainstateManager chainstate;
+    const auto& chainstate = ChainstateManager::Get();
     const auto& chain = chainstate.ActiveChain();
     const auto& blockMap = chainstate.GetBlockMap();
 

--- a/divi/src/spork.cpp
+++ b/divi/src/spork.cpp
@@ -63,7 +63,7 @@ void ProcessSpork(CNode* pfrom, const std::string& strCommand, CDataStream& vRec
 }
 CSporkManager& GetSporkManager()
 {
-    static CSporkManager sporkManager;
+    static CSporkManager sporkManager(ChainstateManager::Get());
     return sporkManager;
 }
 
@@ -188,8 +188,8 @@ bool CSporkManager::IsNewerSpork(const CSporkMessage &spork) const
     return true;
 }
 
-CSporkManager::CSporkManager(
-    ): pSporkDB_()
+CSporkManager::CSporkManager(const ChainstateManager& c
+    ): chainstate_(c), pSporkDB_()
 {
 }
 

--- a/divi/src/spork.h
+++ b/divi/src/spork.h
@@ -166,7 +166,7 @@ struct TxFeeSporkValue : public SporkMultiValue {
 class CSporkManager
 {
 private:
-    const ChainstateManager chainstate_;
+    const ChainstateManager& chainstate_;
     std::unique_ptr<CSporkDB> pSporkDB_;
     std::vector<unsigned char> vchSig;
     // Some sporks require to have history, we will use sorted vector for this approach.
@@ -183,7 +183,7 @@ private:
 
 public:
 
-    CSporkManager();
+    CSporkManager(const ChainstateManager& c);
     ~CSporkManager();
 
     void AllocateDatabase();

--- a/divi/src/test/LotteryWinnersCalculatorTests.cpp
+++ b/divi/src/test/LotteryWinnersCalculatorTests.cpp
@@ -34,7 +34,7 @@ public:
         , lastUpdatedLotteryCoinstakesHeight_(0)
         , heightValidator_(new NiceMock<MockSuperblockHeightValidator>)
         , fakeBlockIndexWithHashes_()
-        , sporkManager_()
+        , sporkManager_(ChainstateManager::Get())
         , nextLockTime_(0)
         , lotteryStartBlock(100)
         , calculator_()

--- a/divi/src/test/test_divi.cpp
+++ b/divi/src/test/test_divi.cpp
@@ -6,6 +6,7 @@
 
 #include <dbenv.h>
 #include <chain.h>
+#include <ChainstateManager.h>
 #include <init.h>
 #include "main.h"
 #include "net.h"
@@ -41,6 +42,8 @@ struct TestingSetup {
     boost::thread_group threadGroup;
     CDBEnv& bitdb_;
 
+    std::unique_ptr<ChainstateManager> chainstateInstance;
+
     TestingSetup(): pcoinsdbview(nullptr), pathTemp(), threadGroup(), bitdb_(BerkleyDBEnvWrapper())
     {
         SetupEnvironment();
@@ -57,6 +60,7 @@ struct TestingSetup {
         pblocktree = new CBlockTreeDB(1 << 20, true);
         pcoinsdbview = new CCoinsViewDB(mapBlockIndex, 1 << 23, true);
         pcoinsTip = new CCoinsViewCache(pcoinsdbview);
+        chainstateInstance.reset(new ChainstateManager());
         InitBlockIndex();
 #ifdef ENABLE_WALLET
         InitializeWallet("wallet.dat");
@@ -77,6 +81,7 @@ struct TestingSetup {
 #ifdef ENABLE_WALLET
         DeallocateWallet();
 #endif
+        chainstateInstance.reset();
         delete pcoinsTip;
         delete pcoinsdbview;
         delete pblocktree;


### PR DESCRIPTION
This set of commits changes the `ChainstateManager` to a singleton class.  It refactors the initialisation and cleanup code to construct a specific instance, which specifies a well-defined life cycle for the duration of time where other code is actually using `ChainstateManager`.  (This requires some slight changes to the order in which things are done, in the third commit.)  The last commit is then just a follow-up, which actually turns the class into a singleton (enforced by `asserts`), so that all other places in the code explicitly reference that one instance instead of constructing their own.

With this, the instance is still a global.  But because we now have a well-defined life cycle and have it integrated into init/shutdown properly, we can actually move all the other globals (like `chainActive`) into the `ChainstateManager` itself (rather than storing references to them there).

The other, orthogonal and complementary path forward is to change all the places calling `ChainstateManager::Get` so that the one instance from `init` is actually passed down to them, and we can remove the global instance pointer.