### PR TITLE
Life-cycle fixes for some helper modules

### DIFF
--- a/divi/src/CoinMintingModule.h
+++ b/divi/src/CoinMintingModule.h
@@ -6,10 +6,8 @@
 #include <boost/thread/recursive_mutex.hpp>
 class I_StakingWallet;
 class CChainParams;
-class ChainstateManager;
 class CNode;
 class CMasternodeSync;
-typedef std::map<unsigned int, unsigned int> BlockTimestampsByHeight;
 class I_BlockFactory;
 class CTxMemPool;
 class CCriticalSection;
@@ -29,6 +27,13 @@ class I_PeerBlockNotifyService;
 
 class CoinMintingModule
 {
+public:
+    using LastExtensionTimestampByBlockHeight = std::map<unsigned int, unsigned int>;
+
+private:
+    class ChainstateManagerReference;
+    LastExtensionTimestampByBlockHeight mapHashedBlocks_;
+    std::unique_ptr<const ChainstateManagerReference> chainstate_;
     std::unique_ptr<ProofOfStakeModule> posModule_;
     std::unique_ptr<SuperblockSubsidyContainer> blockSubsidyContainer_;
     std::unique_ptr<BlockIncentivesPopulator> blockIncentivesPopulator_;
@@ -41,18 +46,17 @@ public:
         const Settings& settings,
         CCriticalSection& mainCS,
         const CChainParams& chainParameters,
-        const ChainstateManager& chainstate,
         const MasternodeModule& masternodeModule,
         const CFeeRate& relayTxFeeCalculator,
         CTxMemPool& mempool,
         const I_PeerBlockNotifyService& peers,
         I_StakingWallet& wallet,
-        BlockTimestampsByHeight& hashedBlockTimestampsByHeight,
         const CSporkManager& sporkManager);
     ~CoinMintingModule();
 
     I_BlockFactory& blockFactory() const;
     I_CoinMinter& coinMinter() const;
+    const LastExtensionTimestampByBlockHeight& GetBlockTimestampsByHeight() const;
 };
 
 #endif// COIN_MINTING_MODULE_H

--- a/divi/src/main.cpp
+++ b/divi/src/main.cpp
@@ -1564,11 +1564,11 @@ bool ReconsiderBlock(CValidationState& state, CBlockIndex* pindex)
 
 CBlockIndex* AddToBlockIndex(const CBlock& block)
 {
-    auto& chainstate = ChainstateManager::Get();
-    auto& blockMap = chainstate.GetBlockMap();
+    ChainstateManager::Reference chainstate;
+    auto& blockMap = chainstate->GetBlockMap();
 
-    static const CSporkManager& sporkManager = GetSporkManager();
-    static BlockIndexLotteryUpdater lotteryUpdater(Params(), chainstate.ActiveChain(), sporkManager);
+    const auto& sporkManager = GetSporkManager();
+    const BlockIndexLotteryUpdater lotteryUpdater(Params(), chainstate->ActiveChain(), sporkManager);
     // Check for duplicate
     const uint256 hash = block.GetHash();
     const auto it = blockMap.find(hash);
@@ -1895,8 +1895,8 @@ bool AcceptBlock(CBlock& block, CValidationState& state, CBlockIndex** ppindex, 
 {
     AssertLockHeld(cs_main);
 
-    const auto& chainstate = ChainstateManager::Get();
-    const auto& blockMap = chainstate.GetBlockMap();
+    const ChainstateManager::Reference chainstate;
+    const auto& blockMap = chainstate->GetBlockMap();
 
     CBlockIndex*& pindex = *ppindex;
 
@@ -1923,8 +1923,8 @@ bool AcceptBlock(CBlock& block, CValidationState& state, CBlockIndex** ppindex, 
         }
     }
 
-    static ProofOfStakeModule posModule(Params(), chainstate.ActiveChain(), blockMap);
-    static const I_ProofOfStakeGenerator& posGenerator = posModule.proofOfStakeGenerator();
+    const ProofOfStakeModule posModule(Params(), chainstate->ActiveChain(), blockMap);
+    const I_ProofOfStakeGenerator& posGenerator = posModule.proofOfStakeGenerator();
 
     const uint256 blockHash = block.GetHash();
     if (blockHash != Params().HashGenesisBlock())

--- a/divi/src/miner.h
+++ b/divi/src/miner.h
@@ -20,6 +20,7 @@ class CoinMintingModule;
 struct CBlockTemplate;
 
 void InitializeCoinMintingModule(I_StakingWallet* pwallet);
+void DestructCoinMintingModule();
 const CoinMintingModule& GetCoinMintingModule();
 
 /** Run the miner threads */

--- a/divi/src/net.cpp
+++ b/divi/src/net.cpp
@@ -1523,6 +1523,8 @@ bool StopNode()
         fAddressesInitialized = false;
     }
 
+    DestructCoinMintingModule();
+
     return true;
 }
 

--- a/divi/src/rpcblockchain.cpp
+++ b/divi/src/rpcblockchain.cpp
@@ -696,9 +696,9 @@ Value reverseblocktransactions(const Array& params, bool fHelp)
     CValidationState state;
 
     {
-        auto& chainstate = ChainstateManager::Get();
+        ChainstateManager::Reference chainstate;
         LOCK(cs_main);
-        auto& blockMap = chainstate.GetBlockMap();
+        auto& blockMap = chainstate->GetBlockMap();
         const auto mit = blockMap.find(hash);
         if (mit == blockMap.end())
             throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Block not found");

--- a/divi/src/rpclottery.cpp
+++ b/divi/src/rpclottery.cpp
@@ -40,15 +40,15 @@ Value getlotteryblockwinners(const Array& params, bool fHelp)
 
 
 
-    static const CChainParams& chainParameters = Params();
-    static SuperblockSubsidyContainer subsidyCointainer(chainParameters);
-    static const auto& chainstate = ChainstateManager::Get();
-    static LotteryWinnersCalculator calculator(
-        chainParameters.GetLotteryBlockStartBlock(), chainstate.ActiveChain(), GetSporkManager(),subsidyCointainer.superblockHeightValidator());
+    const auto& chainParameters = Params();
+    const SuperblockSubsidyContainer subsidyCointainer(chainParameters);
+    const ChainstateManager::Reference chainstate;
+    const LotteryWinnersCalculator calculator(
+        chainParameters.GetLotteryBlockStartBlock(), chainstate->ActiveChain(), GetSporkManager(),subsidyCointainer.superblockHeightValidator());
     const CBlockIndex* chainTip = nullptr;
     {
         LOCK(cs_main);
-        chainTip = chainstate.ActiveChain().Tip();
+        chainTip = chainstate->ActiveChain().Tip();
         if(!chainTip) throw JSONRPCError(RPC_MISC_ERROR,"Could not acquire lock on chain tip.");
     }
     int blockHeight = (params.size()>0)? std::min(params[0].get_int(),chainTip->nHeight): chainTip->nHeight;


### PR DESCRIPTION
This is a combination of two related commits, which work towards better-defined life cycles / removal of some more "`static` globals" and thus help to guarantee that the dependencies between some of these instances will remain valid and not e.g. survive a node shutdown with clean up of the `ChainstateManager`.

See the individual commit messages for more details.