### PR TITLE
Pass ChainstateManager to ConnectBlock

### DIFF
--- a/divi/src/main.h
+++ b/divi/src/main.h
@@ -32,6 +32,7 @@ struct CNodeSignals;
 class CTxMemPool;
 class CCoinsViewCache;
 class CDiskBlockPos;
+class CSporkManager;
 class CTransaction;
 class CLevelDBWrapper;
 
@@ -64,12 +65,12 @@ int GetHeight();
  * @param[out]  dbp     If pblock is stored to disk (or already there), this will be set to its location.
  * @return True if state.IsValid()
  */
-bool ProcessNewBlock(CValidationState& state, CNode* pfrom, CBlock* pblock, CDiskBlockPos* dbp = NULL);
+bool ProcessNewBlock(ChainstateManager& chainstate, const CSporkManager& sporkManager, CValidationState& state, CNode* pfrom, CBlock* pblock, CDiskBlockPos* dbp = NULL);
 
 /** Import blocks from an external file */
-bool LoadExternalBlockFile(FILE* fileIn, CDiskBlockPos* dbp = NULL);
+bool LoadExternalBlockFile(ChainstateManager& chainstate, const CSporkManager& sporkManager, FILE* fileIn, CDiskBlockPos* dbp = NULL);
 /** Initialize a new block tree database + block data on disk */
-bool InitBlockIndex();
+bool InitBlockIndex(ChainstateManager& chainstate, const CSporkManager& sporkManager);
 /** Load the block tree and coins database from disk */
 bool LoadBlockIndex(std::string& strError);
 /** Unload database information.  If a ChainstateManager is present,
@@ -99,7 +100,7 @@ std::string GetWarnings(std::string strFor);
 bool DisconnectBlocksAndReprocess(int blocks);
 
 // ***TODO***
-bool ActivateBestChain(CValidationState& state, const CBlock* pblock = nullptr, bool fAlreadyChecked = false);
+bool ActivateBestChain(ChainstateManager& chainstate, const CSporkManager& sporkManager, CValidationState& state, const CBlock* pblock = nullptr, bool fAlreadyChecked = false);
 
 /** (try to) add transaction to memory pool **/
 bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState& state, const CTransaction& tx, bool fLimitFree, bool* pfMissingInputs = nullptr, bool ignoreFees = false);
@@ -138,7 +139,7 @@ bool IsStandardTx(const CTransaction& tx, std::string& reason);
 bool DisconnectBlocksAndReprocess(int blocks);
 
 /** Apply the effects of this block (with given index) on the UTXO set represented by coins */
-bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pindex, CCoinsViewCache& coins, bool fJustCheck, bool fAlreadyChecked = false);
+bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pindex, ChainstateManager& chainstate, const CSporkManager& sporkManager, CCoinsViewCache& coins, bool fJustCheck, bool fAlreadyChecked = false);
 
 /** Context-independent validity checks */
 bool CheckBlock(const CBlock& block, CValidationState& state);
@@ -146,10 +147,6 @@ bool CheckBlock(const CBlock& block, CValidationState& state);
 /** Context-dependent validity checks */
 bool ContextualCheckBlockHeader(const CBlockHeader& block, CValidationState& state, const CBlockIndex* const pindexPrev);
 bool ContextualCheckBlock(const CBlock& block, CValidationState& state, const CBlockIndex* const pindexPrev);
-
-/** Store block on disk. If dbp is provided, the file is known to already reside on disk */
-bool AcceptBlock(CBlock& block, CValidationState& state, CBlockIndex** pindex, CDiskBlockPos* dbp = NULL, bool fAlreadyCheckedBlock = false);
-bool AcceptBlockHeader(const CBlockHeader& block, CValidationState& state, CBlockIndex** ppindex = NULL);
 
 /** Find the last common block between the parameter chain and a locator. */
 const CBlockIndex* FindForkInGlobalIndex(const CChain& chain, const CBlockLocator& locator);

--- a/divi/src/rpcblockchain.cpp
+++ b/divi/src/rpcblockchain.cpp
@@ -27,6 +27,7 @@
 #include <JsonTxHelpers.h>
 #include <init.h>
 #include <JsonBlockHelpers.h>
+#include <spork.h>
 
 using namespace json_spirit;
 using namespace std;
@@ -626,19 +627,17 @@ Value invalidateblock(const Array& params, bool fHelp)
     uint256 hash(strHash);
     CValidationState state;
 
-    {
-        ChainstateManager::Reference chainstate;
-        auto& blockMap = chainstate->GetBlockMap();
-        const auto mit = blockMap.find(hash);
-        if (mit == blockMap.end())
-            throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Block not found");
+    ChainstateManager::Reference chainstate;
+    auto& blockMap = chainstate->GetBlockMap();
+    const auto mit = blockMap.find(hash);
+    if (mit == blockMap.end())
+        throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Block not found");
 
-        CBlockIndex* pblockindex = mit->second;
-        InvalidateBlock(state, pblockindex);
-    }
+    CBlockIndex* pblockindex = mit->second;
+    InvalidateBlock(state, pblockindex);
 
     if (state.IsValid()) {
-        ActivateBestChain(state);
+        ActivateBestChain(*chainstate, GetSporkManager(), state);
     }
 
     if (!state.IsValid()) {
@@ -665,19 +664,17 @@ Value reconsiderblock(const Array& params, bool fHelp)
     uint256 hash(strHash);
     CValidationState state;
 
-    {
-        ChainstateManager::Reference chainstate;
-        auto& blockMap = chainstate->GetBlockMap();
-        const auto mit = blockMap.find(hash);
-        if (mit == blockMap.end())
-            throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Block not found");
+    ChainstateManager::Reference chainstate;
+    auto& blockMap = chainstate->GetBlockMap();
+    const auto mit = blockMap.find(hash);
+    if (mit == blockMap.end())
+        throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Block not found");
 
-        CBlockIndex* pblockindex = mit->second;
-        ReconsiderBlock(state, pblockindex);
-    }
+    CBlockIndex* pblockindex = mit->second;
+    ReconsiderBlock(state, pblockindex);
 
     if (state.IsValid()) {
-        ActivateBestChain(state);
+        ActivateBestChain(*chainstate, GetSporkManager(), state);
     }
 
     if (!state.IsValid()) {

--- a/divi/src/spork.h
+++ b/divi/src/spork.h
@@ -165,7 +165,7 @@ struct TxFeeSporkValue : public SporkMultiValue {
 class CSporkManager
 {
 private:
-    const ChainstateManager& chainstate_;
+    ChainstateManager& chainstate_;
     std::unique_ptr<CSporkDB> pSporkDB_;
     std::vector<unsigned char> vchSig;
     // Some sporks require to have history, we will use sorted vector for this approach.
@@ -182,7 +182,7 @@ private:
 
 public:
 
-    explicit CSporkManager(const ChainstateManager& chainstate);
+    explicit CSporkManager(ChainstateManager& chainstate);
     ~CSporkManager();
 
     void LoadSporksFromDB();

--- a/divi/src/test/test_divi.cpp
+++ b/divi/src/test/test_divi.cpp
@@ -64,7 +64,7 @@ struct TestingSetup {
         settings.SetParameter("-datadir", pathTemp.string());
         chainstateInstance.reset(new ChainstateManager(1 << 20, 1 << 23, 5000, true, false));
         sporkManagerInstance.reset(new CSporkManager(*chainstateInstance));
-        InitBlockIndex();
+        InitBlockIndex(*chainstateInstance, *sporkManagerInstance);
 #ifdef ENABLE_WALLET
         InitializeWallet("wallet.dat");
         pwalletMain->LoadWallet();

--- a/divi/src/verifyDb.h
+++ b/divi/src/verifyDb.h
@@ -14,6 +14,7 @@ class CCoinsView;
 class CChain;
 class CClientUIInterface;
 class CCoinsViewCache;
+class CSporkManager;
 class CBlockTreeDB;
 class ActiveChainManager;
 class BlockDiskDataReader;
@@ -27,6 +28,8 @@ public:
 private:
     std::unique_ptr<const BlockDiskDataReader> blockDiskReader_;
     std::unique_ptr<const ActiveChainManager> chainManager_;
+    ChainstateManager& chainstate_;
+    const CSporkManager& sporkManager_;
     const CChain& activeChain_;
     CClientUIInterface& clientInterface_;
     const unsigned coinsCacheSize_;
@@ -34,6 +37,7 @@ private:
 public:
     CVerifyDB(
         ChainstateManager& chainstate,
+        const CSporkManager& sporkManager,
         CClientUIInterface& clientInterface,
         const unsigned& coinsCacheSize,
         ShutdownListener shutdownListener);


### PR DESCRIPTION
This refactors the calls to `ConnectBlock` and up in the hierarchy (e.g. `ActivateBestChain`, `AcceptBlockHeader`) to explicitly pass the `ChainstateManager` reference and `CSporkManager` down from a higher level.

The main places that obtain the references from "globals" are now the RPC functions as well as `ProcessMessage` in `main.cpp`.