### PR TITLE
Move actual chain state into ChainstateManager

### DIFF
--- a/divi/src/ChainstateManager.cpp
+++ b/divi/src/ChainstateManager.cpp
@@ -1,11 +1,11 @@
 #include "ChainstateManager.h"
 
+#include <blockmap.h>
+#include <chain.h>
+#include <coins.h>
 #include <sync.h>
-
-extern BlockMap mapBlockIndex;
-extern CChain chainActive;
-extern CBlockTreeDB* pblocktree;
-extern CCoinsViewCache* pcoinsTip;
+#include <txdb.h>
+#include <ui_interface.h>
 
 namespace
 {
@@ -16,11 +16,40 @@ ChainstateManager* instance = nullptr;
 /** Lock for accessing the instance global.  */
 CCriticalSection instanceLock;
 
+class CCoinsViewErrorCatcher : public CCoinsViewBacked
+{
+public:
+  CCoinsViewErrorCatcher(CCoinsView* view) : CCoinsViewBacked(view) {}
+  bool GetCoins(const uint256& txid, CCoins& coins) const override;
+  // Writes do not need special protection, as failure to write is handled by
+  // the caller.
+};
+
+bool CCoinsViewErrorCatcher::GetCoins (const uint256& txid, CCoins& coins) const
+{
+  try {
+    return CCoinsViewBacked::GetCoins(txid, coins);
+  } catch (const std::runtime_error& e) {
+    uiInterface.ThreadSafeMessageBox(translate("Error reading from database, shutting down."), "", CClientUIInterface::MSG_ERROR);
+    LogPrintf("Error reading from database: %s\n", e.what());
+    // Starting the shutdown sequence and returning false to the caller would be
+    // interpreted as 'entry not found' (as opposed to unable to read data), and
+    // could lead to invalid interpration. Just exit immediately, as we can't
+    // continue anyway, and all writes should be atomic.
+    abort();
+  }
+}
+
 } // anonymous namespace
 
-ChainstateManager::ChainstateManager ()
-  : blockMap(mapBlockIndex), activeChain(chainActive),
-    blockTree(*pblocktree), coinsTip(*pcoinsTip)
+ChainstateManager::ChainstateManager (const size_t blockTreeCache, const size_t coinDbCache,
+                                      const bool fMemory, const bool fWipe)
+  : blockMap(new BlockMap ()),
+    activeChain(new CChain ()),
+    blockTree(new CBlockTreeDB (blockTreeCache, fMemory, fWipe)),
+    coinsDbView(new CCoinsViewDB (*blockMap, coinDbCache, fMemory, fWipe)),
+    coinsCatcher(new CCoinsViewErrorCatcher (coinsDbView.get ())),
+    coinsTip(new CCoinsViewCache (coinsCatcher.get ()))
 {
   LOCK (instanceLock);
   assert (instance == nullptr);
@@ -32,6 +61,14 @@ ChainstateManager::~ChainstateManager ()
   LOCK (instanceLock);
   assert (instance == this);
   instance = nullptr;
+
+  coinsTip.reset ();
+  coinsCatcher.reset ();
+  coinsDbView.reset ();
+
+  blockTree.reset ();
+  activeChain.reset ();
+  blockMap.reset ();
 }
 
 ChainstateManager& ChainstateManager::Get ()

--- a/divi/src/ChainstateManager.h
+++ b/divi/src/ChainstateManager.h
@@ -1,9 +1,12 @@
 #ifndef CHAINSTATE_MANAGER_H
 #define CHAINSTATE_MANAGER_H
 
+#include <memory>
+
 class BlockMap;
 class CBlockTreeDB;
 class CChain;
+class CCoinsView;
 class CCoinsViewCache;
 
 /** The main class that encapsulates the blockchain state (including active
@@ -14,68 +17,74 @@ class ChainstateManager
 
 private:
 
-  BlockMap& blockMap;
-  CChain& activeChain;
-  CBlockTreeDB& blockTree;
-  CCoinsViewCache& coinsTip;
+  std::unique_ptr<BlockMap> blockMap;
+  std::unique_ptr<CChain> activeChain;
+  std::unique_ptr<CBlockTreeDB> blockTree;
+
+  std::unique_ptr<CCoinsView> coinsDbView;
+  std::unique_ptr<CCoinsView> coinsCatcher;
+  std::unique_ptr<CCoinsViewCache> coinsTip;
 
 public:
 
-  /** Constructs a fresh instance that refers to the globals.
-   *
-   *  TODO: Remove the globals and instead make the instances held
-   *  by the ChainstateManager instance.  Until then, the ChainstateManager
-   *  is a singleton, and only one instance must be created at a time.  */
-  ChainstateManager ();
-
+  explicit ChainstateManager (size_t blockTreeCache, size_t coinDbCache,
+                              bool fMemory, bool fWipe);
   ~ChainstateManager ();
 
   inline BlockMap&
   GetBlockMap ()
   {
-    return blockMap;
+    return *blockMap;
   }
 
   inline const BlockMap&
   GetBlockMap () const
   {
-    return blockMap;
+    return *blockMap;
   }
 
   inline CChain&
   ActiveChain ()
   {
-    return activeChain;
+    return *activeChain;
   }
 
   inline const CChain&
   ActiveChain () const
   {
-    return activeChain;
+    return *activeChain;
   }
 
   inline CBlockTreeDB&
   BlockTree ()
   {
-    return blockTree;
+    return *blockTree;
   }
 
   inline const CBlockTreeDB&
   BlockTree () const
   {
-    return blockTree;
+    return *blockTree;
   }
 
   inline CCoinsViewCache&
   CoinsTip ()
   {
-    return coinsTip;
+    return *coinsTip;
   }
 
   inline const CCoinsViewCache&
   CoinsTip () const
   {
-    return coinsTip;
+    return *coinsTip;
+  }
+
+  /** Returns a coins view that is not catching errors in GetCoins.  This is
+   *  used during initialisation for verifying the DB.  */
+  inline const CCoinsView&
+  GetNonCatchingCoinsView () const
+  {
+    return *coinsDbView;
   }
 
   /** Returns the singleton instance of the ChainstateManager that exists

--- a/divi/src/ChainstateManager.h
+++ b/divi/src/ChainstateManager.h
@@ -1,6 +1,7 @@
 #ifndef CHAINSTATE_MANAGER_H
 #define CHAINSTATE_MANAGER_H
 
+#include <atomic>
 #include <memory>
 
 class BlockMap;
@@ -25,7 +26,14 @@ private:
   std::unique_ptr<CCoinsView> coinsCatcher;
   std::unique_ptr<CCoinsViewCache> coinsTip;
 
+  /** A refcount for the instance.  We use it to enforce that the
+   *  singleton instance is no longer referenced by anything when it
+   *  gets destructed.  */
+  std::atomic<int> refs;
+
 public:
+
+  class Reference;
 
   explicit ChainstateManager (size_t blockTreeCache, size_t coinDbCache,
                               bool fMemory, bool fWipe);
@@ -90,6 +98,55 @@ public:
   /** Returns the singleton instance of the ChainstateManager that exists
    *  at the moment.  It must be constructed at the moment.  */
   static ChainstateManager& Get ();
+
+};
+
+/** A reference to the singleton ChainstateManager instance.  This class
+ *  is used instead of a raw pointer / reference so that we can track
+ *  the existing references and make sure there remain no dangling ones
+ *  outside of the singleton's life span.
+ *
+ *  FIXME: Once we get rid of a "global singleton" in favour of passing
+ *  the actual instance explicitly, we should remove this concept.  */
+class ChainstateManager::Reference
+{
+
+private:
+
+  /** The referred-to instance.  */
+  ChainstateManager& instance;
+
+public:
+
+  /** Constructs a new reference that refers to the "global" singleton instance
+   *  (which must be alive at the moment).  */
+  Reference ();
+
+  ~Reference ();
+
+  inline ChainstateManager*
+  operator-> ()
+  {
+    return &instance;
+  }
+
+  inline const ChainstateManager*
+  operator-> () const
+  {
+    return &instance;
+  }
+
+  inline ChainstateManager&
+  operator* ()
+  {
+    return instance;
+  }
+
+  inline const ChainstateManager&
+  operator* () const
+  {
+    return instance;
+  }
 
 };
 

--- a/divi/src/miner.cpp
+++ b/divi/src/miner.cpp
@@ -122,11 +122,11 @@ void MinterThread(I_CoinMinter& minter)
 bool HasRecentlyAttemptedToGenerateProofOfStake()
 {
     static const LastExtensionTimestampByBlockHeight& mapHashedBlocks = getLastExtensionTimestampByBlockHeight();
-    const auto& chainstate = ChainstateManager::Get();
+    const ChainstateManager::Reference chainstate;
     bool recentlyAttemptedPoS = false;
-    if (mapHashedBlocks.count(chainstate.ActiveChain().Tip()->nHeight))
+    if (mapHashedBlocks.count(chainstate->ActiveChain().Tip()->nHeight))
         recentlyAttemptedPoS = true;
-    else if (mapHashedBlocks.count(chainstate.ActiveChain().Tip()->nHeight - 1))
+    else if (mapHashedBlocks.count(chainstate->ActiveChain().Tip()->nHeight - 1))
         recentlyAttemptedPoS = true;
 
     return recentlyAttemptedPoS;

--- a/divi/src/rest.cpp
+++ b/divi/src/rest.cpp
@@ -114,8 +114,8 @@ static bool rest_block(AcceptedConnection* conn,
     CBlockIndex* pblockindex = NULL;
     {
         LOCK(cs_main);
-        const auto& chainstate = ChainstateManager::Get();
-        const auto& blockMap = chainstate.GetBlockMap();
+        const ChainstateManager::Reference chainstate;
+        const auto& blockMap = chainstate->GetBlockMap();
 
         const auto mit = blockMap.find(hash);
         if (mit == blockMap.end())

--- a/divi/src/rpcmasternode.cpp
+++ b/divi/src/rpcmasternode.cpp
@@ -388,9 +388,9 @@ Value listmasternodes(const Array& params, bool fHelp)
     Array ret;
     const CBlockIndex* pindex;
     {
-        const auto& chainstate = ChainstateManager::Get();
+        const ChainstateManager::Reference chainstate;
         LOCK(cs_main);
-        pindex = chainstate.ActiveChain().Tip();
+        pindex = chainstate->ActiveChain().Tip();
         if(!pindex) return 0;
     }
 
@@ -435,8 +435,8 @@ Value getmasternodecount (const Array& params, bool fHelp)
             "\nExamples:\n" +
             HelpExampleCli("getmasternodecount", "") + HelpExampleRpc("getmasternodecount", ""));
 
-    const auto& chainstate = ChainstateManager::Get();
-    const CBlockIndex* tip = chainstate.ActiveChain().Tip();
+    const ChainstateManager::Reference chainstate;
+    const CBlockIndex* tip = chainstate->ActiveChain().Tip();
     MasternodeCountData data = GetMasternodeCounts(tip);
 
     Object obj;
@@ -642,9 +642,9 @@ Value getmasternodewinners (const Array& params, bool fHelp)
     int nHeight;
     const CBlockIndex* pindex = nullptr;
     {
-        const auto& chainstate = ChainstateManager::Get();
+        const ChainstateManager::Reference chainstate;
         LOCK(cs_main);
-        pindex = chainstate.ActiveChain().Tip();
+        pindex = chainstate->ActiveChain().Tip();
         if(!pindex) return 0;
         nHeight = pindex->nHeight;
     }

--- a/divi/src/rpcmining.cpp
+++ b/divi/src/rpcmining.cpp
@@ -90,8 +90,8 @@ Value setgenerate(const Array& params, bool fHelp)
     int nHeightEnd = 0;
     int nHeight = 0;
 
-    const auto& chainstate = ChainstateManager::Get();
-    const auto& chain = chainstate.ActiveChain();
+    const ChainstateManager::Reference chainstate;
+    const auto& chain = chainstate->ActiveChain();
 
     { // Don't keep cs_main locked
         LOCK(cs_main);
@@ -151,8 +151,8 @@ Value generateblock(const Array& params, bool fHelp)
 
     int nHeight = 0;
 
-    const auto& chainstate = ChainstateManager::Get();
-    const auto& chain = chainstate.ActiveChain();
+    const ChainstateManager::Reference chainstate;
+    const auto& chain = chainstate->ActiveChain();
 
     { // Don't keep cs_main locked
         LOCK(cs_main);
@@ -235,10 +235,10 @@ Value getmininginfo(const Array& params, bool fHelp)
             "\nExamples:\n" +
             HelpExampleCli("getmininginfo", "") + HelpExampleRpc("getmininginfo", ""));
 
-    const auto& chainstate = ChainstateManager::Get();
+    const ChainstateManager::Reference chainstate;
 
     Object obj;
-    obj.push_back(Pair("blocks", (int)chainstate.ActiveChain().Height()));
+    obj.push_back(Pair("blocks", (int)chainstate->ActiveChain().Height()));
     obj.push_back(Pair("difficulty", (double)GetDifficulty()));
     obj.push_back(Pair("errors", GetWarnings("statusbar")));
     obj.push_back(Pair("pooledtx", (uint64_t)mempool.size()));

--- a/divi/src/rpcwallet.cpp
+++ b/divi/src/rpcwallet.cpp
@@ -248,10 +248,10 @@ void WalletTxToJSON(const CWallet& wallet, const CWalletTx& wtx, Object& entry)
     if (wtx.IsCoinBase() || wtx.IsCoinStake())
         entry.push_back(Pair("generated", true));
     if (confirms > 0) {
-        const auto& chainstate = ChainstateManager::Get();
+        const ChainstateManager::Reference chainstate;
         entry.push_back(Pair("blockhash", wtx.hashBlock.GetHex()));
         entry.push_back(Pair("blockindex", wtx.merkleBranchIndex));
-        entry.push_back(Pair("blocktime", chainstate.GetBlockMap().at(wtx.hashBlock)->GetBlockTime()));
+        entry.push_back(Pair("blocktime", chainstate->GetBlockMap().at(wtx.hashBlock)->GetBlockTime()));
     }
     uint256 hash = wtx.GetHash();
     entry.push_back(Pair("txid", hash.GetHex()));
@@ -381,8 +381,8 @@ CBitcoinAddress GetAccountAddress(CWallet& wallet, string strAccount, bool bForc
 
 CAmount GetAccountBalance(const string& strAccount, int nMinDepth, const UtxoOwnershipFilter& filter)
 {
-    const auto& chainstate = ChainstateManager::Get();
-    const auto& chain = chainstate.ActiveChain();
+    const ChainstateManager::Reference chainstate;
+    const auto& chain = chainstate->ActiveChain();
 
     CAmount nBalance = 0;
 
@@ -1031,8 +1031,8 @@ Value addvault(const Array& params, bool fHelp)
         return result;
     }
 
-    const auto& chainstate = ChainstateManager::Get();
-    const CBlockIndex* blockSearchStart = chainstate.ActiveChain().Tip();
+    const ChainstateManager::Reference chainstate;
+    const CBlockIndex* blockSearchStart = chainstate->ActiveChain().Tip();
     while (blockSearchStart->pprev)
     {
         if(blockSearchStart->GetBlockHash() == blockHash) break;
@@ -1215,8 +1215,8 @@ Value getreceivedbyaddress(const Array& params, bool fHelp)
     if (params.size() > 1)
         nMinDepth = params[1].get_int();
 
-    const auto& chainstate = ChainstateManager::Get();
-    const auto& chain = chainstate.ActiveChain();
+    const ChainstateManager::Reference chainstate;
+    const auto& chain = chainstate->ActiveChain();
 
     // Tally
     CAmount nAmount = 0;
@@ -1281,8 +1281,8 @@ Value getreceivedbyaccount(const Array& params, bool fHelp)
         setAddress = GetAccountAddresses(pwalletMain->GetAddressBookManager().GetAddressBook(),strAccount);
     }
 
-    const auto& chainstate = ChainstateManager::Get();
-    const auto& chain = chainstate.ActiveChain();
+    const ChainstateManager::Reference chainstate;
+    const auto& chain = chainstate->ActiveChain();
 
     // Tally
     CAmount nAmount = 0;
@@ -1548,8 +1548,8 @@ Value ListReceived(const Array& params, bool fByAccounts)
         if (params[2].get_bool())
             filter.addOwnershipType(isminetype::ISMINE_WATCH_ONLY);
 
-    const auto& chainstate = ChainstateManager::Get();
-    const auto& chain = chainstate.ActiveChain();
+    const ChainstateManager::Reference chainstate;
+    const auto& chain = chainstate->ActiveChain();
 
     // Tally
     std::map<CBitcoinAddress, tallyitem> mapTally;
@@ -1733,8 +1733,8 @@ static std::string GetAccountAddressName(const CWallet& wallet, const CTxDestina
 static int ComputeBlockHeightOfFirstConfirmation(const uint256 blockHash)
 {
     LOCK(cs_main);
-    const auto& chainstate = ChainstateManager::Get();
-    const auto& blockMap = chainstate.GetBlockMap();
+    const ChainstateManager::Reference chainstate;
+    const auto& blockMap = chainstate->GetBlockMap();
     const auto it = blockMap.find(blockHash);
     return (it==blockMap.end() || it->second==nullptr)? 0 : it->second->nHeight;
 }
@@ -2163,9 +2163,9 @@ Value listsinceblock(const Array& params, bool fHelp)
     UtxoOwnershipFilter filter;
     filter.addOwnershipType(isminetype::ISMINE_SPENDABLE);
 
-    const auto& chainstate = ChainstateManager::Get();
-    const auto& chain = chainstate.ActiveChain();
-    const auto& blockMap = chainstate.GetBlockMap();
+    const ChainstateManager::Reference chainstate;
+    const auto& chain = chainstate->ActiveChain();
+    const auto& blockMap = chainstate->GetBlockMap();
 
     if (params.size() > 0) {
         uint256 blockId = 0;

--- a/divi/src/test/LotteryWinnersCalculatorTests.cpp
+++ b/divi/src/test/LotteryWinnersCalculatorTests.cpp
@@ -24,6 +24,7 @@ private:
     unsigned lastUpdatedLotteryCoinstakesHeight_;
     std::unique_ptr<NiceMock<MockSuperblockHeightValidator>> heightValidator_;
     std::unique_ptr<FakeBlockIndexWithHashes> fakeBlockIndexWithHashes_;
+    const ChainstateManager::Reference chainstate_;
     CSporkManager sporkManager_;
     int nextLockTime_;
 public:
@@ -34,7 +35,7 @@ public:
         , lastUpdatedLotteryCoinstakesHeight_(0)
         , heightValidator_(new NiceMock<MockSuperblockHeightValidator>)
         , fakeBlockIndexWithHashes_()
-        , sporkManager_(ChainstateManager::Get())
+        , sporkManager_(*chainstate_)
         , nextLockTime_(0)
         , lotteryStartBlock(100)
         , calculator_()


### PR DESCRIPTION
This moves the actual instances holding the chainstate (like the `CChain` for `activeChain`, or the `CCoinsViewCache` / `CCoinsViewDB` for the UTXO set) into `ChainstateManager`, rather than having them as globals and just referring to them from there.

After this change, it gets strictly enforced that the state is only accessed through `ChainstateManager` (which is already largely the case), and also makes it more explicit how the life cycle is managed (namely through that one instance of `ChainstateManager` created/destructed from `init.cpp`).