### PR TITLE
More cleanups to "static globals"

### DIFF
--- a/divi/src/init.cpp
+++ b/divi/src/init.cpp
@@ -905,10 +905,8 @@ BlockLoadingStatus TryToLoadBlocks(std::string& strLoadError)
         {
 
             LOCK(cs_main);
-            const ActiveChainManager& chainManager = GetActiveChainManager();
             const CVerifyDB dbVerifier(
-                chainManager,
-                chainstate->ActiveChain(),
+                *chainstate,
                 uiInterface,
                 nCoinCacheSize,
                 &ShutdownRequested);

--- a/divi/src/main.cpp
+++ b/divi/src/main.cpp
@@ -956,14 +956,6 @@ bool CheckMintTotalsAndBlockPayees(
 
 } // anonymous namespace
 
-const ActiveChainManager& GetActiveChainManager()
-{
-    static const BlockDiskDataReader blockDiskReader;
-    static auto& chainstate = ChainstateManager::Get();
-    static ActiveChainManager chainManager(fAddressIndex,fSpentIndex, &chainstate.BlockTree(), blockDiskReader);
-    return chainManager;
-}
-
 bool ConnectBlock(
     const CBlock& block,
     CValidationState& state,
@@ -1144,7 +1136,8 @@ bool static DisconnectTip(CValidationState& state, const bool updateCoinDatabase
     assert(pindexDelete);
     mempool.check(&coinsTip, blockMap);
     // Read block from disk.
-    const ActiveChainManager& chainManager = GetActiveChainManager();
+    const BlockDiskDataReader blockDiskReader;
+    const ActiveChainManager chainManager(fAddressIndex, fSpentIndex, &chainstate->BlockTree(), blockDiskReader);
     std::pair<CBlock,bool> disconnectedBlock;
     {
          CCoinsViewCache view(&coinsTip);

--- a/divi/src/main.h
+++ b/divi/src/main.h
@@ -15,7 +15,6 @@
 #include "amount.h"
 #include <string>
 
-class ActiveChainManager;
 class CChain;
 class CBlock;
 struct CBlockLocator;
@@ -162,5 +161,4 @@ bool InvalidateBlock(CValidationState& state, CBlockIndex* pindex, const bool up
 /** Remove invalidity status from a block and its descendants. */
 bool ReconsiderBlock(CValidationState& state, CBlockIndex* pindex);
 
-const ActiveChainManager& GetActiveChainManager();
 #endif // BITCOIN_MAIN_H

--- a/divi/src/rpcblockchain.cpp
+++ b/divi/src/rpcblockchain.cpp
@@ -515,11 +515,9 @@ Value verifychain(const Array& params, bool fHelp)
         nCheckDepth = params[1].get_int();
 
     LOCK(cs_main);
-    const ActiveChainManager& chainManager = GetActiveChainManager();
-    const ChainstateManager::Reference chainstate;
+    ChainstateManager::Reference chainstate;
     const CVerifyDB dbVerifier(
-        chainManager,
-        chainstate->ActiveChain(),
+        *chainstate,
         uiInterface,
         nCoinCacheSize,
         &ShutdownRequested);

--- a/divi/src/spork.h
+++ b/divi/src/spork.h
@@ -183,11 +183,9 @@ private:
 
 public:
 
-    CSporkManager(const ChainstateManager& c);
+    explicit CSporkManager(const ChainstateManager& chainstate);
     ~CSporkManager();
 
-    void AllocateDatabase();
-    void DeallocateDatabase();
     void LoadSporksFromDB();
     void ProcessSpork(CNode* pfrom, const std::string& strCommand, CDataStream& vRecv);
     bool UpdateSpork(int nSporkID, std::string strValue);

--- a/divi/src/test/LotteryWinnersCalculatorTests.cpp
+++ b/divi/src/test/LotteryWinnersCalculatorTests.cpp
@@ -25,7 +25,7 @@ private:
     std::unique_ptr<NiceMock<MockSuperblockHeightValidator>> heightValidator_;
     std::unique_ptr<FakeBlockIndexWithHashes> fakeBlockIndexWithHashes_;
     const ChainstateManager::Reference chainstate_;
-    CSporkManager sporkManager_;
+    const CSporkManager& sporkManager_;
     int nextLockTime_;
 public:
     const int lotteryStartBlock;
@@ -35,7 +35,7 @@ public:
         , lastUpdatedLotteryCoinstakesHeight_(0)
         , heightValidator_(new NiceMock<MockSuperblockHeightValidator>)
         , fakeBlockIndexWithHashes_()
-        , sporkManager_(*chainstate_)
+        , sporkManager_(GetSporkManager())
         , nextLockTime_(0)
         , lotteryStartBlock(100)
         , calculator_()

--- a/divi/src/verifyDb.h
+++ b/divi/src/verifyDb.h
@@ -7,27 +7,33 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 #ifndef BITCOIN_VERIFYDB_H
 #define BITCOIN_VERIFYDB_H
+
+#include <memory>
+
 class CCoinsView;
 class CChain;
 class CClientUIInterface;
 class CCoinsViewCache;
 class CBlockTreeDB;
 class ActiveChainManager;
+class BlockDiskDataReader;
+class ChainstateManager;
+
 /** RAII wrapper for VerifyDB: Verify consistency of the block and coin databases */
 class CVerifyDB
 {
 public:
     typedef bool (*ShutdownListener)();
 private:
-    const ActiveChainManager& chainManager_;
+    std::unique_ptr<const BlockDiskDataReader> blockDiskReader_;
+    std::unique_ptr<const ActiveChainManager> chainManager_;
     const CChain& activeChain_;
     CClientUIInterface& clientInterface_;
     const unsigned coinsCacheSize_;
     ShutdownListener shutdownListener_;
 public:
     CVerifyDB(
-        const ActiveChainManager& chainManager,
-        const CChain& activeChain,
+        ChainstateManager& chainstate,
         CClientUIInterface& clientInterface,
         const unsigned& coinsCacheSize,
         ShutdownListener shutdownListener);


### PR DESCRIPTION
This does more cleanups to "`static` globals" (see the individual commit messages for details).  In particular, the `ActiveChainManager` is changed to no longer be a global at all, and the `CSporkManager` is integrated into the startup/shutdown sequence in `init.cpp` (but remains a global for now).