### PR TITLE
Introduce RPCContext

### DIFF
--- a/divi/src/Makefile.am
+++ b/divi/src/Makefile.am
@@ -216,6 +216,7 @@ BITCOIN_CORE_H = \
   IndexDatabaseUpdateCollector.h \
   NodeState.h \
   NodeStateRegistry.h \
+  RPCContext.h \
   BlocksInFlightRegistry.h \
   NodeSignals.h \
   BlockRejects.h\
@@ -436,6 +437,7 @@ libbitcoin_server_a_SOURCES = \
   NodeState.cpp \
   BlocksInFlightRegistry.cpp \
   NodeStateRegistry.cpp \
+  RPCContext.cpp \
   BlockFileHelpers.cpp \
   main.cpp \
   TransactionSearchIndexes.cpp \

--- a/divi/src/RPCContext.cpp
+++ b/divi/src/RPCContext.cpp
@@ -1,9 +1,10 @@
 #include "RPCContext.h"
 
 #include "spork.h"
+#include "MasternodeModule.h"
 
 RPCContext::RPCContext ()
-  : sporkManager(GetSporkManager ())
+  : sporkManager(GetSporkManager ()), masternodeModule(GetMasternodeModule ())
 {}
 
 RPCContext::~RPCContext () = default;

--- a/divi/src/RPCContext.cpp
+++ b/divi/src/RPCContext.cpp
@@ -1,5 +1,9 @@
 #include "RPCContext.h"
 
-RPCContext::RPCContext () = default;
+#include "spork.h"
+
+RPCContext::RPCContext ()
+  : sporkManager(GetSporkManager ())
+{}
 
 RPCContext::~RPCContext () = default;

--- a/divi/src/RPCContext.cpp
+++ b/divi/src/RPCContext.cpp
@@ -1,0 +1,5 @@
+#include "RPCContext.h"
+
+RPCContext::RPCContext () = default;
+
+RPCContext::~RPCContext () = default;

--- a/divi/src/RPCContext.h
+++ b/divi/src/RPCContext.h
@@ -1,10 +1,16 @@
 #ifndef RPC_CONTEXT_H
 #define RPC_CONTEXT_H
 
+class CSporkManager;
+
 /** This class holds all the "context" (such as the chainstate, masternode
  *  and other references) needed to handle RPC method calls.  */
 class RPCContext
 {
+
+private:
+
+  CSporkManager& sporkManager;
 
 public:
 
@@ -22,6 +28,12 @@ public:
    *  This method is implemented in rpcserver.cpp.
    */
   static RPCContext& Get ();
+
+  CSporkManager&
+  SporkManager ()
+  {
+    return sporkManager;
+  }
 
 };
 

--- a/divi/src/RPCContext.h
+++ b/divi/src/RPCContext.h
@@ -1,0 +1,28 @@
+#ifndef RPC_CONTEXT_H
+#define RPC_CONTEXT_H
+
+/** This class holds all the "context" (such as the chainstate, masternode
+ *  and other references) needed to handle RPC method calls.  */
+class RPCContext
+{
+
+public:
+
+  /** Constructs a new instance based on globals.  */
+  RPCContext ();
+
+  RPCContext (const RPCContext&) = delete;
+  void operator= (const RPCContext&) = delete;
+
+  ~RPCContext ();
+
+  /** Returns the global instance that should be used during RPC calls
+   *  (called from the RPC method handler).
+   *
+   *  This method is implemented in rpcserver.cpp.
+   */
+  static RPCContext& Get ();
+
+};
+
+#endif // RPC_CONTEXT_H

--- a/divi/src/RPCContext.h
+++ b/divi/src/RPCContext.h
@@ -2,6 +2,7 @@
 #define RPC_CONTEXT_H
 
 class CSporkManager;
+class MasternodeModule;
 
 /** This class holds all the "context" (such as the chainstate, masternode
  *  and other references) needed to handle RPC method calls.  */
@@ -11,6 +12,7 @@ class RPCContext
 private:
 
   CSporkManager& sporkManager;
+  const ::MasternodeModule& masternodeModule;
 
 public:
 
@@ -33,6 +35,12 @@ public:
   SporkManager ()
   {
     return sporkManager;
+  }
+
+  const ::MasternodeModule&
+  MasternodeModule () const
+  {
+    return masternodeModule;
   }
 
 };

--- a/divi/src/RpcMasternodeFeatures.h
+++ b/divi/src/RpcMasternodeFeatures.h
@@ -5,6 +5,7 @@
 #include <stdint.h>
 class CBlockIndex;
 class CKeyStore;
+class RPCContext;
 class StoredMasternodeBroadcasts;
 struct MasternodeStartResult
 {
@@ -55,10 +56,10 @@ struct MasternodeCountData
 /** Relays a broadcast given in serialised form as hex string.  If the signature
  *  is present, then it will replace the signature in the broadcast.  If
  *  updatePing is true, then the masternode ping is re-signed freshly.  */
-MasternodeStartResult RelayMasternodeBroadcast(const std::string& hexData, const std::string& signature, bool updatePing);
+MasternodeStartResult RelayMasternodeBroadcast(const RPCContext& ctx, const std::string& hexData, const std::string& signature, bool updatePing);
 bool SignMasternodeBroadcast(const CKeyStore& keystore, std::string& hexData);
-MasternodeStartResult StartMasternode(const CKeyStore& keyStore, const StoredMasternodeBroadcasts& stored, std::string alias, bool deferRelay);
-ActiveMasternodeStatus GetActiveMasternodeStatus();
-std::vector<MasternodeListEntry> GetMasternodeList(std::string strFilter, const CBlockIndex* chainTip);
-MasternodeCountData GetMasternodeCounts(const CBlockIndex* chainTip);
+MasternodeStartResult StartMasternode(const RPCContext& ctx, const CKeyStore& keyStore, const StoredMasternodeBroadcasts& stored, std::string alias, bool deferRelay);
+ActiveMasternodeStatus GetActiveMasternodeStatus(const RPCContext& ctx);
+std::vector<MasternodeListEntry> GetMasternodeList(const RPCContext& ctx, std::string strFilter, const CBlockIndex* chainTip);
+MasternodeCountData GetMasternodeCounts(const RPCContext& ctx, const CBlockIndex* chainTip);
 #endif// RPC_MASTERNODE_FEATURES_H

--- a/divi/src/rpcblockchain.cpp
+++ b/divi/src/rpcblockchain.cpp
@@ -6,6 +6,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <ChainstateManager.h>
+#include <RPCContext.h>
 #include "checkpoints.h"
 #include "main.h"
 #include "BlockDiskAccessor.h"
@@ -27,7 +28,6 @@
 #include <JsonTxHelpers.h>
 #include <init.h>
 #include <JsonBlockHelpers.h>
-#include <spork.h>
 
 using namespace json_spirit;
 using namespace std;
@@ -628,6 +628,7 @@ Value invalidateblock(const Array& params, bool fHelp, CWallet* pwallet)
     uint256 hash(strHash);
     CValidationState state;
 
+    auto& ctx = RPCContext::Get();
     ChainstateManager::Reference chainstate;
     auto& blockMap = chainstate->GetBlockMap();
     const auto mit = blockMap.find(hash);
@@ -638,7 +639,7 @@ Value invalidateblock(const Array& params, bool fHelp, CWallet* pwallet)
     InvalidateBlock(*chainstate, state, pblockindex);
 
     if (state.IsValid()) {
-        ActivateBestChain(*chainstate, GetSporkManager(), state);
+        ActivateBestChain(*chainstate, ctx.SporkManager(), state);
     }
 
     if (!state.IsValid()) {
@@ -665,6 +666,7 @@ Value reconsiderblock(const Array& params, bool fHelp, CWallet* pwallet)
     uint256 hash(strHash);
     CValidationState state;
 
+    auto& ctx = RPCContext::Get();
     ChainstateManager::Reference chainstate;
     auto& blockMap = chainstate->GetBlockMap();
     const auto mit = blockMap.find(hash);
@@ -675,7 +677,7 @@ Value reconsiderblock(const Array& params, bool fHelp, CWallet* pwallet)
     ReconsiderBlock(*chainstate, state, pblockindex);
 
     if (state.IsValid()) {
-        ActivateBestChain(*chainstate, GetSporkManager(), state);
+        ActivateBestChain(*chainstate, ctx.SporkManager(), state);
     }
 
     if (!state.IsValid()) {

--- a/divi/src/rpclottery.cpp
+++ b/divi/src/rpclottery.cpp
@@ -1,7 +1,7 @@
 #include <chain.h>
 #include <ChainstateManager.h>
-#include <spork.h>
 #include <LotteryWinnersCalculator.h>
+#include <RPCContext.h>
 #include <SuperblockSubsidyContainer.h>
 #include <script/standard.h>
 #include <json/json_spirit_value.h>
@@ -40,11 +40,12 @@ Value getlotteryblockwinners(const Array& params, bool fHelp, CWallet* pwallet)
 
 
 
+    auto& ctx = RPCContext::Get();
     const auto& chainParameters = Params();
-    const SuperblockSubsidyContainer subsidyCointainer(chainParameters, GetSporkManager());
+    const SuperblockSubsidyContainer subsidyCointainer(chainParameters, ctx.SporkManager());
     const ChainstateManager::Reference chainstate;
     const LotteryWinnersCalculator calculator(
-        chainParameters.GetLotteryBlockStartBlock(), chainstate->ActiveChain(), GetSporkManager(),subsidyCointainer.superblockHeightValidator());
+        chainParameters.GetLotteryBlockStartBlock(), chainstate->ActiveChain(), ctx.SporkManager(),subsidyCointainer.superblockHeightValidator());
     const CBlockIndex* chainTip = chainstate->ActiveChain().Tip();
     if(!chainTip) throw JSONRPCError(RPC_MISC_ERROR,"Could not acquire lock on chain tip.");
     int blockHeight = (params.size()>0)? std::min(params[0].get_int(),chainTip->nHeight): chainTip->nHeight;

--- a/divi/src/rpcmisc.cpp
+++ b/divi/src/rpcmisc.cpp
@@ -200,9 +200,11 @@ Value mnsync(const Array& params, bool fHelp, CWallet* pwallet)
             HelpExampleCli("mnsync", "\"status\"") + HelpExampleRpc("mnsync", "\"status\""));
     }
 
+    auto& ctx = RPCContext::Get ();
+
     if (strMode == "status") {
         Object obj;
-        const CMasternodeSync& masternodeSynchronization = GetMasternodeModule().getMasternodeSynchronization();
+        const CMasternodeSync& masternodeSynchronization = ctx.MasternodeModule().getMasternodeSynchronization();
         obj.push_back(Pair("IsBlockchainSynced", IsBlockchainSynced()));
         obj.push_back(Pair("timestampOfLastMasternodeListUpdate", masternodeSynchronization.timestampOfLastMasternodeListUpdate));
         obj.push_back(Pair("timestampOfLastMasternodeWinnerUpdate", masternodeSynchronization.timestampOfLastMasternodeWinnerUpdate));
@@ -1057,6 +1059,7 @@ Value getstakingstatus(const Array& params, bool fHelp, CWallet* pwallet)
             "\nExamples:\n" +
             HelpExampleCli("getstakingstatus", "") + HelpExampleRpc("getstakingstatus", ""));
 
+    auto& ctx = RPCContext::Get ();
     const ChainstateManager::Reference chainstate;
 
     Object obj;
@@ -1070,7 +1073,7 @@ Value getstakingstatus(const Array& params, bool fHelp, CWallet* pwallet)
         obj.push_back(Pair("enoughcoins", stakkingBalance > 0 ));
     }
 
-    obj.push_back(Pair("mnsync", GetMasternodeModule().getMasternodeSynchronization().IsSynced()));
+    obj.push_back(Pair("mnsync", ctx.MasternodeModule().getMasternodeSynchronization().IsSynced()));
 
     bool nStaking = HasRecentlyAttemptedToGenerateProofOfStake();
     obj.push_back(Pair("staking status", nStaking));

--- a/divi/src/rpcmisc.cpp
+++ b/divi/src/rpcmisc.cpp
@@ -8,6 +8,7 @@
 #include "base58.h"
 #include "clientversion.h"
 #include "init.h"
+#include <RPCContext.h>
 #include <rpcprotocol.h>
 #include "rpcserver.h"
 #include "spork.h"
@@ -278,7 +279,8 @@ public:
 */
 Value spork(const Array& params, bool fHelp, CWallet* pwallet)
 {
-    CSporkManager& sporkManager = GetSporkManager();
+    auto& ctx = RPCContext::Get();
+    CSporkManager& sporkManager = ctx.SporkManager();
     if (params.size() == 1 && params[0].get_str() == "show") {
         Object ret;
         for (int nSporkID = SPORK_START; nSporkID <= SPORK_END; nSporkID++) {


### PR DESCRIPTION
This introduces the `RPCContext` class.  This is a singleton instance which holds references to some context (at the moment, the `MasternodeModule` and `CSporkManager`, but also the `ChainstateManager` and perhaps others will fit in there in the future).  The plan is to access all global state from RPC handlers through this instance, which gets managed with the RPC warmup and shutdown sequence.

Once this is done, it will also allow us to get rid of globals in the RPC code completely more easily:  We could then modify the signature of RPC handlers to pass in such an `RPCContext& ctx` argument to all handler methods and thus get rid of globals for them.  (This would be a rather large change that would have to adapt every single RPC handler at once, but is much easier to do and more consistent once we have `RPCContext` to begin with.)