### PR TITLE
Clean up some uses of GetSporkManager()

### DIFF
--- a/divi/src/BlockIndexLotteryUpdater.cpp
+++ b/divi/src/BlockIndexLotteryUpdater.cpp
@@ -11,7 +11,7 @@ BlockIndexLotteryUpdater::BlockIndexLotteryUpdater(
     const CChain& activeChain,
     const CSporkManager& sporkManager
     ): chainParameters_(chainParameters)
-    , subsidyContainer_(new SuperblockSubsidyContainer(chainParameters_))
+    , subsidyContainer_(new SuperblockSubsidyContainer(chainParameters_, sporkManager))
     , lotteryCalculator_(new LotteryWinnersCalculator(chainParameters_.GetLotteryBlockStartBlock(),activeChain,sporkManager, subsidyContainer_->superblockHeightValidator()) )
 {
 }

--- a/divi/src/BlockSubsidyProvider.cpp
+++ b/divi/src/BlockSubsidyProvider.cpp
@@ -59,7 +59,3 @@ CBlockRewards BlockSubsidyProvider::GetBlockSubsidity(int nHeight) const
     updateLotteryReward(nHeight,rewards, heightValidator_.IsValidLotteryBlockHeight(nHeight));
     return rewards;
 }
-CAmount BlockSubsidyProvider::GetFullBlockValue(int nHeight) const
-{
-    return GetBlockSubsidity(nHeight).total();
-}

--- a/divi/src/BlockSubsidyProvider.cpp
+++ b/divi/src/BlockSubsidyProvider.cpp
@@ -7,8 +7,10 @@
 
 BlockSubsidyProvider::BlockSubsidyProvider(
     const CChainParams& chainParameters,
+    const CSporkManager& sporkManager,
     I_SuperblockHeightValidator& heightValidator
     ): chainParameters_(chainParameters)
+    , sporkManager_(sporkManager)
     , heightValidator_(heightValidator)
 {
 
@@ -25,7 +27,7 @@ void BlockSubsidyProvider::updateTreasuryReward(int nHeight, CBlockRewards& rewa
     }
     int treasuryBlockCycleLength = heightValidator_.GetTreasuryBlockPaymentCycle(nHeight);
     int priorTreasuryBlockHeight = nHeight - treasuryBlockCycleLength;
-    CBlockRewards priorRewards = isTreasuryBlock? Legacy::GetBlockSubsidity(priorTreasuryBlockHeight,chainParameters_): rewards;
+    CBlockRewards priorRewards = isTreasuryBlock? Legacy::GetBlockSubsidity(priorTreasuryBlockHeight, chainParameters_, sporkManager_): rewards;
     int numberOfSubsidyIntervals = nHeight/chainParameters_.SubsidyHalvingInterval(); // must be at least 2;
     int priorRewardWeight = numberOfSubsidyIntervals*chainParameters_.SubsidyHalvingInterval() - priorTreasuryBlockHeight;
     int currentRewardWeight =  nHeight - numberOfSubsidyIntervals*chainParameters_.SubsidyHalvingInterval();
@@ -44,7 +46,7 @@ void BlockSubsidyProvider::updateLotteryReward(int nHeight, CBlockRewards& rewar
     }
     int lotteryBlockCycleLength = heightValidator_.GetLotteryBlockPaymentCycle(nHeight);
     int priorLotteryBlockHeight = nHeight - lotteryBlockCycleLength;
-    CBlockRewards priorRewards = isLotteryBlock? Legacy::GetBlockSubsidity(priorLotteryBlockHeight,chainParameters_): rewards;
+    CBlockRewards priorRewards = isLotteryBlock? Legacy::GetBlockSubsidity(priorLotteryBlockHeight, chainParameters_, sporkManager_): rewards;
     int numberOfSubsidyIntervals = nHeight/chainParameters_.SubsidyHalvingInterval(); // must be at least 2;
     int priorRewardWeight = numberOfSubsidyIntervals*chainParameters_.SubsidyHalvingInterval() - priorLotteryBlockHeight;
     int currentRewardWeight =  nHeight - numberOfSubsidyIntervals*chainParameters_.SubsidyHalvingInterval();
@@ -54,7 +56,7 @@ void BlockSubsidyProvider::updateLotteryReward(int nHeight, CBlockRewards& rewar
 
 CBlockRewards BlockSubsidyProvider::GetBlockSubsidity(int nHeight) const
 {
-    CBlockRewards rewards = Legacy::GetBlockSubsidity(nHeight,chainParameters_);
+    CBlockRewards rewards = Legacy::GetBlockSubsidity(nHeight, chainParameters_, sporkManager_);
     updateTreasuryReward(nHeight,rewards, heightValidator_.IsValidTreasuryBlockHeight(nHeight));
     updateLotteryReward(nHeight,rewards, heightValidator_.IsValidLotteryBlockHeight(nHeight));
     return rewards;

--- a/divi/src/BlockSubsidyProvider.h
+++ b/divi/src/BlockSubsidyProvider.h
@@ -4,11 +4,13 @@
 class CChainParams;
 class I_SuperblockHeightValidator;
 class CBlockRewards;
+class CSporkManager;
 
 class BlockSubsidyProvider: public I_BlockSubsidyProvider
 {
 private:
     const CChainParams& chainParameters_;
+    const CSporkManager& sporkManager_;
     I_SuperblockHeightValidator& heightValidator_;
 
     void updateTreasuryReward(int nHeight, CBlockRewards& rewards, bool isTreasuryBlock) const;
@@ -16,6 +18,7 @@ private:
 public:
     BlockSubsidyProvider(
         const CChainParams& chainParameters,
+        const CSporkManager& sporkManager,
         I_SuperblockHeightValidator& heightValidator);
     virtual CBlockRewards GetBlockSubsidity(int nHeight) const;
 };

--- a/divi/src/BlockSubsidyProvider.h
+++ b/divi/src/BlockSubsidyProvider.h
@@ -18,6 +18,5 @@ public:
         const CChainParams& chainParameters,
         I_SuperblockHeightValidator& heightValidator);
     virtual CBlockRewards GetBlockSubsidity(int nHeight) const;
-    virtual CAmount GetFullBlockValue(int nHeight) const;
 };
 #endif// BLOCK_SUBSIDY_PROVIDER_H

--- a/divi/src/CoinMintingModule.cpp
+++ b/divi/src/CoinMintingModule.cpp
@@ -68,7 +68,7 @@ CoinMintingModule::CoinMintingModule(
     ): mapHashedBlocks_()
     , chainstate_(new ChainstateManagerReference())
     , posModule_(new ProofOfStakeModule(chainParameters, (*chainstate_)->ActiveChain(), (*chainstate_)->GetBlockMap()))
-    , blockSubsidyContainer_(new SuperblockSubsidyContainer(chainParameters))
+    , blockSubsidyContainer_(new SuperblockSubsidyContainer(chainParameters, sporkManager))
     , blockIncentivesPopulator_(new BlockIncentivesPopulator(
         chainParameters,
         masternodeModule,

--- a/divi/src/I_BlockSubsidyProvider.h
+++ b/divi/src/I_BlockSubsidyProvider.h
@@ -8,6 +8,5 @@ class I_BlockSubsidyProvider
 public:
     virtual ~I_BlockSubsidyProvider(){}
     virtual CBlockRewards GetBlockSubsidity(int nHeight) const = 0;
-    virtual CAmount GetFullBlockValue(int nHeight) const = 0;
 };
 #endif // I_BLOCK_SUBSIDY_PROVIDER_H

--- a/divi/src/LegacyBlockSubsidies.cpp
+++ b/divi/src/LegacyBlockSubsidies.cpp
@@ -27,10 +27,10 @@ CAmount BlockSubsidy(int nHeight, const CChainParams& chainParameters)
     return nSubsidy;
 }
 
-CAmount GetFullBlockValue(int nHeight, const CChainParams& chainParameters)
+CAmount GetFullBlockValue(int nHeight, const CChainParams& chainParameters, const CSporkManager& sporkManager)
 {
     CAmount blockSubsidy = 0u;
-    if(GetSporkManager().GetFullBlockValue(nHeight,chainParameters,blockSubsidy))
+    if(sporkManager.GetFullBlockValue(nHeight,chainParameters,blockSubsidy))
     {
         return blockSubsidy;
     }
@@ -42,9 +42,9 @@ CAmount GetFullBlockValue(int nHeight, const CChainParams& chainParameters)
 
 } // anonymous namespace
 
-CBlockRewards GetBlockSubsidity(int nHeight, const CChainParams& chainParameters)
+CBlockRewards GetBlockSubsidity(int nHeight, const CChainParams& chainParameters, const CSporkManager& sporkManager)
 {
-    CAmount nSubsidy = GetFullBlockValue(nHeight,chainParameters);
+    CAmount nSubsidy = GetFullBlockValue(nHeight, chainParameters, sporkManager);
 
     if(nHeight <= chainParameters.LAST_POW_BLOCK()) {
         return CBlockRewards(nSubsidy, 0, 0, 0, 0, 0);
@@ -76,7 +76,7 @@ CBlockRewards GetBlockSubsidity(int nHeight, const CChainParams& chainParameters
     };
 
     BlockPaymentSporkValue rewardDistribution;
-    if(GetSporkManager().GetRewardDistribution(nHeight,chainParameters,rewardDistribution))
+    if(sporkManager.GetRewardDistribution(nHeight,chainParameters,rewardDistribution))
     {
         return helper(
                 rewardDistribution.nStakeReward,

--- a/divi/src/LegacyBlockSubsidies.cpp
+++ b/divi/src/LegacyBlockSubsidies.cpp
@@ -6,7 +6,12 @@
 #include <timedata.h>
 #include <chain.h>
 
-// Legacy methods
+namespace Legacy
+{
+
+namespace
+{
+
 CAmount BlockSubsidy(int nHeight, const CChainParams& chainParameters)
 {
     if(nHeight == 0) {
@@ -21,7 +26,8 @@ CAmount BlockSubsidy(int nHeight, const CChainParams& chainParameters)
 
     return nSubsidy;
 }
-CAmount Legacy::GetFullBlockValue(int nHeight, const CChainParams& chainParameters)
+
+CAmount GetFullBlockValue(int nHeight, const CChainParams& chainParameters)
 {
     CAmount blockSubsidy = 0u;
     if(GetSporkManager().GetFullBlockValue(nHeight,chainParameters,blockSubsidy))
@@ -34,9 +40,11 @@ CAmount Legacy::GetFullBlockValue(int nHeight, const CChainParams& chainParamete
     }
 }
 
-CBlockRewards Legacy::GetBlockSubsidity(int nHeight, const CChainParams& chainParameters)
+} // anonymous namespace
+
+CBlockRewards GetBlockSubsidity(int nHeight, const CChainParams& chainParameters)
 {
-    CAmount nSubsidy = Legacy::GetFullBlockValue(nHeight,chainParameters);
+    CAmount nSubsidy = GetFullBlockValue(nHeight,chainParameters);
 
     if(nHeight <= chainParameters.LAST_POW_BLOCK()) {
         return CBlockRewards(nSubsidy, 0, 0, 0, 0, 0);
@@ -84,30 +92,32 @@ CBlockRewards Legacy::GetBlockSubsidity(int nHeight, const CChainParams& chainPa
 }
 
 
-bool Legacy::IsValidLotteryBlockHeight(int nBlockHeight,const CChainParams& chainParams)
+bool IsValidLotteryBlockHeight(int nBlockHeight,const CChainParams& chainParams)
 {
     return nBlockHeight >= chainParams.GetLotteryBlockStartBlock() &&
             ((nBlockHeight % chainParams.GetLotteryBlockCycle()) == 0);
 }
 
-bool Legacy::IsValidTreasuryBlockHeight(int nBlockHeight,const CChainParams& chainParams)
+bool IsValidTreasuryBlockHeight(int nBlockHeight,const CChainParams& chainParams)
 {
     return nBlockHeight >= chainParams.GetTreasuryPaymentsStartBlock() &&
             ((nBlockHeight % chainParams.GetTreasuryPaymentsCycle()) == 0);
 }
 
-int64_t Legacy::GetTreasuryReward(const CBlockRewards &rewards, const CChainParams& chainParameters)
+int64_t GetTreasuryReward(const CBlockRewards &rewards, const CChainParams& chainParameters)
 {
     return rewards.nTreasuryReward*chainParameters.GetTreasuryPaymentsCycle();
 }
 
-int64_t Legacy::GetCharityReward(const CBlockRewards &rewards, const CChainParams& chainParameters)
+int64_t GetCharityReward(const CBlockRewards &rewards, const CChainParams& chainParameters)
 {
     return rewards.nCharityReward*chainParameters.GetTreasuryPaymentsCycle();
 }
 
-int64_t Legacy::GetLotteryReward(const CBlockRewards &rewards, const CChainParams& chainParameters)
+int64_t GetLotteryReward(const CBlockRewards &rewards, const CChainParams& chainParameters)
 {
     // 50 coins every block for lottery
     return rewards.nLotteryReward*chainParameters.GetLotteryBlockCycle();
 }
+
+} // namespace Legacy

--- a/divi/src/LegacyBlockSubsidies.h
+++ b/divi/src/LegacyBlockSubsidies.h
@@ -12,6 +12,5 @@ namespace Legacy
     int64_t GetCharityReward(const CBlockRewards &rewards, const CChainParams& chainParams);
     int64_t GetLotteryReward(const CBlockRewards &rewards, const CChainParams& chainParams);
     CBlockRewards GetBlockSubsidity(int nHeight, const CChainParams& chainParams);
-    CAmount GetFullBlockValue(int nHeight, const CChainParams& chainParams);
-};
+}
 #endif // LEGACY_BLOCK_SUBSIDIES_H

--- a/divi/src/LegacyBlockSubsidies.h
+++ b/divi/src/LegacyBlockSubsidies.h
@@ -3,6 +3,7 @@
 #include <amount.h>
 class CBlockRewards;
 class CChainParams;
+class CSporkManager;
 
 namespace Legacy
 {
@@ -11,6 +12,6 @@ namespace Legacy
     int64_t GetTreasuryReward(const CBlockRewards &rewards, const CChainParams& chainParams);
     int64_t GetCharityReward(const CBlockRewards &rewards, const CChainParams& chainParams);
     int64_t GetLotteryReward(const CBlockRewards &rewards, const CChainParams& chainParams);
-    CBlockRewards GetBlockSubsidity(int nHeight, const CChainParams& chainParams);
+    CBlockRewards GetBlockSubsidity(int nHeight, const CChainParams& chainParams, const CSporkManager& sporkManager);
 }
 #endif // LEGACY_BLOCK_SUBSIDIES_H

--- a/divi/src/SuperblockSubsidyContainer.cpp
+++ b/divi/src/SuperblockSubsidyContainer.cpp
@@ -4,9 +4,10 @@
 #include <BlockSubsidyProvider.h>
 
 SuperblockSubsidyContainer::SuperblockSubsidyContainer(
-    const CChainParams& chainParameters
+    const CChainParams& chainParameters,
+    const CSporkManager& sporkManager
     ): heightValidator_(new SuperblockHeightValidator(chainParameters))
-    , blockSubsidies_(new BlockSubsidyProvider(chainParameters,*heightValidator_))
+    , blockSubsidies_(new BlockSubsidyProvider(chainParameters, sporkManager, *heightValidator_))
 {
 }
 

--- a/divi/src/SuperblockSubsidyContainer.h
+++ b/divi/src/SuperblockSubsidyContainer.h
@@ -7,6 +7,7 @@
 #include <memory>
 
 class CChainParams;
+class CSporkManager;
 
 class SuperblockSubsidyContainer: public I_SuperblockSubsidyContainer
 {
@@ -15,7 +16,7 @@ private:
     std::unique_ptr<I_BlockSubsidyProvider> blockSubsidies_;
 
 public:
-    SuperblockSubsidyContainer(const CChainParams& chainParameters);
+    SuperblockSubsidyContainer(const CChainParams& chainParameters, const CSporkManager& sporkManager);
     ~SuperblockSubsidyContainer();
     virtual const I_SuperblockHeightValidator& superblockHeightValidator() const;
     virtual const I_BlockSubsidyProvider& blockSubsidiesProvider() const;

--- a/divi/src/main.cpp
+++ b/divi/src/main.cpp
@@ -983,7 +983,7 @@ bool ConnectBlock(
         return false;
     }
 
-    const SuperblockSubsidyContainer subsidiesContainer(chainParameters);
+    const SuperblockSubsidyContainer subsidiesContainer(chainParameters, GetSporkManager());
     const BlockIncentivesPopulator incentives(
         chainParameters,
         GetMasternodeModule(),

--- a/divi/src/main.cpp
+++ b/divi/src/main.cpp
@@ -971,7 +971,7 @@ bool ConnectBlock(
     if (!fAlreadyChecked && !CheckBlock(block, state))
         return false;
 
-    static const CChainParams& chainParameters = Params();
+    const CChainParams& chainParameters = Params();
     VerifyBestBlockIsAtPreviousBlock(pindex,view);
     if (block.GetHash() == Params().HashGenesisBlock())
     {
@@ -983,8 +983,8 @@ bool ConnectBlock(
         return false;
     }
 
-    static const SuperblockSubsidyContainer subsidiesContainer(chainParameters);
-    static const BlockIncentivesPopulator incentives(
+    const SuperblockSubsidyContainer subsidiesContainer(chainParameters);
+    const BlockIncentivesPopulator incentives(
         chainParameters,
         GetMasternodeModule(),
         subsidiesContainer.superblockHeightValidator(),

--- a/divi/src/main.cpp
+++ b/divi/src/main.cpp
@@ -3560,7 +3560,7 @@ bool static ProcessMessage(CNode* pfrom, std::string strCommand, CDataStream& vR
             }
         }
     } else {
-        ProcessSpork(pfrom, strCommand, vRecv);
+        GetSporkManager().ProcessSpork(pfrom, strCommand, vRecv);
         ProcessMasternodeMessages(pfrom,strCommand,vRecv);
     }
 

--- a/divi/src/rpclottery.cpp
+++ b/divi/src/rpclottery.cpp
@@ -41,7 +41,7 @@ Value getlotteryblockwinners(const Array& params, bool fHelp)
 
 
     const auto& chainParameters = Params();
-    const SuperblockSubsidyContainer subsidyCointainer(chainParameters);
+    const SuperblockSubsidyContainer subsidyCointainer(chainParameters, GetSporkManager());
     const ChainstateManager::Reference chainstate;
     const LotteryWinnersCalculator calculator(
         chainParameters.GetLotteryBlockStartBlock(), chainstate->ActiveChain(), GetSporkManager(),subsidyCointainer.superblockHeightValidator());

--- a/divi/src/rpcmisc.cpp
+++ b/divi/src/rpcmisc.cpp
@@ -288,7 +288,7 @@ public:
 */
 Value spork(const Array& params, bool fHelp)
 {
-    static CSporkManager& sporkManager = GetSporkManager();
+    CSporkManager& sporkManager = GetSporkManager();
     if (params.size() == 1 && params[0].get_str() == "show") {
         Object ret;
         for (int nSporkID = SPORK_START; nSporkID <= SPORK_END; nSporkID++) {

--- a/divi/src/rpcwallet.cpp
+++ b/divi/src/rpcwallet.cpp
@@ -1763,7 +1763,7 @@ static std::string ParseScriptAsAddressString(const CScript& scriptPubKey)
 }
 void ParseTransactionDetails(const CWallet& wallet, const CWalletTx& wtx, const string& strAccount, int nMinDepth, bool fLong, Array& ret, const UtxoOwnershipFilter& filter)
 {
-    const SuperblockSubsidyContainer superblockSubsidies(Params());
+    const SuperblockSubsidyContainer superblockSubsidies(Params(), GetSporkManager());
     const I_SuperblockHeightValidator& heightValidator = superblockSubsidies.superblockHeightValidator();
     const I_BlockSubsidyProvider& blockSubsidies = superblockSubsidies.blockSubsidiesProvider();
 

--- a/divi/src/rpcwallet.cpp
+++ b/divi/src/rpcwallet.cpp
@@ -1763,9 +1763,9 @@ static std::string ParseScriptAsAddressString(const CScript& scriptPubKey)
 }
 void ParseTransactionDetails(const CWallet& wallet, const CWalletTx& wtx, const string& strAccount, int nMinDepth, bool fLong, Array& ret, const UtxoOwnershipFilter& filter)
 {
-    static SuperblockSubsidyContainer superblockSubsidies(Params());
-    static const I_SuperblockHeightValidator& heightValidator = superblockSubsidies.superblockHeightValidator();
-    static const I_BlockSubsidyProvider& blockSubsidies = superblockSubsidies.blockSubsidiesProvider();
+    const SuperblockSubsidyContainer superblockSubsidies(Params());
+    const I_SuperblockHeightValidator& heightValidator = superblockSubsidies.superblockHeightValidator();
+    const I_BlockSubsidyProvider& blockSubsidies = superblockSubsidies.blockSubsidiesProvider();
 
     string strSentAccount = wtx.strFromAccount;
     const std::string allAccounts = "*";

--- a/divi/src/spork.cpp
+++ b/divi/src/spork.cpp
@@ -60,10 +60,6 @@ bool SporkDataIsKnown(const uint256& inventoryHash)
 {
     return mapSporks.count(inventoryHash);
 }
-void ProcessSpork(CNode* pfrom, const std::string& strCommand, CDataStream& vRecv)
-{
-    GetSporkManager().ProcessSpork(pfrom, strCommand, vRecv);
-}
 CSporkManager& GetSporkManager()
 {
     assert(sporkManagerInstance != nullptr);

--- a/divi/src/spork.h
+++ b/divi/src/spork.h
@@ -41,7 +41,6 @@ static const int SPORK_END                                              = SPORK_
 
 bool ShareSporkDataWithPeer(CNode* peer, const uint256& inventoryHash);
 bool SporkDataIsKnown(const uint256& inventoryHash);
-void ProcessSpork(CNode* pfrom, const std::string& strCommand, CDataStream& vRecv);
 CSporkManager& GetSporkManager();
 //
 // Spork classes

--- a/divi/src/test/PoSTransactionCreator_tests.cpp
+++ b/divi/src/test/PoSTransactionCreator_tests.cpp
@@ -75,8 +75,6 @@ protected:
       walletScript(GetScriptForDestination(wallet.getNewKey().GetID()))
   {
     /* Set up a default block reward if we don't need anything else.  */
-    EXPECT_CALL(blockSubsidyProvider, GetFullBlockValue(_))
-        .WillRepeatedly(Return(11 * COIN));
     EXPECT_CALL(blockSubsidyProvider, GetBlockSubsidity(_))
         .WillRepeatedly(Return(CBlockRewards(10 * COIN, COIN, 0, 0, 0, 0)));
 


### PR DESCRIPTION
This is a collection of clean-up commits that reduce usage of `GetSporkManager()` (access to the global spork manager) a bit by explicitly passing instances instead where easily possible.